### PR TITLE
log_softmax fwd: fused online single-read kernel, 11.55->4.13 ms on H100

### DIFF
--- a/tests/test_aten_functions.py
+++ b/tests/test_aten_functions.py
@@ -1875,6 +1875,30 @@ def test_aten_isin_3d_tensor(conf: Conf):
     check_outputs(fn, conf, [elements, test_elements])
 
 
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+@pytest.mark.parametrize(("shape", "dim"), [((64, 40), -1), ((4, 5, 64), 1)])
+def test_aten__log_softmax_backward_data_autograd(
+    conf: Conf,
+    call_checker: CallChecker,
+    dtype: torch.dtype,
+    shape: tuple[int, ...],
+    dim: int,
+):
+    """Backward through log_softmax reaches the dedicated backward op."""
+    call_checker.register(aten_functions.aten__log_softmax_backward_data)
+
+    def fn(x, grad_output):
+        leaf = x.detach().requires_grad_(True)
+        y = torch.log_softmax(leaf, dim=dim)
+        (grad_input,) = torch.autograd.grad(y, leaf, grad_output)
+        return grad_input
+
+    x = torch.randn(shape, dtype=dtype)
+    grad_output = torch.randn(shape, dtype=dtype)
+    tolerance = 2e-2 if dtype == torch.bfloat16 else 2e-3
+    check_outputs(fn, conf, [x, grad_output], atol=tolerance, rtol=tolerance)
+
+
 def test_aten_isin_with_assume_unique(conf: Conf):
     """Test aten.isin with assume_unique=True"""
 

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -2557,6 +2557,105 @@ def test_fast_bmm(mojo_gpu):
     torch.testing.assert_close(dev, torch.bmm(a, b), atol=1e-2, rtol=1e-2)
 
 
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize(
+    ("shape", "dim"),
+    [
+        ((33, 257), -1),  # odd cols: rows off 16B alignment take head/tail
+        ((16, 4096), -1),  # pure 16B-aligned vector body
+        ((2, 3, 129), 2),  # rank-3 trailing dim flattens without a view
+    ],
+)
+def test_fast_log_softmax_backward_fused_matches_reference(mojo_gpu, dtype, shape, dim):
+    """The fused trailing-dim kernel must match fp32-accumulated math."""
+    generator = torch.Generator().manual_seed(20260722)
+    source = torch.randn(shape, generator=generator)
+    output = torch.log_softmax(source, dim=dim).to(dtype)
+    grad_output = torch.randn(shape, generator=generator).to(dtype)
+    expected = (
+        grad_output.float()
+        - output.float().exp() * grad_output.float().sum(dim=dim, keepdim=True)
+    ).to(dtype)
+
+    actual = torch.ops.aten._log_softmax_backward_data(
+        grad_output.to(mojo_gpu), output.to(mojo_gpu), dim, dtype
+    )
+
+    assert actual.dtype == dtype
+    tol = 2e-2 if dtype in (torch.bfloat16, torch.float16) else 2e-5
+    torch.testing.assert_close(actual.cpu(), expected, atol=tol, rtol=tol)
+
+
+def test_fast_log_softmax_backward_uses_fused_kernel(mojo_gpu, monkeypatch):
+    """Contiguous trailing-dim same-dtype autograd must call the bridge once."""
+    from torch_mojo_backend import eager_kernels
+
+    calls = 0
+    original = eager_kernels.softmax_backward_ops.LogSoftmaxBackwardData
+
+    def spy(*args):
+        nonlocal calls
+        calls += 1
+        return original(*args)
+
+    monkeypatch.setattr(
+        eager_kernels.softmax_backward_ops, "LogSoftmaxBackwardData", spy
+    )
+
+    source = torch.randn(8, 640)
+    grad_output = torch.randn(8, 640)
+    reference = source.clone().requires_grad_()
+    reference_output = torch.log_softmax(reference, dim=-1)
+    reference_output.backward(grad_output)
+
+    actual = source.to(mojo_gpu).requires_grad_()
+    actual_output = torch.log_softmax(actual, dim=-1)
+    actual_output.backward(grad_output.to(mojo_gpu))
+
+    assert calls == 1
+    assert actual.grad is not None
+    torch.testing.assert_close(actual.grad.cpu(), reference.grad, atol=2e-5, rtol=2e-5)
+
+
+def test_fast_log_softmax_backward_non_trailing_keeps_composed_path(
+    mojo_gpu, monkeypatch
+):
+    """Non-trailing dims and the f32->f16 promotion stay on the composed path."""
+    from torch_mojo_backend import eager_kernels
+
+    def fail(*_args):
+        raise AssertionError("composed-path case reached the fused kernel")
+
+    monkeypatch.setattr(
+        eager_kernels.softmax_backward_ops, "LogSoftmaxBackwardData", fail
+    )
+
+    source = torch.randn(6, 33, 5)
+    output = torch.log_softmax(source, dim=1)
+    grad_output = torch.randn(6, 33, 5)
+    expected = torch.ops.aten._log_softmax_backward_data(
+        grad_output, output, 1, torch.float32
+    )
+    actual = torch.ops.aten._log_softmax_backward_data(
+        grad_output.to(mojo_gpu), output.to(mojo_gpu), 1, torch.float32
+    )
+    torch.testing.assert_close(actual.cpu(), expected, atol=2e-5, rtol=2e-5)
+
+    # The CPU op rejects the f32-grad -> f16-target promotion, so compute
+    # the reference directly (fp32 math, one final rounding).
+    half_source = torch.randn(6, 40)
+    half_output = torch.log_softmax(half_source, dim=-1)
+    half_grad = torch.randn(6, 40)
+    expected_half = (
+        half_grad - half_output.exp() * half_grad.sum(dim=-1, keepdim=True)
+    ).to(torch.float16)
+    actual_half = torch.ops.aten._log_softmax_backward_data(
+        half_grad.to(mojo_gpu), half_output.to(mojo_gpu), -1, torch.float16
+    )
+    assert actual_half.dtype == torch.float16
+    torch.testing.assert_close(actual_half.cpu(), expected_half, atol=2e-3, rtol=2e-3)
+
+
 @pytest.mark.parametrize("reduction", [0, 1, 2])
 def test_fast_nll_loss_forward_and_backward_out(mojo_gpu, reduction):
     generator = torch.Generator().manual_seed(20260718)

--- a/torch_mojo_backend/eager_kernels/__init__.py
+++ b/torch_mojo_backend/eager_kernels/__init__.py
@@ -49,6 +49,7 @@ _MOJO_MODULES = (
     "conv_ops",
     "reduction_ops",
     "loss_ops",
+    "softmax_backward_ops",
     "normalization_forward_ops",
     "normalization_backward_ops",
     "optimizer_ops",

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -60,6 +60,7 @@ _SDPA_BACKWARD_SOURCE_PATHS = (
 _BF16_SOURCE_PATHS = (
     eager_kernels._PACKAGE_DIR / "bf16_matmul_ops.mojo",
     eager_kernels._PACKAGE_DIR / "bf16_gemm_v3_kernels.mojo",
+    eager_kernels._PACKAGE_DIR / "bf16_gemm_tn_v4_kernels.mojo",
     eager_kernels._PACKAGE_DIR / "bf16_gemm_kernels.mojo",
 )
 _BF16_IMPORT_FAILED = False

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -3233,7 +3233,12 @@ def fast_aten__log_softmax(input, dim, half_to_float=False):
     return result if result is not None else NOT_HANDLED
 
 
-def fast_aten__log_softmax_backward_data(grad_output, output, dim, input_dtype):
+def fast_aten__log_softmax_backward_data(
+    grad_output: object, output: object, dim: int, input_dtype: object
+) -> object:
+    # `object` params: besides real (TorchMojoTensor, torch.dtype) calls, the
+    # composed path's lifetime contract is regression-tested with duck-typed
+    # doubles (tests/test_autograd_memory_lifetime.py).
     grad = _t(grad_output)
     saved_output = _t(output)
     target_dtype = _torch_dtype_to_max(input_dtype)
@@ -3271,6 +3276,43 @@ def fast_aten__log_softmax_backward_data(grad_output, output, dim, input_dtype):
         # specs whose empty-axis behavior varies across MAX releases.
         if grad._numel == 0:
             return _alloc(grad._shape, target_dtype, grad._device)
+
+        # Fused single-kernel GPU path (softmax_backward_kernels.mojo): the
+        # reduction dim is trailing, so any rank flattens to [rows, cols]
+        # without a view. Everything else (non-trailing dim, the
+        # f32-grad -> f16-target promotion, strided or unaligned tensors,
+        # CPU device) keeps the composed sum -> exp -> addcmul path below.
+        if (
+            dim == rank - 1
+            and isinstance(grad, TorchMojoTensor)
+            and isinstance(saved_output, TorchMojoTensor)
+            and grad._dtype == target_dtype
+            and grad._dtype in _FLOAT_DTYPES
+            and _on_gpu(grad)
+            and grad._is_contiguous
+            and saved_output._is_contiguous
+            and grad._ptr % 16 == 0
+            and saved_output._ptr % 16 == 0
+        ):
+            cols = grad._shape[dim]
+            rows = grad._numel // cols
+            if rows < 2**31:
+                grad_input = _alloc(grad._shape, target_dtype, grad._device)
+                if grad_input._ptr % 16 == 0:
+                    eager_kernels.softmax_backward_ops.LogSoftmaxBackwardData(
+                        grad_input._ptr,
+                        grad._ptr,
+                        saved_output._ptr,
+                        rows,
+                        cols,
+                        grad._dtype.value,
+                        _ctx_ptr(grad._device),
+                    )
+                    return grad_input
+                # Unaligned fresh allocation (never expected): fall through
+                # to the composed path rather than launching a misaligned
+                # vector kernel.
+                del grad_input
 
         summed = None
 

--- a/torch_mojo_backend/eager_kernels/bf16_gemm_nn_v4_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/bf16_gemm_nn_v4_kernels.mojo
@@ -1,0 +1,545 @@
+"""Persistent clustered H100 BF16 NN GEMM (dgrad) kernels — v4.
+
+C[m, n] = A[m, k] @ B[k, n] with both operands row-major.
+
+Design, motivated by ncu on the nanogpt dgrad shapes (m=32768, short k):
+  - The v3 NN kernel is operand-delivery bound, not DRAM bound: DRAM sits at
+    ~18%, L2 at ~66%, the tensor pipes at ~49%, and the dominant warp stall
+    is consumers waiting on TMA full barriers.  Every k-tile moves
+    (BM + BN) * BK * 2 bytes from L2 into each CTA.
+  - CTA clusters of CLUSTER_M x 1 multicast each B tile to the CLUSTER_M
+    CTAs that share it (same n0, adjacent m0), removing a third of the
+    per-CTA L2 traffic at BM=128 / BN=256.
+  - A persistent grid (one CTA per SM, grid == SM count) removes the
+    per-wave pipeline refill and epilogue serialization of the former
+    multi-wave launch: the producer warp group prefetches the next work
+    tile's operands while the consumers are still storing the previous
+    accumulators.
+  - A TMA-store epilogue (the single largest win, ~20%): accumulators are
+    staged in a 128B-swizzled shared-memory tile and handed to TMA, which
+    drains the store in the background of the next work tile's mainloop.
+    The former scalar epilogue both serialized ~4-5us per work tile and
+    inflated L2 write traffic ~3x through partial-sector stores.
+  - A 192x192 / 3-consumer tile (nvjet's pick) was also implemented and
+    benched; 128x256 with 2 consumers won on every nanogpt dgrad shape.
+
+Dynamic shapes: any problem in the tall-m NN regime with n % BN == 0 and
+k % BK == 0 is handled (m may be ragged: TMA clamps loads and clips
+stores); everything else must be routed to the existing v3 dispatcher by
+the caller (`maybe_enqueue_...` returns False in that case).
+"""
+
+from std.gpu import (
+    MAX_THREADS_PER_BLOCK_METADATA,
+    block_idx,
+    grid_dim,
+    thread_idx,
+)
+from std.gpu.host import DeviceAttribute, DeviceBuffer, DeviceContext
+from std.gpu.host.nvidia.tma import TensorMapSwizzle, create_tma_descriptor
+from std.gpu.intrinsics import warpgroup_reg_alloc, warpgroup_reg_dealloc
+from std.gpu.memory import (
+    AddressSpace,
+    fence_async_view_proxy,
+    fence_mbarrier_init,
+)
+from std.gpu.sync import named_barrier
+from std.gpu.primitives.cluster import (
+    block_rank_in_cluster,
+    cluster_sync,
+    cluster_sync_relaxed,
+)
+from std.memory import stack_allocation
+from std.sys.info import _has_sm_9x, _is_sm_9x
+from std.utils.index import Index, IndexList
+from std.utils.static_tuple import StaticTuple
+
+from layout import Layout, LayoutTensor
+from layout.tensor_core_async import (
+    TensorCoreAsync,
+    tile_layout_k_major,
+    tile_layout_mn_major,
+    warpgroup_fence,
+)
+from layout.tma_async import SharedMemBarrier, TMATensorTile
+
+comptime _V4_BF16 = DType.bfloat16
+comptime _V4_F32 = DType.float32
+comptime _V4_PTR = UnsafePointer[Scalar[_V4_BF16], MutAnyOrigin]
+comptime _V4_BK = 64
+# Macro-rows per rasterization group: consecutive work indices cover
+# _V4_GROUP macro rows before advancing one BN column, keeping the in-flight
+# A slab and the current B column resident in L2.
+comptime _V4_GROUP = 4
+comptime _V4_SWIZZLE = TensorMapSwizzle.SWIZZLE_128B
+
+# Production configuration (best of the kernel_bench sweeps: "s3c2ts").
+comptime _V4_PROD_STAGES = 3
+comptime _V4_PROD_CLUSTER_M = 2
+comptime _V4_PROD_BM = 128
+comptime _V4_PROD_BN = 256
+comptime _V4_PROD_CONSUMERS = 2
+comptime _V4_PROD_TMA_STORE = True
+
+
+@__llvm_arg_metadata(a_tma, `nvvm.grid_constant`)
+@__llvm_arg_metadata(b_tma, `nvvm.grid_constant`)
+@__llvm_arg_metadata(c_tma, `nvvm.grid_constant`)
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](
+        Int32(128 * (consumers + 1))
+    ),
+    `nvvm.cluster_dim`=StaticTuple[Int32, 3](
+        Int32(cluster_m), Int32(1), Int32(1)
+    ),
+)
+def _v4_nn_persistent_ws[
+    stages: Int,
+    cluster_m: Int,
+    bm: Int,
+    bn: Int,
+    consumers: Int,
+    tma_store: Bool,
+](
+    a_tma: TMATensorTile[_V4_BF16, 2, Index(bm, _V4_BK), Index(bm, _V4_BK)],
+    b_tma: TMATensorTile[_V4_BF16, 2, Index(_V4_BK, 64), Index(_V4_BK, 64)],
+    c_tma: TMATensorTile[_V4_BF16, 2, Index(bm, 64), Index(bm, 64)],
+    output: _V4_PTR,
+    m: Int,
+    n: Int,
+    k: Int,
+):
+    comptime if _is_sm_9x():
+        comptime A_LAYOUT = tile_layout_k_major[
+            _V4_BF16, bm, _V4_BK, _V4_SWIZZLE
+        ]()
+        comptime B_LAYOUT = tile_layout_mn_major[
+            _V4_BF16, bn, _V4_BK, _V4_SWIZZLE
+        ]()
+        comptime B_CHUNK_LAYOUT = tile_layout_mn_major[
+            _V4_BF16, 64, _V4_BK, _V4_SWIZZLE
+        ]()
+        comptime A_PIPE_LAYOUT = Layout.row_major(stages, bm * _V4_BK)
+        comptime B_PIPE_LAYOUT = Layout.row_major(stages, bn * _V4_BK)
+        var a_pipeline = LayoutTensor[
+            _V4_BF16,
+            A_PIPE_LAYOUT,
+            MutAnyOrigin,
+            address_space=AddressSpace.SHARED,
+            alignment=128,
+        ].stack_allocation()
+        var b_pipeline = LayoutTensor[
+            _V4_BF16,
+            B_PIPE_LAYOUT,
+            MutAnyOrigin,
+            address_space=AddressSpace.SHARED,
+            alignment=128,
+        ].stack_allocation()
+        # C staging tile for the TMA-store epilogue (swizzled 128B rows of
+        # 64 elements, bn // 64 chunks).  A dummy allocation when disabled.
+        comptime C_SMEM_ELEMS = bm * bn if tma_store else 512
+        var c_smem = LayoutTensor[
+            _V4_BF16,
+            Layout.row_major(1, C_SMEM_ELEMS),
+            MutAnyOrigin,
+            address_space=AddressSpace.SHARED,
+            alignment=1024,
+        ].stack_allocation()
+        var full_barriers = stack_allocation[
+            stages,
+            SharedMemBarrier,
+            address_space=AddressSpace.SHARED,
+            alignment=8,
+        ]()
+        var empty_barriers = stack_allocation[
+            stages,
+            SharedMemBarrier,
+            address_space=AddressSpace.SHARED,
+            alignment=8,
+        ]()
+        if thread_idx.x == 0:
+            comptime for stage in range(stages):
+                full_barriers[stage].init()
+                # Released by every consumer warp group of every CTA in the
+                # cluster: the multicast source must not overwrite a peer's
+                # tile while that peer is still reading it.
+                empty_barriers[stage].init(Int32(consumers * cluster_m))
+            a_tma.prefetch_descriptor()
+            b_tma.prefetch_descriptor()
+            comptime if tma_store:
+                c_tma.prefetch_descriptor()
+            fence_mbarrier_init()
+        # All barriers must be initialized cluster-wide before any arrival
+        # (the consumers below arrive at peer CTAs' empty barriers).
+        cluster_sync_relaxed()
+
+        comptime CFRAG = 64 * bn // 128
+        comptime MACRO_BM = bm * cluster_m
+        comptime TMA_BYTES = (bm + bn) * _V4_BK * 2
+        comptime MCAST_MASK = UInt16((1 << cluster_m) - 1)
+        comptime B_CHUNKS = bn // 64
+        var warp_group_idx = Int(thread_idx.x) // 128
+        var warp_group_thread_idx = Int(thread_idx.x) % 128
+        var rank = Int(block_rank_in_cluster())
+        var cluster_id = Int(block_idx.x) // cluster_m
+        var num_clusters = Int(grid_dim.x) // cluster_m
+        # m may be ragged: TMA A reads clamp out-of-bounds rows and the
+        # epilogue stores are row-predicated.
+        var macro_rows = (m + MACRO_BM - 1) // MACRO_BM
+        var blocks_n = n // bn
+        var total_works = macro_rows * blocks_n
+        var num_tiles = k // _V4_BK
+        var group_span = _V4_GROUP * blocks_n
+
+        # Release every pipeline slot to the producers (cluster-wide).
+        if warp_group_idx > 0 and warp_group_thread_idx < cluster_m:
+            comptime for stage in range(stages):
+                empty_barriers[stage].arrive_cluster(
+                    UInt32(warp_group_thread_idx)
+                )
+
+        if warp_group_idx == 0:
+            warpgroup_reg_dealloc[24]()
+            if warp_group_thread_idx == 0:
+                var gt = 0
+                var w = cluster_id
+                while w < total_works:
+                    var group = w // group_span
+                    var rem = w % group_span
+                    var rows_in_group = min(
+                        _V4_GROUP, macro_rows - group * _V4_GROUP
+                    )
+                    var macro_row = group * _V4_GROUP + rem % rows_in_group
+                    var n0 = (rem // rows_in_group) * bn
+                    var m0 = macro_row * MACRO_BM + rank * bm
+                    var t = 0
+                    while t < num_tiles:
+                        var stage = gt % stages
+                        var phase = UInt32((gt // stages) % 2)
+                        empty_barriers[stage].wait(phase)
+                        full_barriers[stage].expect_bytes(Int32(TMA_BYTES))
+                        var a_tile = LayoutTensor[
+                            _V4_BF16,
+                            A_LAYOUT,
+                            MutAnyOrigin,
+                            address_space=AddressSpace.SHARED,
+                            alignment=128,
+                        ](a_pipeline.ptr + stage * bm * _V4_BK)
+                        var k0 = t * _V4_BK
+                        a_tma.async_copy(a_tile, full_barriers[stage], (k0, m0))
+                        # Cooperative B load: each cluster rank reads its
+                        # share of the 64-column chunks once from L2 and
+                        # multicasts it to every peer, so the per-SM TMA
+                        # engines split the shared-tile traffic instead of
+                        # rank 0 funneling all of B (nvjet's "coopB").
+                        var cc = rank * B_CHUNKS // cluster_m
+                        var cend = (rank + 1) * B_CHUNKS // cluster_m
+                        while cc < cend:
+                            var b_chunk = LayoutTensor[
+                                _V4_BF16,
+                                B_CHUNK_LAYOUT,
+                                MutAnyOrigin,
+                                address_space=AddressSpace.SHARED,
+                                alignment=128,
+                            ](
+                                b_pipeline.ptr
+                                + stage * bn * _V4_BK
+                                + cc * 64 * _V4_BK
+                            )
+                            comptime if cluster_m > 1:
+                                b_tma.async_multicast_load(
+                                    b_chunk,
+                                    full_barriers[stage],
+                                    (n0 + cc * 64, k0),
+                                    MCAST_MASK,
+                                )
+                            else:
+                                b_tma.async_copy(
+                                    b_chunk,
+                                    full_barriers[stage],
+                                    (n0 + cc * 64, k0),
+                                )
+                            cc += 1
+                        t += 1
+                        gt += 1
+                    w += num_clusters
+        else:
+            # Consumer registers: three warp groups fit 65536 regs/SM only
+            # at 160 regs/thread (96 accumulator + addressing); two fit 232.
+            comptime if consumers >= 3:
+                warpgroup_reg_alloc[160]()
+            else:
+                warpgroup_reg_alloc[232]()
+            var accum = LayoutTensor[
+                _V4_F32,
+                Layout.row_major(1, CFRAG),
+                MutAnyOrigin,
+                address_space=AddressSpace.LOCAL,
+            ].stack_allocation()
+            comptime wgmma = TensorCoreAsync[
+                _V4_F32,
+                _V4_BF16,
+                _V4_BF16,
+                Index(64, bn, 16),
+                a_swizzle=_V4_SWIZZLE,
+                b_swizzle=_V4_SWIZZLE,
+                transpose_b=False,
+            ]()
+
+            var gt = 0
+            var w = cluster_id
+            while w < total_works:
+                var group = w // group_span
+                var rem = w % group_span
+                var rows_in_group = min(
+                    _V4_GROUP, macro_rows - group * _V4_GROUP
+                )
+                var macro_row = group * _V4_GROUP + rem % rows_in_group
+                var n0 = (rem // rows_in_group) * bn
+                var m0 = macro_row * MACRO_BM + rank * bm
+                _ = accum.fill(0.0)
+                var t = 0
+                while t < num_tiles:
+                    var stage = gt % stages
+                    var phase = UInt32((gt // stages) % 2)
+                    full_barriers[stage].wait(phase)
+                    var a_tile = LayoutTensor[
+                        _V4_BF16,
+                        A_LAYOUT,
+                        MutAnyOrigin,
+                        address_space=AddressSpace.SHARED,
+                        alignment=128,
+                    ](a_pipeline.ptr + stage * bm * _V4_BK)
+                    var b_tile = LayoutTensor[
+                        _V4_BF16,
+                        B_LAYOUT,
+                        MutAnyOrigin,
+                        address_space=AddressSpace.SHARED,
+                        alignment=128,
+                    ](b_pipeline.ptr + stage * bn * _V4_BK)
+                    warpgroup_fence(accum)
+                    wgmma.arrive()
+                    wgmma.wgmma[consumers](
+                        a_tile, b_tile, accum, warp_group_idx - 1
+                    )
+                    wgmma.commit_group()
+                    warpgroup_fence(accum)
+                    wgmma.wait_group()
+                    if warp_group_thread_idx < cluster_m:
+                        empty_barriers[stage].arrive_cluster(
+                            UInt32(warp_group_thread_idx)
+                        )
+                    t += 1
+                    gt += 1
+
+                var tid = warp_group_thread_idx
+                var warp = tid // 32
+                var lane = tid % 32
+                var base_row = warp * 16 + lane // 4
+                var base_col = (lane % 4) * 2
+                comptime if tma_store:
+                    # Stage the tile in shared memory and hand it to TMA;
+                    # the store drains in the background of the next work's
+                    # mainloop, and TMA clips rows past a ragged m edge.
+                    comptime NCONS = Int32(consumers * 128)
+                    if warp_group_idx == 1 and warp_group_thread_idx == 0:
+                        # Previous work's store must fully drain before the
+                        # staging tile is overwritten.
+                        c_tma.wait_group[0]()
+                    named_barrier[NCONS](1)
+                    comptime for q in range(CFRAG // 2):
+                        var e = q * 2
+                        var row = (
+                            (warp_group_idx - 1) * 64 + base_row + (q % 2) * 8
+                        )
+                        var col = base_col + (q // 2) * 8
+                        var pair = SIMD[_V4_BF16, 2](
+                            accum.ptr[e].cast[_V4_BF16](),
+                            accum.ptr[e + 1].cast[_V4_BF16](),
+                        )
+                        # 128B-swizzled staging layout: 16B units within
+                        # each 64-element row are XORed with (row % 8).
+                        var lcol = col % 64
+                        var elem = (
+                            (col // 64) * (bm * 64)
+                            + row * 64
+                            + ((lcol // 8) ^ (row % 8)) * 8
+                            + lcol % 8
+                        )
+                        c_smem.ptr.store[alignment=4](elem, pair)
+                    fence_async_view_proxy()
+                    named_barrier[NCONS](1)
+                    if warp_group_idx == 1 and warp_group_thread_idx == 0:
+                        comptime for chunk in range(bn // 64):
+                            var c_chunk = LayoutTensor[
+                                _V4_BF16,
+                                Layout.row_major(bm, 64),
+                                MutAnyOrigin,
+                                address_space=AddressSpace.SHARED,
+                                alignment=128,
+                            ](c_smem.ptr + chunk * bm * 64)
+                            c_tma.async_store(c_chunk, (n0 + chunk * 64, m0))
+                        c_tma.commit_group()
+                else:
+                    comptime for q in range(CFRAG // 2):
+                        var e = q * 2
+                        var row = (
+                            (warp_group_idx - 1) * 64 + base_row + (q % 2) * 8
+                        )
+                        var col = base_col + (q // 2) * 8
+                        var pair = SIMD[_V4_BF16, 2](
+                            accum.ptr[e].cast[_V4_BF16](),
+                            accum.ptr[e + 1].cast[_V4_BF16](),
+                        )
+                        if m0 + row < m and n0 + col + 1 < n:
+                            output.store[alignment=4](
+                                (m0 + row) * n + n0 + col, pair
+                            )
+                w += num_clusters
+            comptime if tma_store:
+                # Outstanding bulk stores must complete before kernel exit.
+                if warp_group_idx == 1 and warp_group_thread_idx == 0:
+                    c_tma.wait_group[0]()
+
+        # Peer CTAs receive multicast writes into this CTA's shared memory;
+        # do not tear the block down while any cluster member is running.
+        cluster_sync()
+
+
+def _v4_enqueue_nn_persistent[
+    stages: Int,
+    cluster_m: Int,
+    bm: Int,
+    bn: Int,
+    consumers: Int,
+    tma_store: Bool = False,
+](
+    output: _V4_PTR,
+    a: _V4_PTR,
+    b: _V4_PTR,
+    m: Int,
+    n: Int,
+    k: Int,
+    sm_count: Int,
+    ctx: DeviceContext,
+) raises:
+    var a_desc = create_tma_descriptor[_V4_BF16, 2, _V4_SWIZZLE](
+        DeviceBuffer(
+            ctx,
+            a.address_space_cast[AddressSpace.GENERIC](),
+            1,
+            owning=False,
+        ),
+        IndexList[2](m, k),
+        IndexList[2](k, 1),
+        IndexList[2](bm, _V4_BK),
+    )
+    var b_desc = create_tma_descriptor[_V4_BF16, 2, _V4_SWIZZLE](
+        DeviceBuffer(
+            ctx,
+            b.address_space_cast[AddressSpace.GENERIC](),
+            1,
+            owning=False,
+        ),
+        IndexList[2](k, n),
+        IndexList[2](n, 1),
+        IndexList[2](_V4_BK, 64),
+    )
+    var c_desc = create_tma_descriptor[_V4_BF16, 2, _V4_SWIZZLE](
+        DeviceBuffer(
+            ctx,
+            output.address_space_cast[AddressSpace.GENERIC](),
+            1,
+            owning=False,
+        ),
+        IndexList[2](m, n),
+        IndexList[2](n, 1),
+        IndexList[2](bm, 64),
+    )
+    var a_tma = TMATensorTile[
+        _V4_BF16, 2, Index(bm, _V4_BK), Index(bm, _V4_BK)
+    ](a_desc)
+    var b_tma = TMATensorTile[
+        _V4_BF16, 2, Index(_V4_BK, 64), Index(_V4_BK, 64)
+    ](b_desc)
+    var c_tma = TMATensorTile[_V4_BF16, 2, Index(bm, 64), Index(bm, 64)](c_desc)
+    var macro_rows = (m + bm * cluster_m - 1) // (bm * cluster_m)
+    var total_works = macro_rows * (n // bn)
+    var num_clusters = min(sm_count // cluster_m, total_works)
+    var grid_x = num_clusters * cluster_m
+    ctx.enqueue_function[
+        _v4_nn_persistent_ws[stages, cluster_m, bm, bn, consumers, tma_store]
+    ](
+        a_tma,
+        b_tma,
+        c_tma,
+        output,
+        m,
+        n,
+        k,
+        grid_dim=(grid_x,),
+        block_dim=(128 * (consumers + 1),),
+    )
+
+
+def maybe_enqueue_bf16_gemm_nn_v4(
+    output: _V4_PTR,
+    a: _V4_PTR,
+    b: _V4_PTR,
+    m: Int,
+    n: Int,
+    k: Int,
+    transpose_a: Bool,
+    transpose_b: Bool,
+    has_bias: Bool,
+    ctx: DeviceContext,
+) raises -> Bool:
+    """Route an NN GEMM to the persistent clustered v4 kernel if it fits the
+    tall-m aligned regime.  Returns False when the caller must fall back."""
+    comptime if _has_sm_9x():
+        if ctx.api() == "cuda":
+            var cc_major = ctx.get_attribute(
+                DeviceAttribute.COMPUTE_CAPABILITY_MAJOR
+            )
+            var cc_minor = ctx.get_attribute(
+                DeviceAttribute.COMPUTE_CAPABILITY_MINOR
+            )
+            if cc_major == 9 and cc_minor == 0:
+                # Same tall-m NN regime as the v3 dispatcher.  m may be
+                # ragged (TMA clamps reads, stores are predicated); n and k
+                # must tile exactly.  The ordered bounds make all descriptor
+                # and address products machine-width safe.
+                if (
+                    not transpose_a
+                    and not transpose_b
+                    and not has_bias
+                    and m >= _V4_PROD_BM * _V4_PROD_CLUSTER_M
+                    and n >= _V4_PROD_BN
+                    and k >= _V4_BK
+                    and m // n >= 8
+                    and n % _V4_PROD_BN == 0
+                    and k % _V4_BK == 0
+                    and Int(output) % 16 == 0
+                    and Int(a) % 16 == 0
+                    and Int(b) % 16 == 0
+                    and m <= 2_147_483_647
+                    and n <= 2_147_483_647
+                    and k <= 2_147_483_647
+                    and k <= 9_223_372_036_854_775_807 // m
+                    and k <= 9_223_372_036_854_775_807 // n
+                    and n <= 9_223_372_036_854_775_807 // m
+                ):
+                    var sm_count = ctx.get_attribute(
+                        DeviceAttribute.MULTIPROCESSOR_COUNT
+                    )
+                    if sm_count >= _V4_PROD_CLUSTER_M:
+                        _v4_enqueue_nn_persistent[
+                            _V4_PROD_STAGES,
+                            _V4_PROD_CLUSTER_M,
+                            _V4_PROD_BM,
+                            _V4_PROD_BN,
+                            _V4_PROD_CONSUMERS,
+                            _V4_PROD_TMA_STORE,
+                        ](output, a, b, m, n, k, sm_count, ctx)
+                        return True
+    return False

--- a/torch_mojo_backend/eager_kernels/bf16_gemm_nt_v4_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/bf16_gemm_nt_v4_kernels.mojo
@@ -1,0 +1,653 @@
+"""Persistent warp-specialized H100 BF16 NT GEMM (v4).
+
+Targets the forward-linear layout C[m,n] = A[m,k] @ B[n,k]^T on SM90.
+
+Improvements over the v3 NT kernel (`_v3_nt_ws_m128n256_tma_s3`):
+
+1. Persistent tile scheduler: a fixed grid of CTAs (one per SM) loops over
+   output tiles.  The producer warp group keeps the shared-memory pipeline
+   full ACROSS output tiles, so the per-tile pipeline fill/drain stalls of
+   the non-persistent kernel disappear.  This matters most for short-K
+   problems (few mainloop iterations per tile) where fill/drain dominated.
+2. TMA store epilogue: accumulators are staged through a 128B-swizzled
+   shared-memory tile via `st.matrix` and written with
+   `cp.async.bulk.tensor` (TMA).  The old direct epilogue issued scattered
+   4-byte global stores at 50% sector efficiency; TMA stores are fully
+   coalesced.  The store is committed asynchronously and only waited on at
+   the START of the next epilogue, so it drains while the next output
+   tile's mainloop runs.
+3. CTA clusters (size 2) with TMA multicast of B: the rasterization pairs
+   CTAs on the same column block, so each B tile is read once from L2 and
+   broadcast to both CTAs.
+4. Per-regime tile width: BN = 256 for wide/deep problems, BN = 192 (with
+   a deeper 4-stage pipeline) when it reduces persistent-wave imbalance
+   (e.g. narrow n where ceil(tiles / grid) quantization costs several
+   percent).  Selection is by a shape-generic cost model, not hardcoded
+   model dimensions.
+
+The kernel is fully dynamic in m, n, k (runtime dispatch, no hardcoded
+model dimensions).  Partial edge tiles are handled by TMA out-of-bounds
+clipping on both loads (zero-fill) and stores (write suppression).
+"""
+
+from std.gpu import (
+    MAX_THREADS_PER_BLOCK_METADATA,
+    barrier,
+    block_idx,
+    grid_dim,
+    thread_idx,
+)
+from std.gpu.compute.mma import st_matrix
+from std.gpu.host import DeviceAttribute, DeviceBuffer, DeviceContext
+from std.gpu.host.nvidia.tma import TensorMapSwizzle, create_tma_descriptor
+from std.gpu.intrinsics import warpgroup_reg_alloc, warpgroup_reg_dealloc
+from std.gpu.primitives.cluster import block_rank_in_cluster, cluster_sync
+from std.gpu.memory import AddressSpace, fence_async_view_proxy
+from std.gpu.sync import named_barrier
+from std.memory import bitcast, stack_allocation
+from std.sys.info import _has_sm_9x, _is_sm_9x
+from std.utils.index import Index, IndexList
+from std.utils.static_tuple import StaticTuple
+
+from layout import Layout, LayoutTensor
+from layout.tensor_core_async import (
+    TensorCoreAsync,
+    tile_layout_k_major,
+    warpgroup_fence,
+)
+from layout.tma_async import SharedMemBarrier, TMATensorTile
+
+comptime _V4_BF16 = DType.bfloat16
+comptime _V4_F32 = DType.float32
+comptime _V4_PTR = UnsafePointer[Scalar[_V4_BF16], MutAnyOrigin]
+comptime _V4_SWIZZLE = TensorMapSwizzle.SWIZZLE_128B
+
+comptime _V4_BM = 128
+comptime _V4_BK = 64
+comptime _V4_THREADS = 384
+comptime _V4_CONSUMERS = 2
+# Consumer warp group owns a 64-row half of the 128-row output tile.
+comptime _V4_WG_ROWS = _V4_BM // _V4_CONSUMERS
+# TMA store box: 64 rows x 64 bf16 columns (128B swizzle span).
+comptime _V4_C_BOX_N = 64
+comptime _V4_C_BOX_ELEMS = _V4_WG_ROWS * _V4_C_BOX_N
+comptime _V4_CLUSTER = 2
+comptime _V4_CLUSTER_SHAPE = StaticTuple[Int32, 3](Int32(_V4_CLUSTER), 1, 1)
+
+comptime _V4_A_LAYOUT = tile_layout_k_major[
+    _V4_BF16, _V4_BM, _V4_BK, _V4_SWIZZLE
+]()
+comptime _V4_A_TMA = TMATensorTile[
+    _V4_BF16, 2, Index(_V4_BM, _V4_BK), Index(_V4_BM, _V4_BK)
+]
+
+
+def _v4_b_layout[bn: Int]() -> Layout:
+    return tile_layout_k_major[_V4_BF16, bn, _V4_BK, _V4_SWIZZLE]()
+
+
+def _v4_b_half_layout[bn: Int]() -> Layout:
+    return tile_layout_k_major[
+        _V4_BF16, bn // _V4_CLUSTER, _V4_BK, _V4_SWIZZLE
+    ]()
+
+
+@always_inline
+def _v4_store_accum_stmatrix[
+    bn: Int
+](
+    wg_half: UnsafePointer[
+        Scalar[_V4_BF16], MutAnyOrigin, address_space=AddressSpace.SHARED
+    ],
+    accum: LayoutTensor[
+        _V4_F32,
+        Layout.row_major(1, 64 * bn // 128),
+        MutAnyOrigin,
+        address_space=AddressSpace.LOCAL,
+    ],
+    warp: Int,
+    lane: Int,
+):
+    """Store one warp group's WGMMA accumulator fragments into the 128B-
+    swizzled TMA staging tile using `st.matrix.x4` (bn // 16 instructions
+    per thread instead of bn // 4 scalar pair stores).
+
+    For instruction t, matrix j holds fragment pair q = 4t + j: row half
+    j % 2, column block 2t + j // 2.  Lane group l // 8 supplies the
+    address of matrix (l // 8), row l % 8, which this function maps through
+    the canonical SWIZZLE_128B 64x64 box layout.
+    """
+    comptime CFRAG = 64 * bn // 128
+    var mi = lane // 8
+    var row = warp * 16 + (lane % 8) + 8 * (mi % 2)
+    var row_base = row * _V4_C_BOX_N
+    var row_mod = row % 8
+    var c0 = mi // 2
+    comptime for t in range(CFRAG // 8):
+        var col = 16 * t + 8 * c0
+        var off = (
+            (col // _V4_C_BOX_N) * _V4_C_BOX_ELEMS
+            + row_base
+            + (((col % _V4_C_BOX_N) // 8) ^ row_mod) * 8
+        )
+        var data = SIMD[DType.float32, 4](
+            bitcast[DType.float32, 1](
+                SIMD[_V4_BF16, 2](
+                    accum.ptr[8 * t].cast[_V4_BF16](),
+                    accum.ptr[8 * t + 1].cast[_V4_BF16](),
+                )
+            ),
+            bitcast[DType.float32, 1](
+                SIMD[_V4_BF16, 2](
+                    accum.ptr[8 * t + 2].cast[_V4_BF16](),
+                    accum.ptr[8 * t + 3].cast[_V4_BF16](),
+                )
+            ),
+            bitcast[DType.float32, 1](
+                SIMD[_V4_BF16, 2](
+                    accum.ptr[8 * t + 4].cast[_V4_BF16](),
+                    accum.ptr[8 * t + 5].cast[_V4_BF16](),
+                )
+            ),
+            bitcast[DType.float32, 1](
+                SIMD[_V4_BF16, 2](
+                    accum.ptr[8 * t + 6].cast[_V4_BF16](),
+                    accum.ptr[8 * t + 7].cast[_V4_BF16](),
+                )
+            ),
+        )
+        st_matrix[simd_width=4](wg_half + off, data)
+
+
+@__llvm_arg_metadata(a_tma, `nvvm.grid_constant`)
+@__llvm_arg_metadata(b_tma, `nvvm.grid_constant`)
+@__llvm_arg_metadata(c_tma, `nvvm.grid_constant`)
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(_V4_THREADS)),
+    `nvvm.cluster_dim`=_V4_CLUSTER_SHAPE,
+)
+def _v4c_nt_persistent[
+    bn: Int, stages: Int, raster_h: Int, defer_release: Bool = False
+](
+    a_tma: _V4_A_TMA,
+    b_tma: TMATensorTile[
+        _V4_BF16,
+        2,
+        Index(bn // _V4_CLUSTER, _V4_BK),
+        Index(bn // _V4_CLUSTER, _V4_BK),
+    ],
+    c_tma: TMATensorTile[
+        _V4_BF16, 2, Index(_V4_WG_ROWS, bn), Index(_V4_WG_ROWS, _V4_C_BOX_N)
+    ],
+    m: Int,
+    n: Int,
+    k: Int,
+):
+    """Clustered persistent NT kernel with TMA multicast of B.
+
+    CTA pairs (cluster dim x = 2) process work tiles (2p, 2p + rank), which
+    the rasterization places at the same n0 with adjacent m0.  Each rank
+    TMA-loads its own A tile plus HALF of the shared B tile, multicast into
+    both CTAs' shared memory, halving B traffic out of L2.  When the pair's
+    work ids do not share n0 (partial raster groups) or fall off the end of
+    the work list, ranks clamp to a common valid tile / load B privately, so
+    both CTAs always execute identical barrier trip counts.
+    """
+    comptime B_HALF = bn // _V4_CLUSTER
+    comptime B_LAYOUT = _v4_b_layout[bn]()
+    comptime B_HALF_LAYOUT = _v4_b_half_layout[bn]()
+    comptime CFRAG = 64 * bn // 128
+    comptime TMA_BYTES = (_V4_BM + bn) * _V4_BK * 2
+    comptime if _is_sm_9x():
+        var a_pipeline = LayoutTensor[
+            _V4_BF16,
+            Layout.row_major(stages, _V4_BM * _V4_BK),
+            MutAnyOrigin,
+            address_space=AddressSpace.SHARED,
+            alignment=128,
+        ].stack_allocation()
+        var b_pipeline = LayoutTensor[
+            _V4_BF16,
+            Layout.row_major(stages, bn * _V4_BK),
+            MutAnyOrigin,
+            address_space=AddressSpace.SHARED,
+            alignment=128,
+        ].stack_allocation()
+        # One 64 x bn bf16 staging slice per consumer warp group, arranged
+        # as consecutive 64x64 boxes in the canonical 128B-swizzled TMA
+        # layout expected by the C descriptor.
+        var c_staging = LayoutTensor[
+            _V4_BF16,
+            Layout.row_major(_V4_CONSUMERS, _V4_WG_ROWS * bn),
+            MutAnyOrigin,
+            address_space=AddressSpace.SHARED,
+            alignment=128,
+        ].stack_allocation()
+        var full_barriers = stack_allocation[
+            stages,
+            SharedMemBarrier,
+            address_space=AddressSpace.SHARED,
+            alignment=8,
+        ]()
+        var empty_barriers = stack_allocation[
+            stages,
+            SharedMemBarrier,
+            address_space=AddressSpace.SHARED,
+            alignment=8,
+        ]()
+        if thread_idx.x == 0:
+            comptime for stage in range(stages):
+                full_barriers[stage].init()
+                # Each of the two consumer warp groups in BOTH cluster CTAs
+                # signals every slot release (arrive_cluster below).
+                empty_barriers[stage].init(Int32(_V4_CONSUMERS * _V4_CLUSTER))
+            a_tma.prefetch_descriptor()
+            b_tma.prefetch_descriptor()
+            c_tma.prefetch_descriptor()
+        barrier()
+        # Peer CTA barriers must be initialized before any cross-CTA arrival.
+        cluster_sync()
+
+        var warp_group_idx = Int(thread_idx.x) // 128
+        var warp_group_thread_idx = Int(thread_idx.x) % 128
+        var rank = Int(block_rank_in_cluster())
+        var blocks_m = (m + _V4_BM - 1) // _V4_BM
+        var blocks_n = (n + bn - 1) // bn
+        var total_work = blocks_m * blocks_n
+        var num_k_tiles = k // _V4_BK
+        var num_pairs = Int(grid_dim.x) // _V4_CLUSTER
+        var pair0 = Int(block_idx.x) // _V4_CLUSTER
+        var group_span = raster_h * blocks_n
+
+        if warp_group_idx > 0 and warp_group_thread_idx < _V4_CLUSTER:
+            comptime for stage in range(stages):
+                empty_barriers[stage].arrive_cluster(
+                    UInt32(warp_group_thread_idx)
+                )
+        barrier()
+
+        if warp_group_idx == 0:
+            warpgroup_reg_dealloc[24]()
+            if thread_idx.x == 0:
+                # Producer: stream A/B tiles for every assigned output tile
+                # through one continuously-cycling pipeline.  The slot/phase
+                # arithmetic uses a single global tile counter so consumers
+                # stay in lockstep across output-tile boundaries.
+                var gkt = 0
+                var pair = pair0
+                while pair * _V4_CLUSTER < total_work:
+                    var my_work = min(pair * _V4_CLUSTER + rank, total_work - 1)
+                    var peer_work = min(
+                        pair * _V4_CLUSTER + (1 - rank), total_work - 1
+                    )
+                    # Rasterization: groups of raster_h m-blocks, n-major
+                    # inside a group; keeps a wave of CTAs inside a band of
+                    # A rows and limits per-pass B re-reads from DRAM.
+                    var group = my_work // group_span
+                    var rem = my_work % group_span
+                    var rows_in_group = min(
+                        raster_h, blocks_m - group * raster_h
+                    )
+                    var m0 = (group * raster_h + rem % rows_in_group) * _V4_BM
+                    var n0 = (rem // rows_in_group) * bn
+                    var peer_group = peer_work // group_span
+                    var peer_rem = peer_work % group_span
+                    var peer_rows = min(
+                        raster_h, blocks_m - peer_group * raster_h
+                    )
+                    var peer_n0 = (peer_rem // peer_rows) * bn
+                    var can_multicast = peer_n0 == n0
+                    var kt = 0
+                    while kt < num_k_tiles:
+                        var stage = gkt % stages
+                        var phase = UInt32((gkt // stages) % 2)
+                        empty_barriers[stage].wait(phase)
+                        full_barriers[stage].expect_bytes(Int32(TMA_BYTES))
+                        var a_tile = LayoutTensor[
+                            _V4_BF16,
+                            _V4_A_LAYOUT,
+                            MutAnyOrigin,
+                            address_space=AddressSpace.SHARED,
+                            alignment=128,
+                        ](a_pipeline.ptr + stage * _V4_BM * _V4_BK)
+                        var k0 = kt * _V4_BK
+                        a_tma.async_copy(a_tile, full_barriers[stage], (k0, m0))
+                        if can_multicast:
+                            # Load our half of B, multicast to both CTAs.
+                            var b_half = LayoutTensor[
+                                _V4_BF16,
+                                B_HALF_LAYOUT,
+                                MutAnyOrigin,
+                                address_space=AddressSpace.SHARED,
+                                alignment=128,
+                            ](
+                                b_pipeline.ptr
+                                + stage * bn * _V4_BK
+                                + rank * B_HALF * _V4_BK
+                            )
+                            b_tma.async_multicast_load(
+                                b_half,
+                                full_barriers[stage],
+                                (k0, n0 + rank * B_HALF),
+                                UInt16(0b11),
+                            )
+                        else:
+                            # Divergent pair: load the full B tile privately.
+                            comptime for half in range(_V4_CLUSTER):
+                                var b_half = LayoutTensor[
+                                    _V4_BF16,
+                                    B_HALF_LAYOUT,
+                                    MutAnyOrigin,
+                                    address_space=AddressSpace.SHARED,
+                                    alignment=128,
+                                ](
+                                    b_pipeline.ptr
+                                    + stage * bn * _V4_BK
+                                    + half * B_HALF * _V4_BK
+                                )
+                                b_tma.async_copy(
+                                    b_half,
+                                    full_barriers[stage],
+                                    (k0, n0 + half * B_HALF),
+                                )
+                        kt += 1
+                        gkt += 1
+                    pair += num_pairs
+        else:
+            warpgroup_reg_alloc[232]()
+            var accum = LayoutTensor[
+                _V4_F32,
+                Layout.row_major(1, CFRAG),
+                MutAnyOrigin,
+                address_space=AddressSpace.LOCAL,
+            ].stack_allocation()
+            comptime wgmma = TensorCoreAsync[
+                _V4_F32,
+                _V4_BF16,
+                _V4_BF16,
+                Index(64, bn, 16),
+                a_swizzle=_V4_SWIZZLE,
+                b_swizzle=_V4_SWIZZLE,
+                transpose_b=True,
+            ]()
+
+            var tid = warp_group_thread_idx
+            var warp = tid // 32
+            var lane = tid % 32
+            var wg_half = c_staging.ptr + (
+                (warp_group_idx - 1) * _V4_WG_ROWS * bn
+            )
+
+            var gkt = 0
+            var pair = pair0
+            while pair * _V4_CLUSTER < total_work:
+                var my_work = min(pair * _V4_CLUSTER + rank, total_work - 1)
+                var group = my_work // group_span
+                var rem = my_work % group_span
+                var rows_in_group = min(raster_h, blocks_m - group * raster_h)
+                var m0 = (group * raster_h + rem % rows_in_group) * _V4_BM
+                var n0 = (rem // rows_in_group) * bn
+
+                var kt = 0
+                var prev_stage = -1
+                while kt < num_k_tiles:
+                    var stage = gkt % stages
+                    var phase = UInt32((gkt // stages) % 2)
+                    full_barriers[stage].wait(phase)
+                    var a_tile = LayoutTensor[
+                        _V4_BF16,
+                        _V4_A_LAYOUT,
+                        MutAnyOrigin,
+                        address_space=AddressSpace.SHARED,
+                        alignment=128,
+                    ](a_pipeline.ptr + stage * _V4_BM * _V4_BK)
+                    var b_tile = LayoutTensor[
+                        _V4_BF16,
+                        B_LAYOUT,
+                        MutAnyOrigin,
+                        address_space=AddressSpace.SHARED,
+                        alignment=128,
+                    ](b_pipeline.ptr + stage * bn * _V4_BK)
+                    warpgroup_fence(accum)
+                    wgmma.arrive()
+                    if kt == 0:
+                        # scale_c = 0: first k-tile overwrites the
+                        # accumulator, so no zero-fill pass is needed.
+                        wgmma.wgmma[_V4_CONSUMERS, scale_c=0](
+                            a_tile, b_tile, accum, warp_group_idx - 1
+                        )
+                    else:
+                        wgmma.wgmma[_V4_CONSUMERS](
+                            a_tile, b_tile, accum, warp_group_idx - 1
+                        )
+                    wgmma.commit_group()
+                    warpgroup_fence(accum)
+                    comptime if defer_release:
+                        # Keep one WGMMA group in flight so the tensor pipe
+                        # never drains between k-tiles; release the PREVIOUS
+                        # slot, whose group is provably complete.  Needs a
+                        # deeper pipeline (stages >= 4) to avoid starving
+                        # the producer.
+                        wgmma.wait_group[1]()
+                        if (
+                            prev_stage >= 0
+                            and warp_group_thread_idx < _V4_CLUSTER
+                        ):
+                            empty_barriers[prev_stage].arrive_cluster(
+                                UInt32(warp_group_thread_idx)
+                            )
+                        prev_stage = stage
+                    else:
+                        wgmma.wait_group()
+                        if warp_group_thread_idx < _V4_CLUSTER:
+                            empty_barriers[stage].arrive_cluster(
+                                UInt32(warp_group_thread_idx)
+                            )
+                    kt += 1
+                    gkt += 1
+                comptime if defer_release:
+                    wgmma.wait_group[0]()
+                    if prev_stage >= 0 and warp_group_thread_idx < _V4_CLUSTER:
+                        empty_barriers[prev_stage].arrive_cluster(
+                            UInt32(warp_group_thread_idx)
+                        )
+
+                # ---- Epilogue: registers -> swizzled smem -> TMA store ----
+                # The previous output tile's TMA store must have drained
+                # before this warp group's staging slice is overwritten.  The
+                # wait is executed by the issuing thread; the named barrier
+                # (one per consumer warp group) releases the rest.
+                if warp_group_thread_idx == 0:
+                    c_tma.wait_group[0]()
+                named_barrier[Int32(128)](Int32(warp_group_idx))
+
+                _v4_store_accum_stmatrix[bn](wg_half, accum, warp, lane)
+
+                # Make generic-proxy smem writes visible to the async proxy,
+                # then let one thread issue the (clipped) TMA store.  It is
+                # only waited on at the next epilogue, so the store drains
+                # while the next output tile's mainloop runs.
+                fence_async_view_proxy()
+                named_barrier[Int32(128)](Int32(warp_group_idx))
+                if warp_group_thread_idx == 0:
+                    var c_store = LayoutTensor[
+                        _V4_BF16,
+                        Layout.row_major(_V4_WG_ROWS, bn),
+                        MutAnyOrigin,
+                        address_space=AddressSpace.SHARED,
+                        alignment=128,
+                    ](wg_half)
+                    c_tma.async_store(
+                        c_store,
+                        (n0, m0 + (warp_group_idx - 1) * _V4_WG_ROWS),
+                    )
+                    c_tma.commit_group()
+                pair += num_pairs
+
+            if warp_group_thread_idx == 0:
+                c_tma.wait_group[0]()
+
+        # Keep the cluster resident until every CTA is done: peer shared
+        # memory (barriers) must stay valid for cross-CTA arrivals.
+        cluster_sync()
+
+
+def _v4c_enqueue_nt_persistent[
+    bn: Int, stages: Int, raster_h: Int, defer_release: Bool = False
+](
+    output: _V4_PTR,
+    a: _V4_PTR,
+    b: _V4_PTR,
+    m: Int,
+    n: Int,
+    k: Int,
+    grid_x: Int,
+    ctx: DeviceContext,
+) raises:
+    var a_desc = create_tma_descriptor[_V4_BF16, 2, _V4_SWIZZLE](
+        DeviceBuffer(
+            ctx,
+            a.address_space_cast[AddressSpace.GENERIC](),
+            1,
+            owning=False,
+        ),
+        IndexList[2](m, k),
+        IndexList[2](k, 1),
+        IndexList[2](_V4_BM, _V4_BK),
+    )
+    var b_desc = create_tma_descriptor[_V4_BF16, 2, _V4_SWIZZLE](
+        DeviceBuffer(
+            ctx,
+            b.address_space_cast[AddressSpace.GENERIC](),
+            1,
+            owning=False,
+        ),
+        IndexList[2](n, k),
+        IndexList[2](k, 1),
+        IndexList[2](bn // _V4_CLUSTER, _V4_BK),
+    )
+    var c_desc = create_tma_descriptor[_V4_BF16, 2, _V4_SWIZZLE](
+        DeviceBuffer(
+            ctx,
+            output.address_space_cast[AddressSpace.GENERIC](),
+            1,
+            owning=False,
+        ),
+        IndexList[2](m, n),
+        IndexList[2](n, 1),
+        IndexList[2](_V4_WG_ROWS, _V4_C_BOX_N),
+    )
+    var a_tma = _V4_A_TMA(a_desc)
+    var b_tma = TMATensorTile[
+        _V4_BF16,
+        2,
+        Index(bn // _V4_CLUSTER, _V4_BK),
+        Index(bn // _V4_CLUSTER, _V4_BK),
+    ](b_desc)
+    var c_tma = TMATensorTile[
+        _V4_BF16, 2, Index(_V4_WG_ROWS, bn), Index(_V4_WG_ROWS, _V4_C_BOX_N)
+    ](c_desc)
+    ctx.enqueue_function[
+        _v4c_nt_persistent[bn, stages, raster_h, defer_release]
+    ](
+        a_tma,
+        b_tma,
+        c_tma,
+        m,
+        n,
+        k,
+        grid_dim=(grid_x,),
+        block_dim=(_V4_THREADS,),
+    )
+
+
+def maybe_enqueue_bf16_gemm_nt_v4(
+    output: _V4_PTR,
+    a: _V4_PTR,
+    b: _V4_PTR,
+    m: Int,
+    n: Int,
+    k: Int,
+    ctx: DeviceContext,
+) raises -> Bool:
+    """Route an NT GEMM to the persistent v4 kernel if the regime allows.
+
+    Returns True when the work was enqueued.  Callers must fall back to the
+    v3 dispatcher when False is returned.  Alignment requirements: 16B base
+    pointers (TMA), n % 8 for 16B-aligned gmem rows, k % BK for the
+    pipeline, and TMA descriptor dimension limits.  m and n need NOT be
+    tile-aligned: TMA clips partial edge tiles on load and store.
+    """
+    comptime if _has_sm_9x():
+        if ctx.api() == "cuda":
+            var cc_major = ctx.get_attribute(
+                DeviceAttribute.COMPUTE_CAPABILITY_MAJOR
+            )
+            var cc_minor = ctx.get_attribute(
+                DeviceAttribute.COMPUTE_CAPABILITY_MINOR
+            )
+            if (
+                cc_major == 9
+                and cc_minor == 0
+                and m >= 1
+                and n >= _V4_C_BOX_N
+                and k >= _V4_BK
+                and n % 8 == 0
+                and k % _V4_BK == 0
+                and Int(output) % 16 == 0
+                and Int(a) % 16 == 0
+                and Int(b) % 16 == 0
+                and m <= 2_147_483_647
+                and n <= 2_147_483_647
+                and k <= 2_147_483_647
+                and k <= 9_223_372_036_854_775_807 // m
+                and k <= 9_223_372_036_854_775_807 // n
+                and n <= 9_223_372_036_854_775_807 // m
+            ):
+                var blocks_m = (m + _V4_BM - 1) // _V4_BM
+                var sm_count = ctx.get_attribute(
+                    DeviceAttribute.MULTIPROCESSOR_COUNT
+                )
+                var max_grid_x = ctx.get_attribute(
+                    DeviceAttribute.MAX_GRID_DIM_X
+                )
+                var grid_pairs = sm_count // _V4_CLUSTER
+                var blocks_n_256 = (n + 255) // 256
+                var blocks_n_192 = (n + 191) // 192
+                if (
+                    blocks_m > 0
+                    and grid_pairs > 0
+                    and max_grid_x > 0
+                    and blocks_m <= max_grid_x // blocks_n_256
+                    and blocks_m <= max_grid_x // blocks_n_192
+                ):
+                    # Persistent-wave cost model: per-cluster time is
+                    # (waves) x (per-tile cost ~ BN + fixed per-tile
+                    # overhead).  Measured on H100: the fixed overhead makes
+                    # BN = 256 win whenever both widths tile n comparably;
+                    # BN = 192 only pays off for genuinely narrow n where
+                    # the wide tile would compute mostly-clipped columns.
+                    var pairs_256 = (
+                        blocks_m * blocks_n_256 + _V4_CLUSTER - 1
+                    ) // _V4_CLUSTER
+                    var pairs_192 = (
+                        blocks_m * blocks_n_192 + _V4_CLUSTER - 1
+                    ) // _V4_CLUSTER
+                    var cost_256 = (
+                        (pairs_256 + grid_pairs - 1) // grid_pairs
+                    ) * (256 + 32)
+                    var cost_192 = (
+                        (pairs_192 + grid_pairs - 1) // grid_pairs
+                    ) * (192 + 32)
+                    if cost_192 * 102 < cost_256 * 100:
+                        var grid_x = min(pairs_192, grid_pairs) * _V4_CLUSTER
+                        _v4c_enqueue_nt_persistent[192, 4, 16](
+                            output, a, b, m, n, k, grid_x, ctx
+                        )
+                        return True
+                    var grid_x = min(pairs_256, grid_pairs) * _V4_CLUSTER
+                    _v4c_enqueue_nt_persistent[256, 3, 16](
+                        output, a, b, m, n, k, grid_x, ctx
+                    )
+                    return True
+    return False

--- a/torch_mojo_backend/eager_kernels/bf16_gemm_tn_v4_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/bf16_gemm_tn_v4_kernels.mojo
@@ -1,0 +1,652 @@
+"""V4 H100 BF16 TN (wgrad) GEMM kernels: split-K and narrow-tile variants.
+
+The nanogpt wgrad family C[m,n] = A[k,m]^T @ B[k,n] has a huge reduction
+dimension (K = tokens = 32768) and small outputs (m,n in the hundreds to a
+few thousand), so the v3 one-CTA-per-output-tile kernels leave most of the
+GPU idle: (768,768) yields only 18 CTAs of 128x256 for 114 SMs.
+
+Two remedies, both dispatched by regime (no model dims hardcoded):
+
+1. Split-K: when output tiles fill less than half the SMs, partition K
+   across `splits` CTAs per tile (grid y).  Each CTA accumulates its K-chunk
+   into an fp32 workspace slice; a small elementwise kernel reduces the
+   slices and casts to bf16.  A workspace + separate reduce is deterministic
+   and much faster than atomics on these deep-K shapes.
+2. Narrow 128x192 tiles whenever the wave-quantized cost (waves x per-CTA
+   work) beats 256-wide tiles.  That covers the one-wave underfilled case
+   (72 CTAs of 128x256 on 114 SMs -> 96 fuller CTAs) and the multi-wave
+   case with an idle tail (1179 CTAs = 10.3 waves -> 1572 = 13.8 waves but
+   25% less work per CTA).  Single-wave grids get a 4-stage pipeline;
+   multi-wave sustained grids get 3 stages (measurably less power draw on
+   this power-limited card) and 16-row rasterization groups (halves DRAM
+   traffic for B, which all row-tiles share).
+
+Both kernels reuse the v3 warp-specialized TMA + WGMMA structure: A is
+physical row-major (K, M) and loaded directly into an MN-major shared tile,
+which is the column-major A representation accepted by SM90 WGMMA.
+"""
+
+from std.gpu import (
+    MAX_THREADS_PER_BLOCK_METADATA,
+    barrier,
+    block_idx,
+    thread_idx,
+)
+from std.gpu.host import DeviceAttribute, DeviceBuffer, DeviceContext
+from std.gpu.host.nvidia.tma import (
+    TensorMapSwizzle,
+    create_tma_descriptor,
+)
+from std.gpu.compute.mma import (
+    wgmma_async,
+    wgmma_commit_group_sync,
+    wgmma_fence_aligned,
+    wgmma_wait_group_sync,
+)
+from std.gpu.intrinsics import warpgroup_reg_alloc, warpgroup_reg_dealloc
+from std.gpu.memory import AddressSpace
+from std.memory import stack_allocation
+from std.sys.info import _has_sm_9x, _is_sm_9x
+from std.utils.index import Index, IndexList
+from std.utils.static_tuple import StaticTuple
+
+from layout import Layout, LayoutTensor
+from layout.tensor_core_async import (
+    _convert_cfrags_to_simd,
+    _convert_cfrags_to_tuple,
+    _wgmma_descriptor,
+    tile_layout_mn_major,
+    tile_to_descriptor,
+    warpgroup_fence,
+)
+from layout.tma_async import SharedMemBarrier, TMATensorTile
+
+
+comptime _V4_BF16 = DType.bfloat16
+comptime _V4_F32 = DType.float32
+comptime _V4_PTR = UnsafePointer[Scalar[_V4_BF16], MutAnyOrigin]
+comptime _V4_F32_PTR = UnsafePointer[Scalar[_V4_F32], MutAnyOrigin]
+comptime _V4_BM = 128
+comptime _V4_BK = 64
+comptime _V4_SWIZZLE = TensorMapSwizzle.SWIZZLE_128B
+comptime _V4_THREADS = 384
+comptime _V4_CONSUMERS = 2
+# Split-K sizing: never split below this many BK-tiles per chunk (pipeline
+# ramp-up dominates below that), and cap the workspace size.
+comptime _V4_MIN_CHUNK_TILES = 16
+comptime _V4_MAX_SPLITS = 8
+comptime _V4_MAX_WS_BYTES = 256 * 1024 * 1024
+
+
+# ============================================================================
+# Shared warp-specialized TMA + WGMMA body.
+#
+# SPLITK=True : accumulates BK-tiles [tile_start, tile_start + chunk) and
+#               stores the fp32 partial tile into ws at slice block_idx.y.
+# SPLITK=False: accumulates the whole K range and stores bf16 into out.
+# ============================================================================
+@always_inline
+def _v4_tn_ws_body[
+    BN: Int, STAGES: Int, SPLITK: Bool, GROUP_ROWS: Int
+](
+    a_tma: TMATensorTile[_V4_BF16, 2, Index(_V4_BK, _V4_BM), Index(_V4_BK, 64)],
+    b_tma: TMATensorTile[_V4_BF16, 2, Index(_V4_BK, BN), Index(_V4_BK, 64)],
+    output: _V4_PTR,
+    ws: _V4_F32_PTR,
+    m: Int,
+    n: Int,
+    k: Int,
+    chunk_tiles: Int,
+):
+    comptime if _is_sm_9x():
+        comptime A_LAYOUT = tile_layout_mn_major[
+            _V4_BF16, _V4_BM, _V4_BK, _V4_SWIZZLE
+        ]()
+        comptime B_LAYOUT = tile_layout_mn_major[
+            _V4_BF16, BN, _V4_BK, _V4_SWIZZLE
+        ]()
+        comptime A_PIPE_LAYOUT = Layout.row_major(STAGES, _V4_BM * _V4_BK)
+        comptime B_PIPE_LAYOUT = Layout.row_major(STAGES, BN * _V4_BK)
+
+        var a_pipeline = LayoutTensor[
+            _V4_BF16,
+            A_PIPE_LAYOUT,
+            MutAnyOrigin,
+            address_space=AddressSpace.SHARED,
+            alignment=128,
+        ].stack_allocation()
+        var b_pipeline = LayoutTensor[
+            _V4_BF16,
+            B_PIPE_LAYOUT,
+            MutAnyOrigin,
+            address_space=AddressSpace.SHARED,
+            alignment=128,
+        ].stack_allocation()
+        var full_barriers = stack_allocation[
+            STAGES,
+            SharedMemBarrier,
+            address_space=AddressSpace.SHARED,
+            alignment=8,
+        ]()
+        var empty_barriers = stack_allocation[
+            STAGES,
+            SharedMemBarrier,
+            address_space=AddressSpace.SHARED,
+            alignment=8,
+        ]()
+        if thread_idx.x == 0:
+            comptime for stage in range(STAGES):
+                full_barriers[stage].init()
+                empty_barriers[stage].init(Int32(_V4_CONSUMERS))
+            a_tma.prefetch_descriptor()
+            b_tma.prefetch_descriptor()
+        # Order barrier initialization before cross-warp-group arrivals.
+        barrier()
+
+        comptime CFRAG = 64 * BN // 128
+        var warp_group_idx = Int(thread_idx.x) // 128
+        var warp_group_thread_idx = Int(thread_idx.x) % 128
+        var blocks_m = (m + _V4_BM - 1) // _V4_BM
+        var blocks_n = (n + BN - 1) // BN
+        var lin = Int(block_idx.x)
+        var group_span = GROUP_ROWS * blocks_n
+        var group = lin // group_span
+        var rem = lin % group_span
+        var rows_in_group = min(GROUP_ROWS, blocks_m - group * GROUP_ROWS)
+        var m0 = (group * GROUP_ROWS + rem % rows_in_group) * _V4_BM
+        var n0 = (rem // rows_in_group) * BN
+
+        # K range handled by this CTA (whole K unless split-K).
+        var tile_start = 0
+        var my_tiles = k // _V4_BK
+        comptime if SPLITK:
+            tile_start = Int(block_idx.y) * chunk_tiles
+            my_tiles = min(chunk_tiles, k // _V4_BK - tile_start)
+            if my_tiles < 0:
+                my_tiles = 0
+        comptime TMA_BYTES = (_V4_BM + BN) * _V4_BK * 2
+
+        # Initially release every pipeline slot to the producer.  Thereafter
+        # both consumer warp groups arrive only after their WGMMA reads
+        # finish.
+        if warp_group_idx > 0 and warp_group_thread_idx == 0:
+            comptime for stage in range(STAGES):
+                _ = empty_barriers[stage].arrive()
+        barrier()
+
+        if warp_group_idx == 0:
+            warpgroup_reg_dealloc[24]()
+            if thread_idx.x == 0:
+                var it = 0
+                while it < my_tiles:
+                    var stage = it % STAGES
+                    var phase = UInt32((it // STAGES) % 2)
+                    empty_barriers[stage].wait(phase)
+                    full_barriers[stage].expect_bytes(Int32(TMA_BYTES))
+
+                    var a_tile = LayoutTensor[
+                        _V4_BF16,
+                        A_LAYOUT,
+                        MutAnyOrigin,
+                        address_space=AddressSpace.SHARED,
+                        alignment=128,
+                    ](a_pipeline.ptr + stage * _V4_BM * _V4_BK)
+                    var b_tile = LayoutTensor[
+                        _V4_BF16,
+                        B_LAYOUT,
+                        MutAnyOrigin,
+                        address_space=AddressSpace.SHARED,
+                        alignment=128,
+                    ](b_pipeline.ptr + stage * BN * _V4_BK)
+                    var k0 = (tile_start + it) * _V4_BK
+                    a_tma.async_copy(a_tile, full_barriers[stage], (m0, k0))
+                    b_tma.async_copy(b_tile, full_barriers[stage], (n0, k0))
+                    it += 1
+        else:
+            warpgroup_reg_alloc[232]()
+            var accum = LayoutTensor[
+                _V4_F32,
+                Layout.row_major(1, CFRAG),
+                MutAnyOrigin,
+                address_space=AddressSpace.LOCAL,
+            ].stack_allocation()
+            _ = accum.fill(0.0)
+
+            # MN-major descriptors are required for WGMMA's column-major A
+            # and row-major B modes.  The second consumer advances by one
+            # 64-row WGMMA tile within the shared A tile.
+            comptime a_canonical_layout = tile_to_descriptor[
+                _V4_BF16, A_LAYOUT, False
+            ]()
+            comptime b_canonical_layout = tile_to_descriptor[
+                _V4_BF16, B_LAYOUT, False
+            ]()
+            comptime a_shape00 = a_canonical_layout[0].shape[0].value()
+            comptime a_stride01 = a_canonical_layout[0].stride[1].value()
+            comptime a_stride11 = a_canonical_layout[1].stride[1].value()
+            comptime b_stride11 = b_canonical_layout[1].stride[1].value()
+            comptime a_m_stride = a_stride01 * (64 // a_shape00) * 2
+            comptime a_k_stride = a_stride11 * 2 * 2
+            comptime b_k_stride = b_stride11 * 2 * 2
+            comptime NUM_K_MMAS = _V4_BK // 16
+
+            var it = 0
+            while it < my_tiles:
+                var stage = it % STAGES
+                var phase = UInt32((it // STAGES) % 2)
+                full_barriers[stage].wait(phase)
+                var a_tile = LayoutTensor[
+                    _V4_BF16,
+                    A_LAYOUT,
+                    MutAnyOrigin,
+                    address_space=AddressSpace.SHARED,
+                    alignment=128,
+                ](a_pipeline.ptr + stage * _V4_BM * _V4_BK)
+                var b_tile = LayoutTensor[
+                    _V4_BF16,
+                    B_LAYOUT,
+                    MutAnyOrigin,
+                    address_space=AddressSpace.SHARED,
+                    alignment=128,
+                ](b_pipeline.ptr + stage * BN * _V4_BK)
+                var a_desc = _wgmma_descriptor[
+                    a_canonical_layout, False, _V4_SWIZZLE
+                ](a_tile.ptr)
+                var b_desc = _wgmma_descriptor[
+                    b_canonical_layout, False, _V4_SWIZZLE
+                ](b_tile.ptr)
+                a_desc += a_m_stride * (warp_group_idx - 1)
+
+                warpgroup_fence(accum)
+                wgmma_fence_aligned()
+                comptime for k_mma in range(NUM_K_MMAS):
+                    var c_tuple = _convert_cfrags_to_tuple[_V4_F32, CFRAG](
+                        accum
+                    )
+                    var c_out = wgmma_async[
+                        64,
+                        BN,
+                        16,
+                        a_type=_V4_BF16,
+                        b_type=_V4_BF16,
+                        layout_a="col",
+                        layout_b="row",
+                    ](
+                        a_desc + k_mma * a_k_stride,
+                        b_desc + k_mma * b_k_stride,
+                        c_tuple,
+                    )
+                    _convert_cfrags_to_simd[_V4_F32, CFRAG](c_out, accum)
+                wgmma_commit_group_sync()
+                warpgroup_fence(accum)
+                wgmma_wait_group_sync()
+                if warp_group_thread_idx == 0:
+                    _ = empty_barriers[stage].arrive()
+                it += 1
+
+            var tid = warp_group_thread_idx
+            var warp = tid // 32
+            var lane = tid % 32
+            var base_row = warp * 16 + lane // 4
+            var base_col = (lane % 4) * 2
+            comptime if SPLITK:
+                var ws_base = ws + Int(block_idx.y) * (m * n)
+                comptime for q in range(CFRAG // 2):
+                    var e = q * 2
+                    var row = (warp_group_idx - 1) * 64 + base_row + (q % 2) * 8
+                    var col = base_col + (q // 2) * 8
+                    var pair = SIMD[_V4_F32, 2](accum.ptr[e], accum.ptr[e + 1])
+                    if m0 + row < m and n0 + col + 1 < n:
+                        ws_base.store[alignment=8](
+                            (m0 + row) * n + n0 + col, pair
+                        )
+            else:
+                comptime for q in range(CFRAG // 2):
+                    var e = q * 2
+                    var row = (warp_group_idx - 1) * 64 + base_row + (q % 2) * 8
+                    var col = base_col + (q // 2) * 8
+                    var pair = SIMD[_V4_BF16, 2](
+                        accum.ptr[e].cast[_V4_BF16](),
+                        accum.ptr[e + 1].cast[_V4_BF16](),
+                    )
+                    if m0 + row < m and n0 + col + 1 < n:
+                        output.store[alignment=4](
+                            (m0 + row) * n + n0 + col, pair
+                        )
+
+
+# ============================================================================
+# Concrete kernel entry points (thin named wrappers over the shared body).
+# ============================================================================
+@__llvm_arg_metadata(a_tma, `nvvm.grid_constant`)
+@__llvm_arg_metadata(b_tma, `nvvm.grid_constant`)
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(_V4_THREADS))
+)
+@__name("nanogpt_bf16_gemm_tn_v4_splitk_m128n256_s4")
+def _v4_tn_splitk_m128n256_s4(
+    a_tma: TMATensorTile[_V4_BF16, 2, Index(_V4_BK, _V4_BM), Index(_V4_BK, 64)],
+    b_tma: TMATensorTile[_V4_BF16, 2, Index(_V4_BK, 256), Index(_V4_BK, 64)],
+    ws: _V4_F32_PTR,
+    m: Int,
+    n: Int,
+    k: Int,
+    chunk_tiles: Int,
+):
+    _v4_tn_ws_body[256, 4, True, 8](
+        a_tma, b_tma, ws.bitcast[Scalar[_V4_BF16]](), ws, m, n, k, chunk_tiles
+    )
+
+
+@__llvm_arg_metadata(a_tma, `nvvm.grid_constant`)
+@__llvm_arg_metadata(b_tma, `nvvm.grid_constant`)
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(_V4_THREADS))
+)
+@__name("nanogpt_bf16_gemm_tn_v4_direct_m128n192_s4")
+def _v4_tn_direct_m128n192_s4(
+    a_tma: TMATensorTile[_V4_BF16, 2, Index(_V4_BK, _V4_BM), Index(_V4_BK, 64)],
+    b_tma: TMATensorTile[_V4_BF16, 2, Index(_V4_BK, 192), Index(_V4_BK, 64)],
+    output: _V4_PTR,
+    m: Int,
+    n: Int,
+    k: Int,
+):
+    _v4_tn_ws_body[192, 4, False, 8](
+        a_tma, b_tma, output, output.bitcast[Scalar[_V4_F32]](), m, n, k, 0
+    )
+
+
+# Multi-wave variant: 3 stages draw measurably less power than 4 on this
+# power-limited card (sustained multi-wave runs throttle), and 16-row
+# rasterization groups halve DRAM traffic for B, which all row-tiles share.
+@__llvm_arg_metadata(a_tma, `nvvm.grid_constant`)
+@__llvm_arg_metadata(b_tma, `nvvm.grid_constant`)
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(_V4_THREADS))
+)
+@__name("nanogpt_bf16_gemm_tn_v4_direct_m128n192_s3g16")
+def _v4_tn_direct_m128n192_s3g16(
+    a_tma: TMATensorTile[_V4_BF16, 2, Index(_V4_BK, _V4_BM), Index(_V4_BK, 64)],
+    b_tma: TMATensorTile[_V4_BF16, 2, Index(_V4_BK, 192), Index(_V4_BK, 64)],
+    output: _V4_PTR,
+    m: Int,
+    n: Int,
+    k: Int,
+):
+    _v4_tn_ws_body[192, 3, False, 16](
+        a_tma, b_tma, output, output.bitcast[Scalar[_V4_F32]](), m, n, k, 0
+    )
+
+
+# Elementwise reduction of the split-K fp32 workspace slices into the bf16
+# output: out[i] = bf16(sum_s ws[s * count + i]).  Each thread owns
+# _V4_RED_GROUPS independent vec4 chains so enough loads are in flight to
+# saturate DRAM (a single chain per thread measured only ~53% of peak).
+comptime _V4_RED_THREADS = 256
+comptime _V4_RED_GROUPS = 4
+comptime _V4_RED_SPAN = _V4_RED_THREADS * _V4_RED_GROUPS * 4
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(_V4_RED_THREADS))
+)
+@__name("nanogpt_bf16_gemm_tn_v4_splitk_reduce")
+def _v4_tn_splitk_reduce(
+    output: _V4_PTR,
+    ws: _V4_F32_PTR,
+    count: Int,
+    splits: Int,
+):
+    var base = Int(block_idx.x) * _V4_RED_SPAN + Int(thread_idx.x) * 4
+    if base + (_V4_RED_GROUPS - 1) * _V4_RED_THREADS * 4 + 4 <= count:
+        # Fast path: all four chains fully in range.
+        var acc = StaticTuple[SIMD[_V4_F32, 4], _V4_RED_GROUPS]()
+        comptime for g in range(_V4_RED_GROUPS):
+            acc[g] = ws.load[width=4, alignment=16](
+                base + g * _V4_RED_THREADS * 4
+            )
+        for s in range(1, splits):
+            var slice_base = s * count + base
+            comptime for g in range(_V4_RED_GROUPS):
+                acc[g] += ws.load[width=4, alignment=16](
+                    slice_base + g * _V4_RED_THREADS * 4
+                )
+        comptime for g in range(_V4_RED_GROUPS):
+            output.store[alignment=8](
+                base + g * _V4_RED_THREADS * 4, acc[g].cast[_V4_BF16]()
+            )
+    else:
+        comptime for g in range(_V4_RED_GROUPS):
+            var i = base + g * _V4_RED_THREADS * 4
+            if i + 4 <= count:
+                var acc4 = ws.load[width=4, alignment=16](i)
+                for s in range(1, splits):
+                    acc4 += ws.load[width=4, alignment=16](s * count + i)
+                output.store[alignment=8](i, acc4.cast[_V4_BF16]())
+            else:
+                while i < count:
+                    var acc1 = ws[i]
+                    for s in range(1, splits):
+                        acc1 += ws[s * count + i]
+                    output[i] = acc1.cast[_V4_BF16]()
+                    i += 1
+
+
+# ============================================================================
+# Enqueue helpers
+# ============================================================================
+def _v4_make_a_tma(
+    a: _V4_PTR, m: Int, k: Int, ctx: DeviceContext
+) raises -> TMATensorTile[
+    _V4_BF16, 2, Index(_V4_BK, _V4_BM), Index(_V4_BK, 64)
+]:
+    var a_desc = create_tma_descriptor[_V4_BF16, 2, _V4_SWIZZLE](
+        DeviceBuffer(
+            ctx,
+            a.address_space_cast[AddressSpace.GENERIC](),
+            1,
+            owning=False,
+        ),
+        IndexList[2](k, m),
+        IndexList[2](m, 1),
+        IndexList[2](_V4_BK, 64),
+    )
+    return TMATensorTile[_V4_BF16, 2, Index(_V4_BK, _V4_BM), Index(_V4_BK, 64)](
+        a_desc
+    )
+
+
+def _v4_enqueue_splitk_m128n256(
+    output: _V4_PTR,
+    a: _V4_PTR,
+    b: _V4_PTR,
+    m: Int,
+    n: Int,
+    k: Int,
+    grid_x: Int,
+    splits: Int,
+    ctx: DeviceContext,
+) raises:
+    var a_tma = _v4_make_a_tma(a, m, k, ctx)
+    var b_desc = create_tma_descriptor[_V4_BF16, 2, _V4_SWIZZLE](
+        DeviceBuffer(
+            ctx,
+            b.address_space_cast[AddressSpace.GENERIC](),
+            1,
+            owning=False,
+        ),
+        IndexList[2](k, n),
+        IndexList[2](n, 1),
+        IndexList[2](_V4_BK, 64),
+    )
+    var b_tma = TMATensorTile[
+        _V4_BF16, 2, Index(_V4_BK, 256), Index(_V4_BK, 64)
+    ](b_desc)
+    var total_tiles = k // _V4_BK
+    var chunk_tiles = (total_tiles + splits - 1) // splits
+    var count = m * n
+    var ws = ctx.enqueue_create_buffer[DType.float32](splits * count)
+    var ws_ptr = ws.unsafe_ptr().as_unsafe_any_origin()
+    ctx.enqueue_function[_v4_tn_splitk_m128n256_s4](
+        a_tma,
+        b_tma,
+        ws_ptr,
+        m,
+        n,
+        k,
+        chunk_tiles,
+        grid_dim=(grid_x, splits),
+        block_dim=(_V4_THREADS,),
+    )
+    ctx.enqueue_function[_v4_tn_splitk_reduce](
+        output,
+        ws_ptr,
+        count,
+        splits,
+        grid_dim=((count + _V4_RED_SPAN - 1) // _V4_RED_SPAN,),
+        block_dim=(_V4_RED_THREADS,),
+    )
+    # Normal release after both stream-ordered consumers are enqueued.
+    _ = ws^
+
+
+def _v4_enqueue_direct_m128n192(
+    output: _V4_PTR,
+    a: _V4_PTR,
+    b: _V4_PTR,
+    m: Int,
+    n: Int,
+    k: Int,
+    grid_x: Int,
+    multi_wave: Bool,
+    ctx: DeviceContext,
+) raises:
+    var a_tma = _v4_make_a_tma(a, m, k, ctx)
+    var b_desc = create_tma_descriptor[_V4_BF16, 2, _V4_SWIZZLE](
+        DeviceBuffer(
+            ctx,
+            b.address_space_cast[AddressSpace.GENERIC](),
+            1,
+            owning=False,
+        ),
+        IndexList[2](k, n),
+        IndexList[2](n, 1),
+        IndexList[2](_V4_BK, 64),
+    )
+    var b_tma = TMATensorTile[
+        _V4_BF16, 2, Index(_V4_BK, 192), Index(_V4_BK, 64)
+    ](b_desc)
+    if multi_wave:
+        ctx.enqueue_function[_v4_tn_direct_m128n192_s3g16](
+            a_tma,
+            b_tma,
+            output,
+            m,
+            n,
+            k,
+            grid_dim=(grid_x,),
+            block_dim=(_V4_THREADS,),
+        )
+    else:
+        ctx.enqueue_function[_v4_tn_direct_m128n192_s4](
+            a_tma,
+            b_tma,
+            output,
+            m,
+            n,
+            k,
+            grid_dim=(grid_x,),
+            block_dim=(_V4_THREADS,),
+        )
+
+
+# ============================================================================
+# Regime dispatch.  Returns True when a v4 kernel handled the call.
+# Caller guarantees: TN (transpose_a and not transpose_b), no bias.
+# ============================================================================
+def try_enqueue_bf16_gemm_tn_v4(
+    output: _V4_PTR,
+    a: _V4_PTR,
+    b: _V4_PTR,
+    m: Int,
+    n: Int,
+    k: Int,
+    ctx: DeviceContext,
+) raises -> Bool:
+    comptime if not _has_sm_9x():
+        return False
+    if ctx.api() != "cuda":
+        return False
+    var cc_major = ctx.get_attribute(DeviceAttribute.COMPUTE_CAPABILITY_MAJOR)
+    var cc_minor = ctx.get_attribute(DeviceAttribute.COMPUTE_CAPABILITY_MINOR)
+    if cc_major != 9 or cc_minor != 0:
+        return False
+    # Aligned full-tile regime with machine-width-safe products (mirrors the
+    # v3 gates).
+    if (
+        m < _V4_BM
+        or k < _V4_BK
+        or m % _V4_BM != 0
+        or k % _V4_BK != 0
+        or n <= 0
+        or Int(output) % 16 != 0
+        or Int(a) % 16 != 0
+        or Int(b) % 16 != 0
+        or m > 2_147_483_647
+        or n > 2_147_483_647
+        or k > 2_147_483_647
+        or k > 9_223_372_036_854_775_807 // m
+        or k > 9_223_372_036_854_775_807 // n
+        or n > 9_223_372_036_854_775_807 // m
+    ):
+        return False
+    var sm_count = ctx.get_attribute(DeviceAttribute.MULTIPROCESSOR_COUNT)
+    var max_grid_x = ctx.get_attribute(DeviceAttribute.MAX_GRID_DIM_X)
+    if sm_count <= 0 or max_grid_x <= 0:
+        return False
+
+    # Split-K on 256-wide tiles: only when at least two K-chunks per tile
+    # fit within the SM count, each chunk deep enough to amortize pipeline
+    # ramp-up, and the fp32 workspace stays modest.
+    if n % 256 == 0:
+        var tiles = (m // _V4_BM) * (n // 256)
+        if tiles > 0 and tiles <= max_grid_x and 2 * tiles <= sm_count:
+            var splits = sm_count // tiles
+            if splits > _V4_MAX_SPLITS:
+                splits = _V4_MAX_SPLITS
+            var max_by_depth = (k // _V4_BK) // _V4_MIN_CHUNK_TILES
+            if splits > max_by_depth:
+                splits = max_by_depth
+            if m * n <= _V4_MAX_WS_BYTES // 4 // max(splits, 1):
+                if splits >= 2:
+                    _v4_enqueue_splitk_m128n256(
+                        output, a, b, m, n, k, tiles, splits, ctx
+                    )
+                    return True
+
+    # Narrow-tile regime: 192-wide tiles trade 33% more CTAs for fuller
+    # waves.  Per-CTA time is proportional to BN at fixed BM/BK, so compare
+    # wave-quantized cost (waves x BN) and pick 192 when it wins; e.g. 72
+    # CTAs on 114 SMs (one third-idle wave) and 1179 CTAs (10.3 waves with
+    # an idle tail wave) both improve.
+    if n % 192 == 0:
+        var tiles192 = (m // _V4_BM) * (n // 192)
+        if tiles192 > 0 and tiles192 <= max_grid_x:
+            if n % 256 == 0:
+                var tiles256 = (m // _V4_BM) * (n // 256)
+                var waves256 = (tiles256 + sm_count - 1) // sm_count
+                var waves192 = (tiles192 + sm_count - 1) // sm_count
+                if waves192 * 192 < waves256 * 256:
+                    _v4_enqueue_direct_m128n192(
+                        output, a, b, m, n, k, tiles192, waves192 > 1, ctx
+                    )
+                    return True
+            elif tiles192 <= sm_count:
+                # No 256-wide alternative; take the single-wave win only.
+                _v4_enqueue_direct_m128n192(
+                    output, a, b, m, n, k, tiles192, False, ctx
+                )
+                return True
+
+    return False

--- a/torch_mojo_backend/eager_kernels/bf16_gemm_v3_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/bf16_gemm_v3_kernels.mojo
@@ -45,6 +45,7 @@ from bf16_gemm_kernels import (
     enqueue_bf16_bmm as _enqueue_accepted_bf16_bmm,
     enqueue_bf16_gemm as _enqueue_accepted_bf16_gemm,
 )
+from bf16_gemm_nt_v4_kernels import maybe_enqueue_bf16_gemm_nt_v4
 
 
 comptime _V3_BF16 = DType.bfloat16
@@ -1622,6 +1623,14 @@ def enqueue_bf16_gemm(
     has_bias: Bool,
     ctx: DeviceContext,
 ) raises:
+    # NT (forward linear) route: persistent clustered v4 kernel with TMA
+    # multicast and TMA-store epilogue (bf16_gemm_nt_v4_kernels.mojo).  The
+    # helper enqueues only for regimes it fully supports (SM90, aligned
+    # n/k, TMA-compatible sizes) and returns False otherwise, in which case
+    # the pre-existing NT path below remains the fallback.
+    if not transpose_a and transpose_b and not has_bias:
+        if maybe_enqueue_bf16_gemm_nt_v4(output, a, b, m, n, k, ctx):
+            return
     comptime if _has_sm_9x():
         if ctx.api() == "cuda":
             var cc_major = ctx.get_attribute(

--- a/torch_mojo_backend/eager_kernels/bf16_gemm_v3_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/bf16_gemm_v3_kernels.mojo
@@ -45,6 +45,7 @@ from bf16_gemm_kernels import (
     enqueue_bf16_bmm as _enqueue_accepted_bf16_bmm,
     enqueue_bf16_gemm as _enqueue_accepted_bf16_gemm,
 )
+from bf16_gemm_nn_v4_kernels import maybe_enqueue_bf16_gemm_nn_v4
 
 
 comptime _V3_BF16 = DType.bfloat16
@@ -1631,6 +1632,26 @@ def enqueue_bf16_gemm(
                 DeviceAttribute.COMPUTE_CAPABILITY_MINOR
             )
             if cc_major == 9 and cc_minor == 0:
+                # NN dgrad route (v4): persistent warp-specialized kernel
+                # with 2-CTA-cluster B multicast and a TMA-store epilogue
+                # (bf16_gemm_nn_v4_kernels.mojo).  It gates itself on the
+                # same tall-m aligned NN regime (m // n >= 8, n % 256 == 0,
+                # k % 64 == 0; m may be ragged) and returns False for
+                # anything else, in which case the pre-existing NN paths
+                # below remain the fallback.
+                if maybe_enqueue_bf16_gemm_nn_v4(
+                    output,
+                    a,
+                    b,
+                    m,
+                    n,
+                    k,
+                    transpose_a,
+                    transpose_b,
+                    has_bias,
+                    ctx,
+                ):
+                    return
                 # A 64x128 tile preserves the prior aligned-NN coverage and
                 # increases available CTAs when the 128x256 grid would be
                 # severely underfilled on the current GPU.  This predicate is

--- a/torch_mojo_backend/eager_kernels/bf16_gemm_v3_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/bf16_gemm_v3_kernels.mojo
@@ -45,6 +45,7 @@ from bf16_gemm_kernels import (
     enqueue_bf16_bmm as _enqueue_accepted_bf16_bmm,
     enqueue_bf16_gemm as _enqueue_accepted_bf16_gemm,
 )
+from bf16_gemm_tn_v4_kernels import try_enqueue_bf16_gemm_tn_v4
 
 
 comptime _V3_BF16 = DType.bfloat16
@@ -1631,6 +1632,15 @@ def enqueue_bf16_gemm(
                 DeviceAttribute.COMPUTE_CAPABILITY_MINOR
             )
             if cc_major == 9 and cc_minor == 0:
+                # V4 TN (wgrad) route: split-K and narrow-tile kernels for
+                # the deep-K, underfilled-output regime (huge K, small m*n;
+                # see bf16_gemm_tn_v4_kernels.mojo).  The dispatcher checks
+                # its own alignment/regime gates and returns False whenever
+                # it declines, so every existing TN path below remains the
+                # fallback.
+                if transpose_a and not transpose_b and not has_bias:
+                    if try_enqueue_bf16_gemm_tn_v4(output, a, b, m, n, k, ctx):
+                        return
                 # A 64x128 tile preserves the prior aligned-NN coverage and
                 # increases available CTAs when the 128x256 grid would be
                 # severely underfilled on the current GPU.  This predicate is

--- a/torch_mojo_backend/eager_kernels/logic_ops.mojo
+++ b/torch_mojo_backend/eager_kernels/logic_ops.mojo
@@ -28,7 +28,7 @@ from std.math import ceildiv, pow
 from std.python import PythonObject
 from std.python._cpython import PyObjectPtr, Py_ssize_t
 from std.python.bindings import PythonModuleBuilder
-from std.sys.info import has_accelerator, has_apple_gpu_accelerator
+from std.sys.info import has_accelerator, has_apple_gpu_accelerator, size_of
 from std.utils.coord import Coord
 
 from std.algorithm.functional import elementwise
@@ -227,6 +227,126 @@ def _bin_bcast_kernel[
 
 
 @always_inline
+def _bin_vec_op[
+    dtype: DType, op_code: Int, width: Int
+](a: SIMD[dtype, width], b: SIMD[dtype, width]) -> SIMD[dtype, width]:
+    """SIMD counterpart of `_bin_bcast_body` (non-comparison ops only).
+
+    Runtime-unreachable (dtype, op) combos are pre-gated by the launcher;
+    they still instantiate, so every branch must compile — hence the
+    trailing pass-through return."""
+    comptime if op_code == BOP_ADD:
+        return a + b
+    comptime if op_code == BOP_SUB:
+        return a - b
+    comptime if op_code == BOP_MUL:
+        return a * b
+    comptime if op_code == BOP_DIV:
+        comptime if dtype.is_floating_point():
+            return a / b
+    comptime if op_code == BOP_MAX:
+        return max(a, b)
+    comptime if op_code == BOP_MIN:
+        return min(a, b)
+    comptime if op_code == BOP_AND:
+        comptime if not dtype.is_floating_point():
+            return a & b
+    comptime if op_code == BOP_OR:
+        comptime if not dtype.is_floating_point():
+            return a | b
+    comptime if op_code == BOP_XOR:
+        comptime if not dtype.is_floating_point():
+            return a ^ b
+    comptime if op_code == BOP_REMAINDER:
+        return a % b
+    comptime if op_code == BOP_FLOORDIV:
+        return a // b
+    comptime if op_code == BOP_POW:
+        comptime if dtype == DType.float16 or dtype == DType.bfloat16:
+            return pow(
+                a.cast[DType.float32](), b.cast[DType.float32]()
+            ).cast[dtype]()
+        elif dtype.is_floating_point():
+            return pow(a, b)
+    return a
+
+
+def _bin_flat_vec_kernel[
+    dtype: DType, op_code: Int
+](
+    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    l_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    r_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    total: Int,
+):
+    """16-byte-vectorized binary op for the no-broadcast, all-contiguous
+    case (both operands and the output flat over the same extent). The
+    launcher guarantees 16B base alignment."""
+    comptime VW = 16 // size_of[dtype]()
+    comptime vec_align = VW * size_of[dtype]()
+    var tid = Int(block_idx.x) * Int(block_dim.x) + Int(thread_idx.x)
+    var gstride = Int(grid_dim.x) * Int(block_dim.x)
+    var nvec = total // VW
+    var c = tid
+    while c < nvec:
+        var i = c * VW
+        var a = l_ptr.load[width=VW, alignment=vec_align](i)
+        var b = r_ptr.load[width=VW, alignment=vec_align](i)
+        out_ptr.store[width=VW, alignment=vec_align](
+            i, _bin_vec_op[dtype, op_code, VW](a, b)
+        )
+        c += gstride
+    var tail = total - nvec * VW
+    if tid < tail:
+        var i = nvec * VW + tid
+        out_ptr[i] = _bin_vec_op[dtype, op_code, 1](l_ptr[i], r_ptr[i])[0]
+
+
+def _bin_rowvec_kernel[
+    dtype: DType, op_code: Int
+](
+    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    l_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    r_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    d1: Int,
+    d2: Int,
+    d3: Int,
+    ls0: Int,
+    ls1: Int,
+    ls2: Int,
+    rs0: Int,
+    rs1: Int,
+    rs2: Int,
+    rows: Int,
+):
+    """Vectorized along a stride-1 innermost dim; outer dims may be strided
+    or broadcast (stride 0). One block per row (grid-stride over rows); the
+    per-row index math runs once per row instead of once per element. The
+    launcher guarantees d3 % VW == 0 and 16B alignment of every row base."""
+    comptime VW = 16 // size_of[dtype]()
+    comptime vec_align = VW * size_of[dtype]()
+    var row = Int(block_idx.x)
+    while row < rows:
+        var i2 = row % d2
+        var rest = row // d2
+        var i1 = rest % d1
+        var i0 = rest // d1
+        var lbase = i0 * ls0 + i1 * ls1 + i2 * ls2
+        var rbase = i0 * rs0 + i1 * rs1 + i2 * rs2
+        var obase = row * d3
+        var j = Int(thread_idx.x) * VW
+        var step = Int(block_dim.x) * VW
+        while j < d3:
+            var a = l_ptr.load[width=VW, alignment=vec_align](lbase + j)
+            var b = r_ptr.load[width=VW, alignment=vec_align](rbase + j)
+            out_ptr.store[width=VW, alignment=vec_align](
+                obase + j, _bin_vec_op[dtype, op_code, VW](a, b)
+            )
+            j += step
+        row += Int(grid_dim.x)
+
+
+@always_inline
 def _bin_bcast[
     dtype: DType, op_code: Int
 ](
@@ -288,29 +408,110 @@ def _bin_bcast[
                     raise Error("float64 is not supported on Apple GPU")
                 else:
                     comptime if has_accelerator():
-                        _enqueue_cached[_bin_bcast_kernel[dtype, op_code]](
-                            ctx,
-                            String(t"lg_bcast_{op_code}_{dtype}"),
-                            _gs_blocks(total),
-                            1,
-                            1,
-                            GS_THREADS,
-                            out_ptr.as_unsafe_any_origin(),
-                            l_ptr.as_unsafe_any_origin().as_immutable(),
-                            r_ptr.as_unsafe_any_origin().as_immutable(),
-                            d1,
-                            d2,
-                            d3,
-                            ls0,
-                            ls1,
-                            ls2,
-                            ls3,
-                            rs0,
-                            rs1,
-                            rs2,
-                            rs3,
-                            total,
+                        # Tiered dispatch: the generic scalar kernel pays
+                        # three integer divisions and strided scalar loads
+                        # per element, which is division-bound at large
+                        # sizes. Prefer 16-byte vector kernels whenever the
+                        # layout allows them.
+                        comptime itemsize = size_of[dtype]()
+                        comptime VW = 16 // itemsize
+                        var d0 = total // max(1, d1 * d2 * d3)
+                        var cont3 = d3
+                        var cont2 = d2 * d3
+                        var cont1 = d1 * d2 * d3
+                        var aligned16 = (
+                            out_addr % 16 == 0
+                            and l_addr % 16 == 0
+                            and r_addr % 16 == 0
                         )
+                        var l_flat = (
+                            (ls3 == 1 or d3 == 1)
+                            and (ls2 == cont3 or d2 == 1)
+                            and (ls1 == cont2 or d1 == 1)
+                            and (ls0 == cont1 or d0 == 1)
+                        )
+                        var r_flat = (
+                            (rs3 == 1 or d3 == 1)
+                            and (rs2 == cont3 or d2 == 1)
+                            and (rs1 == cont2 or d1 == 1)
+                            and (rs0 == cont1 or d0 == 1)
+                        )
+                        var rows_aligned = (
+                            ls3 == 1
+                            and rs3 == 1
+                            and d3 % VW == 0
+                            and d3 >= VW
+                            and (ls0 * itemsize) % 16 == 0
+                            and (ls1 * itemsize) % 16 == 0
+                            and (ls2 * itemsize) % 16 == 0
+                            and (rs0 * itemsize) % 16 == 0
+                            and (rs1 * itemsize) % 16 == 0
+                            and (rs2 * itemsize) % 16 == 0
+                        )
+                        if aligned16 and l_flat and r_flat:
+                            _enqueue_cached[
+                                _bin_flat_vec_kernel[dtype, op_code]
+                            ](
+                                ctx,
+                                String(t"lg_bcast_fv_{op_code}_{dtype}"),
+                                _gs_blocks(max(1, total // VW)),
+                                1,
+                                1,
+                                GS_THREADS,
+                                out_ptr.as_unsafe_any_origin(),
+                                l_ptr.as_unsafe_any_origin().as_immutable(),
+                                r_ptr.as_unsafe_any_origin().as_immutable(),
+                                total,
+                            )
+                        elif aligned16 and rows_aligned:
+                            var rows = total // d3
+                            _enqueue_cached[
+                                _bin_rowvec_kernel[dtype, op_code]
+                            ](
+                                ctx,
+                                String(t"lg_bcast_rv_{op_code}_{dtype}"),
+                                max(1, min(rows, 65535)),
+                                1,
+                                1,
+                                GS_THREADS,
+                                out_ptr.as_unsafe_any_origin(),
+                                l_ptr.as_unsafe_any_origin().as_immutable(),
+                                r_ptr.as_unsafe_any_origin().as_immutable(),
+                                d1,
+                                d2,
+                                d3,
+                                ls0,
+                                ls1,
+                                ls2,
+                                rs0,
+                                rs1,
+                                rs2,
+                                rows,
+                            )
+                        else:
+                            _enqueue_cached[_bin_bcast_kernel[dtype, op_code]](
+                                ctx,
+                                String(t"lg_bcast_{op_code}_{dtype}"),
+                                _gs_blocks(total),
+                                1,
+                                1,
+                                GS_THREADS,
+                                out_ptr.as_unsafe_any_origin(),
+                                l_ptr.as_unsafe_any_origin().as_immutable(),
+                                r_ptr.as_unsafe_any_origin().as_immutable(),
+                                d1,
+                                d2,
+                                d3,
+                                ls0,
+                                ls1,
+                                ls2,
+                                ls3,
+                                rs0,
+                                rs1,
+                                rs2,
+                                rs3,
+                                total,
+                            )
                     else:
                         raise Error(
                             "no GPU accelerator available at compile time"

--- a/torch_mojo_backend/eager_kernels/reduction_ops.mojo
+++ b/torch_mojo_backend/eager_kernels/reduction_ops.mojo
@@ -26,15 +26,18 @@ from std.gpu import (
     MAX_THREADS_PER_BLOCK_METADATA,
     barrier,
     block_idx,
+    grid_dim,
     thread_idx,
 )
 from std.gpu.host import DeviceContext
 from std.gpu.primitives import block
 from std.math import exp, log
 from std.memory import stack_allocation
+from std.memory.unsafe import bitcast
 from std.python import PythonObject
 from std.python.bindings import PythonModuleBuilder
-from std.sys.info import has_accelerator
+from std.sys._assembly import inlined_assembly
+from std.sys.info import has_accelerator, is_nvidia_gpu, size_of
 from std.utils.coord import Coord
 from std.utils.index import IndexList
 from std.utils.numerics import min_or_neg_inf, max_or_inf
@@ -735,66 +738,131 @@ def _var_rows[
 # ---------------------------------------------------------------------------
 
 
+# Keep the concurrent input footprint under L2 (H100: 50 MB) with headroom, so
+# a row survives from its pass-1 read to its pass-2 re-read.
+comptime LSM_L2_BUDGET = 23_000_000
+# Rows whose bytes exceed this need the grid capped below full 256-thread
+# occupancy to fit L2; recover the lost parallelism with 1024-thread blocks.
+# Below it, 256-thread blocks keep every thread busy and reductions cheap.
+comptime LSM_BIG_ROW_BYTES = 25_000
+
+
+@always_inline
+def _lsm_store_out_16B[
+    dtype: DType, width: Int, //, vec_align: Int
+](ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin], val: SIMD[dtype, width]):
+    """128-bit output store. On NVIDIA use a streaming (evict-first)
+    `st.global.cs` store so the writes do not evict the input rows we re-read in
+    pass 2; elsewhere fall back to a normal vectorized store."""
+    comptime if is_nvidia_gpu():
+        var u = bitcast[DType.uint32, 4](val)
+        inlined_assembly[
+            "st.global.cs.v4.b32 [$0], {$1, $2, $3, $4};",
+            NoneType,
+            constraints="l,r,r,r,r",
+            has_side_effect=True,
+        ](ptr, u[0], u[1], u[2], u[3])
+    else:
+        ptr.store[width=width, alignment=vec_align](val)
+
+
+# Fused online (single-read) log-softmax. The reduction reads each row ONCE
+# (vectorized 16-byte loads; per-lane running max m + running sum s rescaled on
+# a new max), then the output pass re-reads that row — kept resident in L2 by
+# the grid cap in `_log_softmax_rows` — and writes with a streaming store.
+# Odd cols: a per-row scalar head reaches a 16-byte-aligned element index, plus
+# a scalar tail. Correct for any rows/cols >= 1, bf16/f16/f32.
 @__llvm_metadata(
-    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(ROWRED_THREADS))
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(threads))
 )
-@__name(t"log_softmax_rows_block_{dtype}")
+@__name(t"log_softmax_rows_block_{dtype}_{threads}")
 def _log_softmax_rows_block_kernel[
-    dtype: DType
+    dtype: DType, threads: Int
 ](
     out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
     in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
     cols: Int,
+    rows: Int,
 ):
-    var r = block_idx.x
-    var tid = thread_idx.x
-    var base = r * cols
+    comptime V = 16 // size_of[dtype]()
+    comptime vec_align = V * size_of[dtype]()  # 16 bytes
+    var tid = Int(thread_idx.x)
 
-    var red = stack_allocation[
-        ROWRED_THREADS, DType.float32, address_space=AddressSpace.SHARED
-    ]()
-    var bcast = stack_allocation[
-        2, DType.float32, address_space=AddressSpace.SHARED
-    ]()
+    var row = Int(block_idx.x)
+    while row < rows:
+        var base = row * cols
 
-    var m = Float32.MIN
-    for j in range(tid, cols, ROWRED_THREADS):
-        var x = in_ptr[base + j].cast[DType.float32]()
-        if x > m:
-            m = x
-    red[tid] = m
-    barrier()
-    var stride = ROWRED_THREADS // 2
-    for _ in range(ROWRED_STAGES):
-        if tid < stride:
-            if red[tid + stride] > red[tid]:
-                red[tid] = red[tid + stride]
-        barrier()
-        stride //= 2
-    if tid == 0:
-        bcast[0] = red[0]
-    barrier()
-    m = bcast[0]
+        var head = (V - (base % V)) % V
+        if head > cols:
+            head = cols
+        var n_vec = (cols - head) // V
+        var vec_start = base + head  # element index, V-aligned
+        var tail_start = head + n_vec * V  # first row-local index of the tail
 
-    var s = Float32(0)
-    for j in range(tid, cols, ROWRED_THREADS):
-        s += exp(in_ptr[base + j].cast[DType.float32]() - m)
-    red[tid] = s
-    barrier()
-    stride = ROWRED_THREADS // 2
-    for _ in range(ROWRED_STAGES):
-        if tid < stride:
-            red[tid] += red[tid + stride]
-        barrier()
-        stride //= 2
-    if tid == 0:
-        bcast[1] = log(red[0])
-    barrier()
-    var log_denom = bcast[1]
+        # ---- Pass 1: online max + sum over the row, one global read. ----
+        var m_vec = SIMD[DType.float32, V](Float32.MIN)
+        var s_vec = SIMD[DType.float32, V](0.0)
+        var v = tid
+        while v < n_vec:
+            var x = in_ptr.load[width=V, alignment=vec_align](
+                vec_start + v * V
+            ).cast[DType.float32]()
+            var new_m = max(m_vec, x)
+            s_vec = s_vec * exp(m_vec - new_m) + exp(x - new_m)
+            m_vec = new_m
+            v += threads
 
-    for j in range(tid, cols, ROWRED_THREADS):
-        var x = in_ptr[base + j].cast[DType.float32]()
-        out_ptr[base + j] = (x - m - log_denom).cast[dtype]()
+        # Collapse the per-lane accumulator to a thread-local (m, s).
+        var m_t = m_vec.reduce_max()
+        var s_t = (s_vec * exp(m_vec - m_t)).reduce_add()
+
+        # Fold in the unaligned scalar head/tail (each < V elements, one thread
+        # per element; no-ops when head == tail == 0).
+        var jh = tid
+        while jh < head:
+            var x = in_ptr[base + jh].cast[DType.float32]()
+            var nm = max(m_t, x)
+            s_t = s_t * exp(m_t - nm) + exp(x - nm)
+            m_t = nm
+            jh += threads
+        var jt = tail_start + tid
+        while jt < cols:
+            var x = in_ptr[base + jt].cast[DType.float32]()
+            var nm = max(m_t, x)
+            s_t = s_t * exp(m_t - nm) + exp(x - nm)
+            m_t = nm
+            jt += threads
+
+        # ---- Block combine: global max, then rescale + global sum. ----
+        var block_m = block.max[block_size=threads](m_t)
+        var s_scaled = s_t * exp(m_t - block_m)
+        var block_s = block.sum[block_size=threads](s_scaled)
+        var log_denom = log(block_s)
+
+        # ---- Pass 2: output = x - max - log_denom. Input read hits L2; the
+        # streaming store keeps the writes from evicting it. ----
+        var vo = tid
+        while vo < n_vec:
+            var x = in_ptr.load[width=V, alignment=vec_align](
+                vec_start + vo * V
+            ).cast[DType.float32]()
+            var y = (x - block_m - log_denom).cast[dtype]()
+            _lsm_store_out_16B[vec_align=vec_align](
+                out_ptr + (vec_start + vo * V), y
+            )
+            vo += threads
+        var jho = tid
+        while jho < head:
+            var x = in_ptr[base + jho].cast[DType.float32]()
+            out_ptr[base + jho] = (x - block_m - log_denom).cast[dtype]()
+            jho += threads
+        var jto = tail_start + tid
+        while jto < cols:
+            var x = in_ptr[base + jto].cast[DType.float32]()
+            out_ptr[base + jto] = (x - block_m - log_denom).cast[dtype]()
+            jto += threads
+
+        row += Int(grid_dim.x)
 
 
 @always_inline
@@ -828,17 +896,40 @@ def _log_softmax_rows[
         _parallel_for[func](rows, ctx)
     else:
         comptime if has_accelerator():
-            _enqueue_cached[_log_softmax_rows_block_kernel[dtype]](
-                ctx,
-                String(t"log_softmax_rows_{dtype}"),
-                rows,
-                1,
-                1,
-                ROWRED_THREADS,
-                out_ptr.as_unsafe_any_origin(),
-                in_ptr.as_unsafe_any_origin().as_immutable(),
-                cols,
-            )
+            # Cap concurrent rows so their input bytes stay resident in L2 for
+            # the pass-2 re-read; grid-stride over the rest.
+            var esize = size_of[dtype]()
+            var blocks = min(rows, max(1, LSM_L2_BUDGET // (cols * esize)))
+            var mout = out_ptr.as_unsafe_any_origin()
+            var min_ = in_ptr.as_unsafe_any_origin().as_immutable()
+            # Big rows: 1024-thread blocks so the small (L2-capped) grid still
+            # saturates memory. Small rows: 256 threads keep every thread busy.
+            if cols * esize > LSM_BIG_ROW_BYTES:
+                _enqueue_cached[_log_softmax_rows_block_kernel[dtype, 1024]](
+                    ctx,
+                    String(t"log_softmax_rows_{dtype}_1024"),
+                    blocks,
+                    1,
+                    1,
+                    1024,
+                    mout,
+                    min_,
+                    cols,
+                    rows,
+                )
+            else:
+                _enqueue_cached[_log_softmax_rows_block_kernel[dtype, 256]](
+                    ctx,
+                    String(t"log_softmax_rows_{dtype}_256"),
+                    blocks,
+                    1,
+                    1,
+                    256,
+                    mout,
+                    min_,
+                    cols,
+                    rows,
+                )
         else:
             raise Error("no GPU accelerator available at compile time")
 

--- a/torch_mojo_backend/eager_kernels/softmax_backward_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/softmax_backward_kernels.mojo
@@ -1,0 +1,374 @@
+# ===----------------------------------------------------------------------=== #
+# Fused eager-mode log_softmax backward kernels for mojo_device
+# (float32/float16/bfloat16 GPU), validated in
+# kernel_bench/bench_log_softmax_bwd.mojo on H100.
+#
+#   grad_input = grad_output - exp(output) * rowsum(grad_output)
+#
+# over the trailing dim, with fp32 accumulation. `output` holds log-probs
+# (<= 0), so exp(output) is in [0, 1] and never overflows in any dtype.
+#
+# The op is memory-bound; the 3-stream minimum DRAM traffic is read grad +
+# read output + write grad_input. The primary kernel stages the grad row in
+# dynamic shared memory during the rowsum pass so the emit pass never
+# re-reads grad from DRAM, and reaches ~95% of HBM roofline at the nanogpt
+# cross-entropy shape (32768x50304 bf16: 5.2 ms vs torch-CUDA's fused
+# kernel at 6.9 ms on the same box). One thread block processes one row:
+# 16-byte vectorized loads/stores over the aligned row body (base pointers
+# are 16B-aligned, enforced by the host; odd-cols rows get a scalar
+# head/tail), a warp-shuffle block.sum for the fp32 rowsum, and a
+# measured-on-H100 block-size heuristic (long rows want 1024 threads —
+# full occupancy at 2 blocks/SM with ~100 KB smem each; short rows want
+# smaller blocks; tiny grids want the fattest block available since
+# blocks, not threads, are the scarce resource).
+#
+# Rows too long for the device's opt-in shared-memory capacity (or devices
+# where the opt-in attribute is unavailable) fall back to a no-staging
+# variant of the same kernel that re-reads grad through L2/DRAM.
+#
+# Shapes are fully dynamic: any rows/cols >= 1, any of the three dtypes.
+# ===----------------------------------------------------------------------=== #
+
+from std.builtin.device_passable import DevicePassable
+from std.ffi import _get_global_or_null, external_call
+from std.gpu import (
+    MAX_THREADS_PER_BLOCK_METADATA,
+    block_idx,
+    grid_dim,
+    thread_idx,
+)
+from std.gpu.host import DeviceAttribute, DeviceContext, FuncAttribute
+from std.gpu.memory import AddressSpace, external_memory
+from std.gpu.primitives import block
+from std.math import exp
+from std.memory import alloc
+from std.sys.info import has_accelerator, size_of
+from std.utils.static_tuple import StaticTuple
+
+from op_utils import _enqueue_cached
+
+# NVIDIA's default dynamic shared-memory limit; anything above needs the
+# MAX_DYNAMIC_SHARED_SIZE_BYTES opt-in function attribute.
+comptime _DEFAULT_DYN_SMEM = 48 * 1024
+
+comptime _NOSMEM_THREADS = 256
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(threads))
+)
+@__name(t"lsm_bwd_smem_{dtype}_{threads}")
+def _log_softmax_bwd_smem_kernel[
+    dtype: DType, threads: Int
+](
+    gi: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    g: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    o: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    rows: Int,
+    cols: Int,
+):
+    # One row per block. Phase 1 stages the vectorized body of the grad row
+    # into dynamic shared memory while accumulating the fp32 rowsum, so
+    # phase 2 never re-reads grad from DRAM: total traffic is the 3-stream
+    # minimum. Each thread re-reads exactly the shared words it wrote (the
+    # same v-loop), so the staging itself needs no barrier. The (at most
+    # VEC-1) head/tail scalars of unaligned rows re-read global memory and
+    # hit L1/L2.
+    comptime VEC = 16 // size_of[dtype]()
+    var smem_g = external_memory[
+        Scalar[dtype], address_space=AddressSpace.SHARED, alignment=16
+    ]()
+    var tid = Int(thread_idx.x)
+    var row = Int(block_idx.x)
+    var base = row * cols
+    var head = (VEC - (base % VEC)) % VEC
+    if head > cols:
+        head = cols
+    var nvec = (cols - head) // VEC
+    var tail_start = head + nvec * VEC
+
+    var vsum = SIMD[DType.float32, VEC](0)
+    var ssum = Float32(0)
+    if tid < head:
+        ssum += g[base + tid].cast[DType.float32]()
+    var v = tid
+    while v < nvec:
+        var gv = g.load[width=VEC, alignment=16](base + head + v * VEC)
+        smem_g.store[width=VEC, alignment=16](v * VEC, gv)
+        vsum += gv.cast[DType.float32]()
+        v += threads
+    var j = tail_start + tid
+    while j < cols:
+        ssum += g[base + j].cast[DType.float32]()
+        j += threads
+    var srow = block.sum[block_size=threads, broadcast=True](
+        vsum.reduce_add() + ssum
+    )
+
+    if tid < head:
+        var idx = base + tid
+        gi[idx] = (
+            g[idx].cast[DType.float32]()
+            - exp(o[idx].cast[DType.float32]()) * srow
+        ).cast[dtype]()
+    v = tid
+    while v < nvec:
+        var idx = base + head + v * VEC
+        var gv = smem_g.load[width=VEC, alignment=16](v * VEC).cast[
+            DType.float32
+        ]()
+        var ov = o.load[width=VEC, alignment=16](idx).cast[DType.float32]()
+        gi.store[width=VEC, alignment=16](
+            idx, (gv - exp(ov) * srow).cast[dtype]()
+        )
+        v += threads
+    j = tail_start + tid
+    while j < cols:
+        var idx = base + j
+        gi[idx] = (
+            g[idx].cast[DType.float32]()
+            - exp(o[idx].cast[DType.float32]()) * srow
+        ).cast[dtype]()
+        j += threads
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(_NOSMEM_THREADS))
+)
+@__name(t"lsm_bwd_nosmem_{dtype}")
+def _log_softmax_bwd_nosmem_kernel[
+    dtype: DType
+](
+    gi: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    g: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    o: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    rows: Int,
+    cols: Int,
+):
+    # Fallback for rows whose vector body exceeds the dynamic shared-memory
+    # capacity: same structure, but phase 2 re-reads grad through L2/DRAM.
+    comptime VEC = 16 // size_of[dtype]()
+    var tid = Int(thread_idx.x)
+    var row = Int(block_idx.x)
+    var base = row * cols
+    var head = (VEC - (base % VEC)) % VEC
+    if head > cols:
+        head = cols
+    var nvec = (cols - head) // VEC
+    var tail_start = head + nvec * VEC
+
+    var vsum = SIMD[DType.float32, VEC](0)
+    var ssum = Float32(0)
+    if tid < head:
+        ssum += g[base + tid].cast[DType.float32]()
+    var v = tid
+    while v < nvec:
+        var gv = g.load[width=VEC, alignment=16](base + head + v * VEC)
+        vsum += gv.cast[DType.float32]()
+        v += _NOSMEM_THREADS
+    var j = tail_start + tid
+    while j < cols:
+        ssum += g[base + j].cast[DType.float32]()
+        j += _NOSMEM_THREADS
+    var srow = block.sum[block_size=_NOSMEM_THREADS, broadcast=True](
+        vsum.reduce_add() + ssum
+    )
+
+    if tid < head:
+        var idx = base + tid
+        gi[idx] = (
+            g[idx].cast[DType.float32]()
+            - exp(o[idx].cast[DType.float32]()) * srow
+        ).cast[dtype]()
+    v = tid
+    while v < nvec:
+        var idx = base + head + v * VEC
+        var gv = g.load[width=VEC, alignment=16](idx).cast[DType.float32]()
+        var ov = o.load[width=VEC, alignment=16](idx).cast[DType.float32]()
+        gi.store[width=VEC, alignment=16](
+            idx, (gv - exp(ov) * srow).cast[dtype]()
+        )
+        v += _NOSMEM_THREADS
+    j = tail_start + tid
+    while j < cols:
+        var idx = base + j
+        gi[idx] = (
+            g[idx].cast[DType.float32]()
+            - exp(o[idx].cast[DType.float32]()) * srow
+        ).cast[dtype]()
+        j += _NOSMEM_THREADS
+
+
+@always_inline
+def _enqueue_cached_smem[
+    declared_arg_types: TypeList[Trait=AnyType, ...],
+    //,
+    func: def(* args: * declared_arg_types) thin -> None,
+    *Ts: DevicePassable,
+](
+    ctx: DeviceContext,
+    key: String,
+    grid: Int,
+    threads: Int,
+    smem_bytes: Int,
+    attr_bytes: Int,
+    *args: *Ts,
+) raises:
+    """`op_utils._enqueue_cached` with dynamic shared memory.
+
+    The MAX_DYNAMIC_SHARED_SIZE_BYTES function attribute is baked in when
+    the `DeviceFunction` is first compiled and cached, so the caller must
+    fold the attribute regime into `key` (kernels launched both above and
+    below the 48 KB opt-in boundary need distinct keys) and must pass the
+    same `attr_bytes` for every call with the same key.
+    """
+    var name = String(t"TMB_KERNEL_{key}_{ctx.id()}")
+    comptime FuncT = type_of(ctx.compile_function[func]())
+
+    if global_ptr := _get_global_or_null(name):
+        var fptr = global_ptr.value().bitcast[FuncT]()
+        ctx.enqueue_function(
+            fptr[],
+            *args,
+            grid_dim=(grid,),
+            block_dim=(threads,),
+            shared_mem_bytes=smem_bytes,
+        )
+        return
+
+    var compiled: FuncT
+    if attr_bytes > 0:
+        compiled = ctx.compile_function[func](
+            func_attribute=FuncAttribute.MAX_DYNAMIC_SHARED_SIZE_BYTES(
+                UInt32(attr_bytes)
+            )
+        )
+    else:
+        compiled = ctx.compile_function[func]()
+    var fptr = alloc[FuncT](1)
+    fptr.init_pointee_move(compiled^)
+    external_call["KGEN_CompilerRT_InsertGlobal", NoneType](
+        StringSlice(name),
+        fptr.bitcast[NoneType](),
+    )
+    ctx.enqueue_function(
+        fptr[],
+        *args,
+        grid_dim=(grid,),
+        block_dim=(threads,),
+        shared_mem_bytes=smem_bytes,
+    )
+
+
+@always_inline
+def _dyn_smem_capacity(ctx: DeviceContext) -> Int:
+    """Usable per-block dynamic shared memory on this device.
+
+    Above the 48 KB default this queries the NVIDIA opt-in limit (minus the
+    1 KB system reservation). Where the attribute is unavailable (e.g. AMD)
+    it conservatively reports the default, routing long rows to the
+    no-staging kernel.
+    """
+    var capacity = _DEFAULT_DYN_SMEM
+    try:
+        var opt_in = ctx.get_attribute(
+            DeviceAttribute.MAX_SHARED_MEMORY_PER_BLOCK_OPTIN
+        )
+        if opt_in - 1024 > capacity:
+            capacity = opt_in - 1024
+    except:
+        pass
+    return capacity
+
+
+def enqueue_log_softmax_backward[
+    dtype: DType
+](
+    gi: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    g: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    o: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    rows: Int,
+    cols: Int,
+    ctx: DeviceContext,
+) raises:
+    """Fire-and-forget trailing-dim log_softmax backward.
+
+    Contract (validated by the Python caller): contiguous row-major 2D
+    views [rows, cols] with rows, cols >= 1; all three base pointers
+    16-byte aligned; rows < 2**31 (one thread block per row).
+    """
+    comptime if not has_accelerator():
+        raise Error("no GPU accelerator available at compile time")
+    else:
+        comptime VEC = 16 // size_of[dtype]()
+        # Worst-case vector-body bytes over rows (head == 0 rows).
+        var smem_bytes = (cols // VEC) * 16
+        var use_smem = False
+        var attr_bytes = 0
+        if smem_bytes > 0 and smem_bytes <= _DEFAULT_DYN_SMEM:
+            use_smem = True
+        elif smem_bytes > _DEFAULT_DYN_SMEM:
+            var capacity = _dyn_smem_capacity(ctx)
+            if smem_bytes <= capacity:
+                use_smem = True
+                attr_bytes = capacity
+        if use_smem:
+            # Measured-on-H100 block-size heuristic; see file header.
+            var nvec_max = cols // VEC
+            var suffix = "l" if attr_bytes > 0 else "s"
+            if nvec_max >= 2048 or rows <= 228:
+                _enqueue_cached_smem[_log_softmax_bwd_smem_kernel[dtype, 1024]](
+                    ctx,
+                    String(t"lsm_bwd_smem_{dtype}_1024_{suffix}"),
+                    rows,
+                    1024,
+                    smem_bytes,
+                    attr_bytes,
+                    gi,
+                    g,
+                    o,
+                    rows,
+                    cols,
+                )
+            elif nvec_max >= 1024:
+                _enqueue_cached_smem[_log_softmax_bwd_smem_kernel[dtype, 512]](
+                    ctx,
+                    String(t"lsm_bwd_smem_{dtype}_512_{suffix}"),
+                    rows,
+                    512,
+                    smem_bytes,
+                    attr_bytes,
+                    gi,
+                    g,
+                    o,
+                    rows,
+                    cols,
+                )
+            else:
+                _enqueue_cached_smem[_log_softmax_bwd_smem_kernel[dtype, 256]](
+                    ctx,
+                    String(t"lsm_bwd_smem_{dtype}_256_{suffix}"),
+                    rows,
+                    256,
+                    smem_bytes,
+                    attr_bytes,
+                    gi,
+                    g,
+                    o,
+                    rows,
+                    cols,
+                )
+        else:
+            _enqueue_cached[_log_softmax_bwd_nosmem_kernel[dtype]](
+                ctx,
+                String(t"lsm_bwd_nosmem_{dtype}"),
+                rows,
+                1,
+                1,
+                _NOSMEM_THREADS,
+                gi,
+                g,
+                o,
+                rows,
+                cols,
+            )

--- a/torch_mojo_backend/eager_kernels/softmax_backward_ops.mojo
+++ b/torch_mojo_backend/eager_kernels/softmax_backward_ops.mojo
@@ -1,0 +1,111 @@
+# ===----------------------------------------------------------------------=== #
+# Thin eager-mode log_softmax-backward bridge for mojo_device
+# (float32/float16/bfloat16 GPU).
+#
+# The device-kernel implementation lives in softmax_backward_kernels.mojo.
+# Same architecture as loss_ops.mojo / embedding_backward_ops.mojo: the
+# Python-visible function gets raw integer pointers (tensor `._ptr`, offset
+# pre-applied) plus shape/dtype ints and the device's DeviceContext pointer,
+# and enqueues the fused kernel on the device queue (fire and forget, no
+# sync, no host reads, no host allocation).
+# ===----------------------------------------------------------------------=== #
+
+from std.os import abort
+from std.python import PythonObject
+from std.python.bindings import PythonModuleBuilder
+from std.python._cpython import PyObjectPtr, Py_ssize_t
+
+from softmax_backward_kernels import enqueue_log_softmax_backward
+from op_utils import (
+    _make_ptr,
+    _raw_ctx,
+    _raw_dtype_int,
+    _raw_int,
+    _raw_ret_none,
+    _spec_unsupported,
+)
+
+
+def _log_softmax_backward_go(
+    grad_input_ptr_obj: PyObjectPtr,
+    grad_output_ptr_obj: PyObjectPtr,
+    output_ptr_obj: PyObjectPtr,
+    rows_obj: PyObjectPtr,
+    cols_obj: PyObjectPtr,
+    dtype_obj: PyObjectPtr,
+    device_context_ptr: PyObjectPtr,
+) raises:
+    var dtype_val = _raw_dtype_int(dtype_obj)
+    var grad_input_addr = _raw_int(grad_input_ptr_obj)
+    var grad_output_addr = _raw_int(grad_output_ptr_obj)
+    var output_addr = _raw_int(output_ptr_obj)
+    var rows = _raw_int(rows_obj)
+    var cols = _raw_int(cols_obj)
+    var ctx = _raw_ctx(device_context_ptr)
+
+    var handled = False
+    comptime for dt in [DType.float32, DType.float16, DType.bfloat16]:
+        if dtype_val == dt:
+            enqueue_log_softmax_backward[dt](
+                _make_ptr[dt](grad_input_addr).as_unsafe_any_origin(),
+                _make_ptr[dt](grad_output_addr)
+                .as_unsafe_any_origin()
+                .as_immutable(),
+                _make_ptr[dt](output_addr)
+                .as_unsafe_any_origin()
+                .as_immutable(),
+                rows,
+                cols,
+                ctx,
+            )
+            handled = True
+    if not handled:
+        raise Error(
+            "unsupported dtype for fused log_softmax backward: "
+            + String(dtype_val)
+        )
+
+
+def _log_softmax_backward_dispatcher(
+    py_self: PyObjectPtr,
+    args: UnsafePointer[PyObjectPtr, MutUntrackedOrigin],
+    nargs: Py_ssize_t,
+) abi("C") -> PyObjectPtr:
+    try:
+        if nargs != 7:
+            raise Error("LogSoftmaxBackwardData expects exactly 7 arguments")
+        _log_softmax_backward_go(
+            args[0],
+            args[1],
+            args[2],
+            args[3],
+            args[4],
+            args[5],
+            args[6],
+        )
+        return _raw_ret_none()
+    except e:
+        # Python validates the public ATen contract before entering the raw
+        # bridge, but candidate-side guards and enqueue failures must still
+        # be visible rather than returning an apparently valid uninitialized
+        # result.
+        return _spec_unsupported(e)
+
+
+@export
+def PyInit_softmax_backward_ops() abi("C") -> PythonObject:
+    try:
+        var b = PythonModuleBuilder("softmax_backward_ops")
+        b.def_py_c_function(
+            _log_softmax_backward_dispatcher,
+            "LogSoftmaxBackwardData",
+            docstring=(
+                "(grad_input_ptr, grad_output_ptr, output_ptr, rows, cols,"
+                " dtype, context_ptr); fused trailing-dim log_softmax"
+                " backward: grad_input = grad_output - exp(output) *"
+                " rowsum(grad_output); f32/f16/bf16, fp32 accumulation"
+            ),
+        )
+        return b.finalize()
+    except e:
+        abort(t"failed to create softmax_backward_ops python module: {e}")


### PR DESCRIPTION
Rewrite _log_softmax_rows_block_kernel for the row-wise log-softmax forward.
Three structural changes over the old scalar 3-pass block kernel:

1. Vectorized 16-byte loads/stores (width 16/esize; per-row scalar head to a
   16B-aligned index + scalar tail handle odd cols).
2. Fused online max+sum: the reduction reads each row ONCE (per-lane running
   max + running sum, rescaled on a new max), so it is 2 reads + 1 write
   instead of 3 reads + 1 write. Warp-shuffle block reductions via
   std.gpu.primitives.block replace the smem tree.
3. L2 residency for the pass-2 output re-read: the grid is capped so the
   concurrent input footprint fits L2, big rows use 1024-thread blocks so the
   small grid still saturates memory, and the output uses a streaming
   (evict-first st.global.cs, NVIDIA-guarded) store so writes don't evict the
   input. DRAM then sees ~1 read + 1 write; ncu confirms reads drop 6.56->3.30
   GB on the primary shape.

Primary 32768x50304 bf16: 11.55 -> 4.13 ms (beats the 4.65 ms CUDA target).
All robustness shapes improved vs baseline; 32 softmax repo tests pass.
