### PR TITLE
Mention the uv install command in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ Simply use [`torch.compile`](https://docs.pytorch.org/tutorials/intermediate/tor
 
 ```bash
 pip install torch-mojo-backend
+
+# or, with uv:
+uv add torch-mojo-backend
 ```
 
 ## Quick Start


### PR DESCRIPTION
Small documentation change, opened mainly as an end-to-end test that the agent account can push to its fork and open a PR here. Close it whenever you like.

The README shows only the `pip` install line, while the project itself is developed with uv (`uv run ...` throughout AGENTS.md). This adds the uv equivalent next to it.

Only `README.md` changes: 3 added lines, no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UtQQafXhqRNJ8DoSPDx1zn