### PR TITLE
Do not block the first device tensor on one-time runtime setup

### DIFF
--- a/tests/test_mojo_device_runtime.py
+++ b/tests/test_mojo_device_runtime.py
@@ -1,13 +1,14 @@
 """PrivateUse1 device-module, transfer, and RNG runtime contracts."""
 
 import gc
+import time
 import weakref
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 import torch
 
-from torch_mojo_backend import register_mojo_devices
+from torch_mojo_backend import get_accelerators, register_mojo_devices
 from torch_mojo_backend.mojo_device import torch_mojo_tensor as mojo_tensor_module
 from torch_mojo_backend.mojo_device.torch_mojo_device_module import (
     _reserve_philox_state,
@@ -249,3 +250,60 @@ def test_torch_fork_rng_restores_mojo_counter(mojo_device):
     with torch.random.fork_rng(devices=[index], device_type="mojo"):
         assert _reserve_philox_state(device, 33) == (91, 0)
     torch.testing.assert_close(torch.mojo.get_rng_state(device), before)
+
+
+def test_registration_prewarms_the_first_device_tensor_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The first device tensor must not pay one-time runtime setup inline.
+
+    `torch.tensor(..., device="mojo")` used to block for ~0.7s warm (2.4s+ on a
+    cold cache) while every *operation* build was already backgrounded. Profiling
+    put 0.711 of 0.721s inside a single native call, `tensor_holder.alloc_from_host`
+    -- one-time runtime and pinned-host staging setup, not compilation. The
+    registration hook does that work on a background thread instead.
+
+    Asserted through observable state rather than timing, so this cannot flake on
+    a loaded machine: the holder module ends up loaded without the test having
+    created a tensor.
+    """
+    from torch_mojo_backend import eager_kernels
+    from torch_mojo_backend.eager_kernels import call_queue
+    from torch_mojo_backend.mojo_device import register
+
+    if not get_accelerators():
+        pytest.skip("prewarm targets an accelerator")
+
+    # The prewarm is deliberately skipped when the kernel queue is off, which is
+    # the default under the test suite -- force it on for this test only.
+    monkeypatch.setenv("TORCH_MOJO_BACKEND_KERNEL_QUEUE", "1")
+    call_queue.refresh()
+    assert call_queue.enabled()
+
+    register._start_tensor_holder_prewarm()
+    for _ in range(600):  # up to 60s on a cold cache, which builds the extension
+        if eager_kernels._TENSOR_HOLDER:
+            break
+        time.sleep(0.1)
+    assert eager_kernels._TENSOR_HOLDER, "prewarm thread never loaded the holder"
+
+
+def test_prewarm_is_skipped_when_the_kernel_queue_is_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`TORCH_MOJO_BACKEND_KERNEL_QUEUE=0` means every build blocks at its call
+    site, for debugging. Prewarming would move one off its call site and make the
+    kill switch a partial lie, so it must not start a thread at all."""
+    import threading
+
+    from torch_mojo_backend.eager_kernels import call_queue
+    from torch_mojo_backend.mojo_device import register
+
+    monkeypatch.setenv("TORCH_MOJO_BACKEND_KERNEL_QUEUE", "0")
+    call_queue.refresh()
+    assert not call_queue.enabled()
+
+    before = {t.name for t in threading.enumerate()}
+    register._start_tensor_holder_prewarm()
+    after = {t.name for t in threading.enumerate()}
+    assert not [n for n in after - before if "prewarm" in n]

--- a/torch_mojo_backend/mojo_device/register.py
+++ b/torch_mojo_backend/mojo_device/register.py
@@ -1,7 +1,11 @@
+import threading
 from functools import wraps
 
 import torch
 
+from .. import eager_kernels
+from ..eager_kernels import call_queue
+from ..torch_compile_backend.utils import get_accelerators
 from .mojo_device_aten_ops import _aten_ops_registry
 
 _registered = False
@@ -214,6 +218,70 @@ def _keep_mojo_kernels_out_of_fake_tensor_construction():
     FakeTensor.__new__ = staticmethod(fake_new_without_mojo_kernels)
 
 
+def _start_tensor_holder_prewarm() -> None:
+    """Start building the TensorHolder extension now, off the calling thread.
+
+    Creating the first device tensor reaches `eager_kernels.tensor_holder`,
+    whose module-level `__getattr__` builds and dlopens the extension
+    SYNCHRONOUSLY on the calling thread. That is a one-time cost (~2.4s on an
+    H100 box, cold cache) but it lands squarely on the user's first
+    `torch.tensor(..., device="mojo")`, while every *operation* build is
+    already handed to the background pool and returns immediately. The stall
+    is therefore not inherent to creating a tensor -- the second and third
+    tensors are instant -- it is the extension build being on the critical
+    path of whoever touches it first.
+
+    Nothing about that build needs the caller, so it starts here. This
+    function is the point where a program declares it intends to use the
+    device, which is why the prewarm lives here and NOT at import time:
+    importing the package must keep compiling nothing, since torch.compile-only
+    users never touch the eager kernels and should not pay for them.
+
+    Daemon thread, and the exception is swallowed on purpose:
+    `_ensure_tensor_holder` caches a failure and re-raises it at the real call
+    site, so a broken build still surfaces there, with the traceback the user
+    can act on, instead of being reported twice or lost in a thread.
+    """
+    if not call_queue.enabled():
+        # Kill switch (TORCH_MOJO_BACKEND_KERNEL_QUEUE=0) means "every build
+        # blocks inline at its call site" for debugging. Prewarming would move
+        # this one off its call site and make the knob a partial lie.
+        return
+
+    def _build() -> None:
+        try:
+            eager_kernels._ensure_tensor_holder()
+        except BaseException:
+            pass
+        try:
+            # Second one-time cost on the same critical path, and the bigger
+            # one once the extension is cached. Profiling the first
+            # `torch.tensor(..., device="mojo")` with the holder already loaded
+            # put 0.711 of its 0.721s inside ONE native call --
+            # `tensor_holder.alloc_from_host` -- with the second tensor at
+            # 0.000s. So it is one-time setup behind that entry point (device
+            # context plus the pinned-host staging path), not the extension
+            # build and not compilation.
+            #
+            # It has to be `_from_cpu`, i.e. `alloc_from_host`: prewarming with
+            # a plain `alloc` did NOT remove the stall, because the two entry
+            # points do not share the setup. Warm the path the user's first
+            # statement actually takes, with the smallest tensor there is.
+            from .torch_mojo_tensor import TorchMojoTensor
+
+            probe = torch.zeros(1)
+            for device in get_accelerators():
+                # Unreferenced on return, so the holder frees it immediately
+                # and this leaves only the initialized runtime behind.
+                TorchMojoTensor._from_cpu(probe, device)
+        except BaseException:
+            pass
+
+    threading.Thread(
+        target=_build, name="tmb-tensor-holder-prewarm", daemon=True
+    ).start()
+
+
 def register_mojo_devices():
     """Enable the mojo device globally and register all aten ops"""
     from torch.utils.backend_registration import _setup_privateuseone_for_python_backend
@@ -271,5 +339,7 @@ def register_mojo_devices():
     from .apple_optimizations import register_apple_optimizations
 
     register_apple_optimizations()
+
+    _start_tensor_holder_prewarm()
 
     _registered = True


### PR DESCRIPTION
Closes #371.

### It is not compilation

That's what the asymmetry suggests, so I profiled it. With the extension already loaded, **0.711 of the first tensor's 0.721 s sits inside a single native call** — `tensor_holder.alloc_from_host` — and the second tensor takes 0.000 s:

```
mojo_device__to_copy                    0.721
  _from_cpu                             0.711
    tensor_holder.alloc_from_host       0.711   <- tottime, one call
```

That is one-time **runtime** setup (device context + the pinned-host staging path) landing on whoever allocates first. Operations look non-blocking only because they are never first — they'd pay it too.

### Two one-time costs, both now started at registration on a background thread

1. building/dlopening the `tensor_holder` extension (~2.4 s cold), which `eager_kernels.tensor_holder`'s module `__getattr__` otherwise does **synchronously on the calling thread**;
2. the `alloc_from_host` setup above, warmed with a 1-element tensor.

The second must go through `_from_cpu`: prewarming with a plain `alloc` measurably did **not** help — the two entry points don't share the setup.

### Measured

| | before | after |
|---|---|---|
| first tensor, warm cache, 1.5 s of startup work first | 0.718 s | **0.007 s** |
| first tensor, warm, nothing before it | 0.72 s | 0.72 s |

The second row is the honest limit: with nothing between `register_mojo_devices()` and the first tensor — the shape of the snippet in the issue — the wall clock is unchanged, because the work still has to happen and there is nothing to overlap it with. Any real program (build a model, load data, read a checkpoint) is the first row.

### Why not return immediately with shape/dtype/strides instead

Because for an operation the queue defers the *launch* but **preallocates the output** — `call_queue.kernel_call_into` is documented as "a descriptor call whose outputs were preallocated in Python", and its `args` are *"raw pointers and scalars"*, with `keepalive` holding the tensors only so the buffers survive. The pointer is baked into the queued launch args **at enqueue time**.

So a tensor cannot hand out a pointer later without the queue holding the *tensor* instead of the pointer and re-reading `_ptr` at drain. That is a real change, and it has two further consequences worth weighing before anyone attempts it:

- OOM would surface at drain rather than at the allocation site, losing the traceback that points at the offending line;
- `_alloc_with_recovery` currently recovers from OOM by **draining the queue** to reclaim memory and retrying once. If allocations themselves happen during the drain, that recovery is circular.

Given the prewarm already covers every program that does anything before its first tensor, I did not think that trade was worth making unprompted — happy to if you want it.

### Details

`register_mojo_devices()` is the hook rather than import: it is where a program declares it will use the device, and importing the package must keep compiling nothing, which torch.compile-only users depend on. Skipped entirely under `TORCH_MOJO_BACKEND_KERNEL_QUEUE=0` so that kill switch keeps meaning "every build blocks at its call site". Daemon thread; the exception is swallowed because `_ensure_tensor_holder` caches a failure and re-raises it at the real call site, so a broken build still surfaces there with an actionable traceback.

Two tests, asserting observable state rather than timings so they cannot flake on a loaded machine: the holder ends up loaded without the test creating a tensor, and no thread starts when the queue is disabled. `tests/test_mojo_device_runtime.py` + `test_mojo_device.py` + `test_call_queue.py`: 159 passed, 6 skipped, 4 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0133Q6PWFo52BNSysckZ3Rke