### PR TITLE
Record the Apple foreach baselines, and fix the Metal build that blocked them

### DIFF
--- a/benchmarks/baselines.html
+++ b/benchmarks/baselines.html
@@ -723,6 +723,163 @@ document.addEventListener("DOMContentLoaded", boot);
             }
           }
         },
+        "_foreach_add_.Scalar": {
+          "dtypes": {
+            "f32": {
+              "shapes": {
+                "L_16x65536": {
+                  "layouts": {
+                    "contig": 0.773
+                  }
+                },
+                "L_4x1048576": {
+                  "layouts": {
+                    "contig": 0.918
+                  }
+                }
+              }
+            }
+          }
+        },
+        "_foreach_addcdiv_.ScalarList": {
+          "dtypes": {
+            "f32": {
+              "shapes": {
+                "L_16x65536": {
+                  "layouts": {
+                    "contig": 0.624
+                  }
+                },
+                "L_4x1048576": {
+                  "layouts": {
+                    "contig": 1.057
+                  }
+                }
+              }
+            }
+          }
+        },
+        "_foreach_addcmul_.Scalar": {
+          "dtypes": {
+            "f32": {
+              "shapes": {
+                "L_16x65536": {
+                  "layouts": {
+                    "contig": 0.635
+                  }
+                },
+                "L_4x1048576": {
+                  "layouts": {
+                    "contig": 1.055
+                  }
+                }
+              }
+            }
+          }
+        },
+        "_foreach_div_.ScalarList": {
+          "dtypes": {
+            "f32": {
+              "shapes": {
+                "L_16x65536": {
+                  "layouts": {
+                    "contig": 0.802
+                  }
+                },
+                "L_4x1048576": {
+                  "layouts": {
+                    "contig": 0.927
+                  }
+                }
+              }
+            }
+          }
+        },
+        "_foreach_lerp_.Scalar": {
+          "dtypes": {
+            "f32": {
+              "shapes": {
+                "L_16x65536": {
+                  "layouts": {
+                    "contig": 0.803
+                  }
+                },
+                "L_4x1048576": {
+                  "layouts": {
+                    "contig": 1.065
+                  }
+                }
+              }
+            }
+          }
+        },
+        "_foreach_mul_.Scalar": {
+          "dtypes": {
+            "f32": {
+              "shapes": {
+                "L_16x65536": {
+                  "layouts": {
+                    "contig": 0.787
+                  }
+                },
+                "L_4x1048576": {
+                  "layouts": {
+                    "contig": 0.921
+                  }
+                }
+              }
+            }
+          }
+        },
+        "_foreach_mul_.Tensor": {
+          "dtypes": {
+            "f32": {
+              "shapes": {
+                "L_16x65536": {
+                  "layouts": {
+                    "contig": 0.999
+                  }
+                },
+                "L_4x1048576": {
+                  "layouts": {
+                    "contig": 0.924
+                  }
+                }
+              }
+            }
+          }
+        },
+        "_foreach_norm.Scalar": {
+          "dtypes": {
+            "f32": {
+              "shapes": {
+                "L_16x65536": {
+                  "layouts": {
+                    "contig": 0.587
+                  }
+                },
+                "L_4x1048576": {
+                  "layouts": {
+                    "contig": 0.843
+                  }
+                }
+              }
+            }
+          }
+        },
+        "_foreach_sqrt": {
+          "dtypes": {
+            "f32": {
+              "shapes": {
+                "L_4x1048576": {
+                  "layouts": {
+                    "contig": 1.503
+                  }
+                }
+              }
+            }
+          }
+        },
         "_fused_adamw_": {
           "dtypes": {
             "f32": {

--- a/benchmarks/baselines.html
+++ b/benchmarks/baselines.html
@@ -729,12 +729,12 @@ document.addEventListener("DOMContentLoaded", boot);
               "shapes": {
                 "L_16x65536": {
                   "layouts": {
-                    "contig": 1.95
+                    "contig": 0.393
                   }
                 },
                 "L_4x1048576": {
                   "layouts": {
-                    "contig": 1.845
+                    "contig": 0.843
                   }
                 }
               }
@@ -747,12 +747,12 @@ document.addEventListener("DOMContentLoaded", boot);
               "shapes": {
                 "L_16x65536": {
                   "layouts": {
-                    "contig": 3.36
+                    "contig": 0.343
                   }
                 },
                 "L_4x1048576": {
                   "layouts": {
-                    "contig": 2.364
+                    "contig": 0.808
                   }
                 }
               }
@@ -765,12 +765,12 @@ document.addEventListener("DOMContentLoaded", boot);
               "shapes": {
                 "L_16x65536": {
                   "layouts": {
-                    "contig": 4.549
+                    "contig": 0.434
                   }
                 },
                 "L_4x1048576": {
                   "layouts": {
-                    "contig": 2.431
+                    "contig": 0.832
                   }
                 }
               }
@@ -783,12 +783,12 @@ document.addEventListener("DOMContentLoaded", boot);
               "shapes": {
                 "L_16x65536": {
                   "layouts": {
-                    "contig": 4.431
+                    "contig": 0.291
                   }
                 },
                 "L_4x1048576": {
                   "layouts": {
-                    "contig": 5.237
+                    "contig": 0.585
                   }
                 }
               }
@@ -801,12 +801,12 @@ document.addEventListener("DOMContentLoaded", boot);
               "shapes": {
                 "L_16x65536": {
                   "layouts": {
-                    "contig": 6.884
+                    "contig": 0.439
                   }
                 },
                 "L_4x1048576": {
                   "layouts": {
-                    "contig": 4.554
+                    "contig": 0.682
                   }
                 }
               }
@@ -819,12 +819,12 @@ document.addEventListener("DOMContentLoaded", boot);
               "shapes": {
                 "L_16x65536": {
                   "layouts": {
-                    "contig": 6.911
+                    "contig": 0.387
                   }
                 },
                 "L_4x1048576": {
                   "layouts": {
-                    "contig": 8.026
+                    "contig": 0.833
                   }
                 }
               }
@@ -837,12 +837,12 @@ document.addEventListener("DOMContentLoaded", boot);
               "shapes": {
                 "L_16x65536": {
                   "layouts": {
-                    "contig": 2.044
+                    "contig": 0.374
                   }
                 },
                 "L_4x1048576": {
                   "layouts": {
-                    "contig": 1.935
+                    "contig": 0.814
                   }
                 }
               }
@@ -873,12 +873,12 @@ document.addEventListener("DOMContentLoaded", boot);
               "shapes": {
                 "L_16x65536": {
                   "layouts": {
-                    "contig": 1.571
+                    "contig": 0.302
                   }
                 },
                 "L_4x1048576": {
                   "layouts": {
-                    "contig": 1.05
+                    "contig": 0.484
                   }
                 }
               }

--- a/docs/optimization_backlog.md
+++ b/docs/optimization_backlog.md
@@ -49,7 +49,7 @@ different kind of item.
 | [D1](#d1) | The hot rank≤4 materialize path lacks the 16-byte vectorized transpose the rank≤8 path already has | Data movement | Medium (2.1–2.4 → 3.57 TB/s on the transposes, gfx942-measured) | **Low** (port an existing kernel) | — |
 | [P1](#p1) | Warm-path regression from the variant loader: 101 ms/step vs 60 ms on `main` | Compile pipeline | **High** — the largest single eager regression currently on record | Medium | — |
 | [R1](#r1) | ~~Non-trailing reductions materialize a whole permuted copy of the input~~ **DONE**: one accumulator-parametrized skeleton over (outer, reduce, inner), strided-axis kernel for every scalar reduction | Reductions | Medium | Medium | — |
-| [O2](#o2) | Five `_foreach_*` batched kernels are Metal-only; CUDA/ROCm fall back to one launch per tensor | Optimizer | Medium (non-fused `AdamW(foreach=True)`) | Low–Medium | — |
+| [O2](#o2) | ~~Five `_foreach_*` batched kernels are Metal-only; CUDA/ROCm fall back to one launch per tensor~~ **DONE**: one descriptor-batched kernel body for the whole elementwise family, chunk size sized from the device | Optimizer | Medium (non-fused `AdamW(foreach=True)`) | Low–Medium | — |
 | [C2](#c2) | Grouped convolution issues `N × groups` GEMM launches from a Python loop | Conv | Medium for depthwise/grouped nets | Medium | — |
 | [C1](#c1) | Convolution is im2col + GEMM with a full `(N, C·kh·kw, out_h·out_w)` temporary | Conv | Medium (memory-bound at large spatial) | High | no conv benchmark exists |
 | [N1](#n1) | LayerNorm backward is fp32-only and GPU-only; the forward accepts fp16/bf16 | Normalization | Medium (blocks pure-bf16 training) | Medium | — |
@@ -969,7 +969,7 @@ temporary** — **DONE** (`NormSpec`)
 * **Why it is not optimal.** Two gaps. (a) Mixed-precision training with bf16
   *master* weights (no fp32 copy) cannot use the fused optimizer. (b) The failure
   mode is a `RuntimeError` rather than `NOT_HANDLED`, so PyTorch cannot fall back
-  to its own foreach path — and that path is itself crippled by [O2](#o2).
+  to its own foreach path (which is now the fast one, see [O2](#o2)).
 * **What the optimized version looks like.** A per-tensor dtype field in the
   descriptor record — the ABI already carries a "homogeneous" flag slot, so the
   heterogeneous encoding was anticipated — with fp32 accumulation inside the
@@ -979,37 +979,49 @@ temporary** — **DONE** (`NormSpec`)
   `bench_nanogpt_train.py` with a bf16-parameter variant.
 
 ### O2
-**Five batched `_foreach_*` kernels are Metal-only**
+**Five batched `_foreach_*` kernels are Metal-only** — **DONE** (one
+descriptor-batched body for the whole family)
 
-* **What.** `_foreach_metal_f32`, `aten_fast.py:586` — returns `None` unless
-  `device.api == "metal"` (`:611`). Its callers:
-  `fast_aten__foreach_mul__scalar` (`:692`),
-  `fast_aten__foreach_div__scalarlist` (`:723`),
-  `fast_aten__foreach_lerp__scalar` (`:733`),
-  `fast_aten__foreach_addcmul__scalar` (`:809`),
-  `fast_aten__foreach_addcdiv__scalarlist` (`:824`) — all via
-  `_foreach_scalar_inplace` (`:668`). Only `fast_aten__foreach_add__scalar`
-  (`:712`) has a generic route (`_fast__foreach_add__scalar_generic`, `:462`),
-  added by journal Change 45. `_foreach_norm` (`:329`) and `_foreach_mul_.Tensor`
-  (`:512`) are device-general but fp32-only.
-* **Current implementation.** On CUDA and ROCm those five decline, and
-  `_register_foreach_inplace` (`mojo_device_aten_ops.py:947`) redispatches to
-  ATen's generic decomposition — one launch per tensor.
-* **Why it is not optimal.** `torch.optim.AdamW(foreach=True)` — PyTorch's
-  default when `fused` is not requested — uses exactly `_foreach_mul_`,
-  `_foreach_addcmul_`, `_foreach_addcdiv_`, `_foreach_div_` and `_foreach_lerp_`.
-  For nanoGPT's 75 parameter tensors that is ~375 launches per step instead of
-  five. The journal priced the analogous case: `_foreach_add_.Scalar` was 76
-  launches / 379 µs against ROCm's 10.4 µs, and Change 45 collapsed it to one.
-* **What the optimized version looks like.** Replace the Metal gate with "GPU +
-  contiguous + homogeneous fp32". The `ForeachScalarOp` kernel
-  (`optimizer_ops/optimizer_ops.mojo`) already takes a runtime descriptor array;
-  what is Metal-specific is the 8-slot batching, not the operation.
-* **Expected win.** By analogy with Change 45, ~370 µs/step on gfx942 — **that is
-  an analogy, not a measurement of these five ops**.
-* **How to measure it.** `bench_nanogpt_train.py` with the optimizer configured
-  `fused=False, foreach=True`, plus `compare_nanogpt_train_kernels.py`'s
-  optimizer group.
+* **What it was.** `_foreach_metal_f32` returned `None` unless
+  `device.api == "metal"`, so `_foreach_mul_.Scalar`,
+  `_foreach_div_.ScalarList`, `_foreach_lerp_.Scalar`,
+  `_foreach_addcmul_.Scalar`, `_foreach_addcdiv_.ScalarList` and
+  `_foreach_sqrt` all declined on CUDA and ROCm and
+  `_register_foreach_inplace` redispatched to ATen's decomposition — one
+  launch per tensor. Only `_foreach_add_.Scalar` and `_foreach_mul_.Tensor`
+  had device-general descriptor kernels of their own.
+* **What replaced it.** `foreach_batched_kernels.mojo`: ONE kernel body,
+  comptime-parametrized by dtype and by op (mul/add/div by a per-tensor host
+  scalar, multiply by a 0-d device scalar, lerp, addcmul, addcdiv, sqrt),
+  reached through one bridge `_foreach_ew_go[op]` and one Python launch
+  helper. The six separate bridges it replaced (`ForeachScalarOp`,
+  `ForeachLerpScalar`, `ForeachAddcOp`, `ForeachSqrt`, `ForeachMulTensor` and
+  `elementwise_ops`' `ForeachAddScalar`) are gone, as is the hand-tuned
+  `foreach_mul_tensor_f32_aligned_streaming_ilp8_t128_v8`. Apple regroups the
+  same descriptors into the fixed-arity Metal launches, which is the only
+  part that ever needed to be Metal-specific.
+* **The Metal gate was not the whole cost.** The chunk size was fixed at
+  65_536 elements, which put the 4x1_048_576 list on 64 blocks and the
+  16x65_536 list on 16 — on 114 SMs. It is now a runtime launch argument
+  derived from the element count and the runtime SM count, which is where
+  most of the win came from: `_foreach_add_.Scalar` and
+  `_foreach_mul_.Tensor` already had a single-launch descriptor path and
+  still went from 1.85/1.94 to 0.84/0.81.
+* **Measured** (H100 PCIe, `benchmarks/test_foreach.py`, ours/stock device
+  time, 4x1_048_576 then 16x65_536): `_foreach_mul_.Scalar` 1.76/4.31 ->
+  0.84/0.39, `_foreach_add_.Scalar` 1.85/1.95 -> 0.84/0.39,
+  `_foreach_div_.ScalarList` 1.19/2.88 -> 0.59/0.29, `_foreach_lerp_.Scalar`
+  4.55/6.88 -> 0.85/0.44, `_foreach_addcmul_.Scalar` 2.43/4.55 ->
+  0.84/0.44, `_foreach_addcdiv_.ScalarList` 2.36/3.36 -> 0.81/0.35,
+  `_foreach_mul_.Tensor` 1.94/2.04 -> 0.81/0.37, `_foreach_sqrt`
+  1.05/1.57 -> 0.53/0.30. (The four `.Scalar`/`.ScalarList` "before" numbers
+  are freshly measured; the recorded baselines for `_foreach_mul_.Scalar`
+  (8.03/6.91) and `_foreach_div_.ScalarList` (5.24/4.43) could not be
+  reproduced at the commit that held them.)
+* **What is still open.** mul/add take every float dtype; div, lerp, addc*,
+  sqrt and mul.Tensor are still fp32-only, because the sequential kernels
+  they have to stay bit-compatible with do not all widen to fp32 the same
+  way. Lists longer than `FEW_DESC_CAP` (64) still pay one launch per 64.
 
 ### O3
 **`clip_grad_norm_` is fp32-only end to end**
@@ -1361,7 +1373,7 @@ fallback runs. This is the answer to "which GPUs run an unoptimized path".
 | Fused softmax+dropout forward | `metal` + fp32 | `aten_fast.py:5581` | separate softmax + dropout |
 | Fused 3-way `cat` | `metal` | `aten_fast.py:3621` | 3 `NarrowCopyDst` launches |
 | `fast_aten_add` spec-bypass fast path | `metal` | `aten_fast.py:2364` | spec path |
-| Five batched `_foreach_*` ops | `metal` | `aten_fast.py:611` | ATen sequential redispatch ([O2](#o2)) |
+| Foreach elementwise family, fixed-arity 8-slot ABI | `has_apple_gpu_accelerator()` | `foreach_batched_kernels.mojo` (`foreach_ew_enqueue`) | the descriptor-batched kernel (same body, same descriptors) |
 | Apple vectorized D2D copy | `has_apple_gpu_accelerator()` | `tensor_holder.mojo:326` | `enqueue_copy_from` |
 | Apple permute rows4 / rowloop | `has_apple_gpu_accelerator()` | `data_movement_ops.mojo:321` | generic gather ladder |
 | Apple fused AdamW variant | `has_apple_gpu_accelerator()` | `optimizer_kernels.mojo:339` | generic fused AdamW |

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -2258,7 +2258,7 @@ def test_fast_foreach_add_scalar_matches_adamw_step_counters(mojo_gpu, monkeypat
     be entered once per call, not once per tensor.
     """
     counter, calls_before = _eager_registration_snapshot("aten::_foreach_add_.Scalar")
-    target = ("elementwise_ops.mojo", "ForeachAddScalar")
+    target = ("optimizer_ops.mojo", "ForeachAdd")
     native_calls = _spy_defined_native_calls(monkeypatch, {target})
     steps = [torch.zeros((), dtype=torch.float32).to(mojo_gpu) for _ in range(75)]
     for _ in range(3):

--- a/tests/test_eager_optimizer_ops.py
+++ b/tests/test_eager_optimizer_ops.py
@@ -531,6 +531,106 @@ _FOREACH_BATCHED_OPS = [
 ]
 
 
+def _misaligned_foreach_lists(
+    device: str, *, stagger: bool = False
+) -> list[list[torch.Tensor]]:
+    """The same three lists, but every tensor an offset view.
+
+    A device allocation is 16-byte aligned, so a misaligned base can only come
+    from a contiguous OFFSET view -- which the fast path accepts and the
+    batched kernel therefore has to handle: each chunk peels up to three
+    elements to reach a 16-byte boundary before its vectorized body, and no
+    length here is a multiple of the four-element vector step, so every last
+    chunk also ends in a scalar tail.
+
+    With `stagger` the parallel lists start at DIFFERENT residues, which no
+    single peel can align: the kernel has to fall back to its scalar path for
+    the multi-operand ops (lerp, addcmul, addcdiv).
+    """
+    lengths = (1, 6, 17, 4099, 65_539)
+    shifts = [index % 3 + 1 for index in range(len(lengths))]
+
+    def group(
+        scale: float, base: float, bump: int, positive: bool = False
+    ) -> list[torch.Tensor]:
+        tensors = []
+        for index, length in enumerate(lengths):
+            shift = shifts[index] + bump
+            whole = (
+                torch.arange(length + shift, dtype=torch.float32)
+                .mul(scale)
+                .add(base + index * 0.01)
+            )
+            if positive:
+                whole = whole.abs().add(0.5)
+            # Slice AFTER the arithmetic: every operation would otherwise
+            # allocate a fresh, 16-byte-aligned result and lose the offset
+            # this fixture exists to produce.
+            tensors.append(whole.to(device)[shift:])
+        return tensors
+
+    return [
+        group(0.003, -0.4, 0),
+        group(-0.0007, 0.3, 1 if stagger else 0),
+        group(0.0002, 0.55, 2 if stagger else 0, positive=True),
+    ]
+
+
+@pytest.mark.parametrize("stagger", (False, True), ids=["aligned", "staggered"])
+@pytest.mark.parametrize(("op_name", "apply"), _FOREACH_BATCHED_OPS)
+def test_batched_foreach_misaligned_views_match_cpu(
+    mojo_gpu: str, call_checker: CallChecker, op_name: str, apply, stagger: bool
+):
+    """Offset views, awkward lengths, and mismatched operand alignments."""
+    _watch_eager_op(call_checker, op_name)
+    cpu_lists = _misaligned_foreach_lists("cpu", stagger=stagger)
+    mojo_lists = _misaligned_foreach_lists(mojo_gpu, stagger=stagger)
+    assert any(tensor._ptr % 16 for tensor in mojo_lists[0])
+    apply(*cpu_lists)
+    apply(*mojo_lists)
+    for expected, actual in zip(cpu_lists[0], mojo_lists[0], strict=True):
+        torch.testing.assert_close(actual.cpu(), expected, rtol=2e-6, atol=2e-7)
+
+
+def test_batched_foreach_mixed_dtype_list_falls_back(
+    mojo_gpu: str, call_checker: CallChecker
+):
+    """A two-dtype list is not one launch, and still gets ATen's answer.
+
+    One batched launch is compiled for exactly one dtype, so a mixed list has
+    to reach the sequential per-tensor decomposition instead.
+    """
+    _watch_eager_op(call_checker, "aten::_foreach_mul_.Scalar")
+    mixed = [
+        torch.tensor([1.5, -2.0]).to(mojo_gpu),
+        torch.tensor([1.5, -2.0], dtype=torch.bfloat16).to(mojo_gpu),
+    ]
+    torch._foreach_mul_(mixed, 2.0)
+    torch.testing.assert_close(
+        mixed[0].cpu(), torch.tensor([3.0, -4.0]), rtol=0, atol=0
+    )
+    torch.testing.assert_close(
+        mixed[1].cpu(), torch.tensor([3.0, -4.0], dtype=torch.bfloat16), rtol=0, atol=0
+    )
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16], ids=["f16", "bf16"])
+def test_batched_foreach_mul_scalar_reduced_precision(mojo_gpu: str, dtype):
+    """Half and bfloat16 lists take the batched path and widen like ATen.
+
+    The per-tensor `mul_.Scalar` this replaces computes in FP32 and narrows
+    once, so the batched launch has to land on the same bits -- not merely
+    close.
+    """
+    host = [torch.linspace(-3.0, 4.0, length).to(dtype) for length in (7, 65_539, 1)]
+    device = [tensor.to(mojo_gpu) for tensor in host]
+    torch._foreach_mul_(device, 0.998)
+    for expected, actual in zip(host, device, strict=True):
+        torch.testing.assert_close(
+            actual.cpu(), (expected.float() * 0.998).to(dtype), rtol=0, atol=0
+        )
+
+
 @pytest.mark.parametrize(("op_name", "apply"), _FOREACH_BATCHED_OPS)
 def test_batched_foreach_elementwise_matches_cpu(
     mojo_gpu: str, call_checker: CallChecker, op_name: str, apply
@@ -573,6 +673,23 @@ def test_batched_foreach_sqrt_matches_cpu(mojo_gpu: str, call_checker: CallCheck
     for original, actual_out in zip(mojo_inputs, actual, strict=True):
         if original.numel() > 0:
             assert actual_out._ptr != original._ptr
+
+
+def test_batched_foreach_sqrt_misaligned_input_matches_cpu(mojo_gpu: str):
+    """Offset-view inputs, freshly aligned outputs: no peel can align both.
+
+    Every other member of the family writes where it reads, so this is the one
+    op whose operands can disagree on alignment in ordinary use, and the
+    element-at-a-time route the kernel then takes has to be exact too.
+    """
+    cpu_inputs = _misaligned_foreach_lists("cpu")[2]
+    mojo_inputs = _misaligned_foreach_lists(mojo_gpu)[2]
+    assert any(tensor._ptr % 16 for tensor in mojo_inputs)
+    expected = [tensor.double().sqrt().to(tensor.dtype) for tensor in cpu_inputs]
+    for expected_out, actual_out in zip(
+        expected, torch._foreach_sqrt(mojo_inputs), strict=True
+    ):
+        torch.testing.assert_close(actual_out.cpu(), expected_out, rtol=0, atol=0)
 
 
 def test_batched_foreach_falls_back_for_non_f32(

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -313,16 +313,23 @@ _ARG_DIRECT_MIN_INNER = 16
 _FUSED_ADAMW_RECORD_FIELDS = 7
 _FOREACH_CHUNK_ELEMENTS = 65_536
 _FOREACH_NORM_RECORD_FIELDS = 3
-_FOREACH_MUL_RECORD_FIELDS = 2
-_FOREACH_ADD_RECORD_FIELDS = 2
 
-# Opcodes of the batched foreach elementwise bridge (must match
-# foreach_elementwise_kernels.mojo).
-_FOREACH_EW_MUL = 0
-_FOREACH_EW_ADD = 1
-_FOREACH_EW_DIV = 2
-_FOREACH_EW_ADDCMUL = 0
-_FOREACH_EW_ADDCDIV = 1
+# Entry names of the batched foreach elementwise family. Each is one
+# specialized build of the single kernel body in foreach_batched_kernels.mojo,
+# so this list is also the list of ops that body serves.
+_FOREACH_MUL = "ForeachMul"
+_FOREACH_ADD = "ForeachAdd"
+_FOREACH_DIV = "ForeachDiv"
+_FOREACH_MUL_TENSOR = "ForeachMulTensor"
+_FOREACH_LERP = "ForeachLerp"
+_FOREACH_ADDCMUL = "ForeachAddcmul"
+_FOREACH_ADDCDIV = "ForeachAddcdiv"
+_FOREACH_SQRT = "ForeachSqrt"
+
+# Dtypes of a list whose sequential per-tensor kernel already computes in FP32
+# and narrows back (`elementwise_ops._scalar_elementwise`), so one batched
+# launch over the concatenation is bit-identical to it.
+_FOREACH_WIDENING_DTYPES = _FLOAT_DTYPES
 
 # ATen Scalar arguments as they arrive at a PrivateUse1 registration.
 AtenScalar = int | float | bool | complex
@@ -613,111 +620,6 @@ def _foreach_scalar_overlap_kind(tensor, scalar) -> str:
     return "partial"
 
 
-def _fast__foreach_add__scalar_generic(self, scalar):
-    """One launch for `t += scalar` over a whole homogeneous float tensor list.
-
-    Without this ATen runs the CompositeExplicitAutograd fallback, a sequential
-    `add_.Scalar` per element of the list. nanoGPT's fused AdamW bumps 75
-    one-element step counters per step, so that is 75 launches to add 75 floats.
-    Anything this cannot serve -- a mixed dtype, a non-float dtype, a strided
-    tensor, a list whose members alias -- returns ``NOT_HANDLED`` and keeps that
-    fallback, which is also what defines the semantics being matched.
-    """
-    if len(self) == 0:
-        return NOT_HANDLED
-    if isinstance(scalar, bool) or not isinstance(scalar, int | float):
-        return NOT_HANDLED
-    tensors = [_t(tensor) for tensor in self]
-    if any(tensor is None for tensor in tensors):
-        return NOT_HANDLED
-    device = tensors[0]._device
-    dtype = tensors[0]._dtype
-    if (
-        device.api == "cpu"
-        or dtype not in _FLOAT_DTYPES
-        or any(
-            tensor._device != device
-            or tensor._dtype != dtype
-            or not tensor._is_contiguous
-            for tensor in tensors
-        )
-        # Duplicated or aliasing entries have to be applied once each, in
-        # order; one grid over the concatenation would race instead.
-        or _foreach_tensors_overlap(tensors)
-    ):
-        return NOT_HANDLED
-
-    metadata = tuple(
-        value for tensor in tensors for value in (tensor._ptr, tensor._numel)
-    )
-    if len(metadata) != len(tensors) * _FOREACH_ADD_RECORD_FIELDS:
-        raise AssertionError("invalid foreach add metadata packing")
-    _call_mojo(
-        _ElementwiseExtension,
-        "ForeachAddScalar",
-        (metadata, float(scalar), dtype.value, _ctx_ptr(device)),
-        arg_dtypes=(dtype,),
-        output_dtypes=(dtype,),
-        flags={"INPLACE": True},
-        keepalive=(tensors,),
-    )
-    return None
-
-
-def fast_aten__foreach_mul__tensor(self, other):
-    """Fast homogeneous FP32 in-place multiply by a device scalar tensor."""
-    if len(self) == 0:
-        raise RuntimeError("Tensor list must have at least one tensor.")
-    scalar = _t(other)
-    tensors = [_t(tensor) for tensor in self]
-    if scalar is None or any(tensor is None for tensor in tensors):
-        return NOT_HANDLED
-    device = tensors[0]._device
-    if scalar._shape == ():
-        overlap_kinds = [
-            _foreach_scalar_overlap_kind(tensor, scalar) for tensor in tensors
-        ]
-        if "partial" in overlap_kinds:
-            raise RuntimeError(
-                "unsupported operation: some elements of the input tensor and "
-                "the written-to tensor refer to a single memory location. "
-                "Please clone() the tensor before performing the operation."
-            )
-        if "full" in overlap_kinds:
-            return NOT_HANDLED
-    if (
-        device.api == "cpu"
-        or scalar._device != device
-        or scalar._dtype != DType.float32
-        or scalar._shape != ()
-        or not scalar._is_contiguous
-        or any(
-            tensor._device != device
-            or tensor._dtype != DType.float32
-            or not tensor._is_contiguous
-            for tensor in tensors
-        )
-        or _foreach_tensors_overlap(tensors)
-    ):
-        return NOT_HANDLED
-
-    metadata = tuple(
-        value for tensor in tensors for value in (tensor._ptr, tensor._numel)
-    )
-    if len(metadata) != len(tensors) * _FOREACH_MUL_RECORD_FIELDS:
-        raise AssertionError("invalid foreach multiply metadata packing")
-    _call_mojo(
-        _OptimizerExtension,
-        "ForeachMulTensor",
-        (metadata, scalar._ptr, _ctx_ptr(device)),
-        arg_dtypes=(DType.float32, DType.float32),
-        output_dtypes=(DType.float32,),
-        flags={"INPLACE": True},
-        keepalive=(scalar,),
-    )
-    return None
-
-
 def _foreach_scalar_value(scalar: AtenScalar) -> float | None:
     """A python float for an ATen Scalar, or None when it disqualifies."""
     if isinstance(scalar, bool) or not isinstance(scalar, int | float):
@@ -739,15 +641,21 @@ def _foreach_scalar_values(
     return values
 
 
-def _foreach_metal_f32(
-    *lists: Sequence[torch.Tensor],
-) -> list[list[TorchMojoTensor]] | None:
-    """Unwrap parallel TensorLists for the batched Metal foreach kernels.
+def _foreach_lists(
+    *lists: Sequence[torch.Tensor], dtypes: tuple[DType, ...] = (DType.float32,)
+) -> tuple[list[list[TorchMojoTensor]], DType] | None:
+    """Unwrap parallel TensorLists for the batched foreach kernels.
 
-    Qualifies only homogeneous lists: every entry a contiguous float32
-    TorchMojoTensor on one shared Metal device, with corresponding entries
-    of all lists shaped identically (the batched kernels are elementwise
-    and never broadcast). Returns None otherwise so callers fall back.
+    Qualifies only homogeneous lists: every entry a contiguous
+    TorchMojoTensor of one accepted dtype on one shared accelerator, with
+    corresponding entries of all lists shaped identically (the batched
+    kernels are elementwise and never broadcast). Returns None otherwise, so
+    the caller falls back to ATen's sequential per-tensor decomposition --
+    which is also what defines the semantics being matched.
+
+    Apple GPUs reach the fixed-arity Metal kernels inside the Mojo bridge
+    (`foreach_batched_kernels`), which exist for float32 only, so anything
+    else there falls back too.
     """
     count = len(lists[0])
     if count == 0:
@@ -764,18 +672,21 @@ def _foreach_metal_f32(
             wrapped.append(mojo_tensor)
         unwrapped.append(wrapped)
     device = unwrapped[0][0]._device
-    if device.api != "metal":
+    dtype = unwrapped[0][0]._dtype
+    if device.api == "cpu" or dtype not in dtypes:
+        return None
+    if device.api == "metal" and dtype != DType.float32:
         return None
     for tensors in unwrapped:
         for index, tensor in enumerate(tensors):
             if (
                 tensor._device != device
-                or tensor._dtype != DType.float32
+                or tensor._dtype != dtype
                 or not tensor._is_contiguous
                 or tensor._shape != unwrapped[0][index]._shape
             ):
                 return None
-    return unwrapped
+    return unwrapped, dtype
 
 
 def _foreach_mutation_hazard(
@@ -821,70 +732,134 @@ def _foreach_mutation_hazard(
     return False
 
 
-def _foreach_scalar_inplace(
-    self: Sequence[torch.Tensor], values: Sequence[float], op_code: int
-) -> object:
-    """Shared launch path of the in-place foreach mul/add/div fast ops."""
-    lists = _foreach_metal_f32(self)
-    if lists is None:
-        return NOT_HANDLED
-    (tensors,) = lists
-    if _foreach_mutation_hazard(tensors, ()):
-        return NOT_HANDLED
+def _foreach_launch(
+    entry: str,
+    lists: Sequence[Sequence[TorchMojoTensor]],
+    dtype: DType,
+    *,
+    scalars: Sequence[float] = (),
+    aux: tuple[int, ...] = (),
+    keepalive: tuple[object, ...] = (),
+) -> None:
+    """One launch of the batched foreach family for a whole TensorList.
+
+    `lists` are the parallel operand lists in the order the Mojo bridge
+    expects them (the mutated list first; for sqrt, input then output). They
+    are flattened into one metadata tuple of `addresses..., numel` per
+    tensor. `scalars` is one host scalar per tensor where the op takes one,
+    and `aux` carries the remaining integers (a device scalar's address, a
+    branch selector).
+    """
+    device = lists[0][0]._device
     metadata = tuple(
-        value for tensor in tensors for value in (tensor._ptr, tensor._numel)
+        value
+        for operands in zip(*lists, strict=True)
+        for value in (*(tensor._ptr for tensor in operands), operands[0]._numel)
     )
     _call_mojo(
         _OptimizerExtension,
-        "ForeachScalarOp",
-        (op_code, metadata, tuple(values), _ctx_ptr(tensors[0]._device)),
-        arg_dtypes=(DType.float32,),
-        output_dtypes=(DType.float32,),
-        flags={"INPLACE": True, "OP_CODE": op_code},
-        keepalive=(tensors,),
+        entry,
+        (metadata, tuple(scalars), aux, dtype.value, _ctx_ptr(device)),
+        arg_dtypes=(dtype,) * len(lists),
+        output_dtypes=(dtype,),
+        keepalive=(*(list(tensors) for tensors in lists), *keepalive),
     )
+
+
+def fast_aten__foreach_mul__tensor(self, other):
+    """Batched in-place multiply of a whole list by one 0-d device tensor."""
+    if len(self) == 0:
+        raise RuntimeError("Tensor list must have at least one tensor.")
+    scalar = _t(other)
+    if scalar is None or scalar._shape != () or not scalar._is_contiguous:
+        return NOT_HANDLED
+    tensors = [_t(tensor) for tensor in self]
+    if any(tensor is None for tensor in tensors):
+        return NOT_HANDLED
+    overlap_kinds = [_foreach_scalar_overlap_kind(tensor, scalar) for tensor in tensors]
+    if "partial" in overlap_kinds:
+        raise RuntimeError(
+            "unsupported operation: some elements of the input tensor and "
+            "the written-to tensor refer to a single memory location. "
+            "Please clone() the tensor before performing the operation."
+        )
+    if "full" in overlap_kinds:
+        return NOT_HANDLED
+    unwrapped = _foreach_lists(self)
+    if unwrapped is None:
+        return NOT_HANDLED
+    lists, dtype = unwrapped
+    if scalar._device != lists[0][0]._device or scalar._dtype != dtype:
+        return NOT_HANDLED
+    if _foreach_mutation_hazard(lists[0], ()):
+        return NOT_HANDLED
+    _foreach_launch(
+        _FOREACH_MUL_TENSOR, lists, dtype, aux=(scalar._ptr,), keepalive=(scalar,)
+    )
+    return None
+
+
+def _foreach_scalar_inplace(
+    entry: str,
+    self: Sequence[torch.Tensor],
+    values: Sequence[float],
+    dtypes: tuple[DType, ...] = (DType.float32,),
+) -> object:
+    """Shared launch path of the in-place foreach mul/add/div fast ops."""
+    unwrapped = _foreach_lists(self, dtypes=dtypes)
+    if unwrapped is None:
+        return NOT_HANDLED
+    lists, dtype = unwrapped
+    if _foreach_mutation_hazard(lists[0], ()):
+        return NOT_HANDLED
+    _foreach_launch(entry, lists, dtype, scalars=values)
     return None
 
 
 def fast_aten__foreach_mul__scalar(
     self: Sequence[torch.Tensor], scalar: AtenScalar
 ) -> object:
-    """Batched homogeneous FP32 in-place multiply by one host scalar."""
+    """Batched homogeneous in-place multiply by one host scalar."""
     value = _foreach_scalar_value(scalar)
     if value is None:
         return NOT_HANDLED
-    return _foreach_scalar_inplace(self, [value] * len(self), _FOREACH_EW_MUL)
-
-
-def _fast__foreach_add__scalar_metal(
-    self: Sequence[torch.Tensor], scalar: AtenScalar
-) -> object:
-    """Batched homogeneous FP32 in-place add of one host scalar."""
-    value = _foreach_scalar_value(scalar)
-    if value is None:
-        return NOT_HANDLED
-    return _foreach_scalar_inplace(self, [value] * len(self), _FOREACH_EW_ADD)
+    return _foreach_scalar_inplace(
+        _FOREACH_MUL, self, [value] * len(self), _FOREACH_WIDENING_DTYPES
+    )
 
 
 def fast_aten__foreach_add__scalar(
     self: Sequence[torch.Tensor], scalar: AtenScalar
 ) -> object:
-    """Batched in-place `t += scalar`: Metal 8-slot path first, then the
-    generic single-launch path (measured on gfx942), else NOT_HANDLED."""
-    result = _fast__foreach_add__scalar_metal(self, scalar)
-    if result is NOT_HANDLED:
-        result = _fast__foreach_add__scalar_generic(self, scalar)
-    return result
+    """Batched homogeneous in-place add of one host scalar.
+
+    Without this ATen runs the CompositeExplicitAutograd fallback, a
+    sequential `add_.Scalar` per element of the list: nanoGPT's fused AdamW
+    bumps 75 one-element step counters per step and would pay 75 launches to
+    add 75 floats.
+    """
+    value = _foreach_scalar_value(scalar)
+    if value is None:
+        return NOT_HANDLED
+    return _foreach_scalar_inplace(
+        _FOREACH_ADD, self, [value] * len(self), _FOREACH_WIDENING_DTYPES
+    )
 
 
 def fast_aten__foreach_div__scalarlist(
     self: Sequence[torch.Tensor], scalars: Sequence[AtenScalar]
 ) -> object:
-    """Batched homogeneous FP32 in-place divide by one scalar per tensor."""
+    """Batched homogeneous FP32 in-place divide by one scalar per tensor.
+
+    FP32 only, unlike mul/add: the per-tensor `div_.Scalar` this replaces
+    divides in the operand dtype (`logic_ops._bin_vec_op`), so widening a
+    half/bfloat16 list to FP32 here would not be the bit-identical result the
+    fallback produces.
+    """
     values = _foreach_scalar_values(scalars, len(self))
     if values is None:
         return NOT_HANDLED
-    return _foreach_scalar_inplace(self, values, _FOREACH_EW_DIV)
+    return _foreach_scalar_inplace(_FOREACH_DIV, self, values)
 
 
 def fast_aten__foreach_lerp__scalar(
@@ -898,11 +873,11 @@ def fast_aten__foreach_lerp__scalar(
     """
     if isinstance(weight, bool) or not isinstance(weight, int | float):
         return NOT_HANDLED
-    lists = _foreach_metal_f32(self, tensors1)
-    if lists is None:
+    unwrapped = _foreach_lists(self, tensors1)
+    if unwrapped is None:
         return NOT_HANDLED
-    tensors, ends = lists
-    if _foreach_mutation_hazard(tensors, (ends,)):
+    lists, dtype = unwrapped
+    if _foreach_mutation_hazard(lists[0], (lists[1],)):
         return NOT_HANDLED
     try:
         narrowed_weight = struct.unpack("=f", struct.pack("=f", weight))[0]
@@ -911,57 +886,31 @@ def fast_aten__foreach_lerp__scalar(
             "value cannot be converted to type float without overflow"
         ) from exc
     one_minus_weight = struct.unpack("=f", struct.pack("=f", 1.0 - narrowed_weight))[0]
-    metadata = tuple(
-        value
-        for tensor, end in zip(tensors, ends, strict=True)
-        for value in (tensor._ptr, end._ptr, tensor._numel)
-    )
-    _call_mojo(
-        _OptimizerExtension,
-        "ForeachLerpScalar",
-        (
-            metadata,
-            narrowed_weight,
-            one_minus_weight,
-            int(abs(narrowed_weight) < 0.5),
-            _ctx_ptr(tensors[0]._device),
-        ),
-        arg_dtypes=(DType.float32, DType.float32),
-        output_dtypes=(DType.float32,),
-        flags={"INPLACE": True, "SMALL_WEIGHT": abs(narrowed_weight) < 0.5},
-        keepalive=(tensors, ends),
+    _foreach_launch(
+        _FOREACH_LERP,
+        lists,
+        dtype,
+        scalars=(narrowed_weight, one_minus_weight),
+        aux=(int(abs(narrowed_weight) < 0.5),),
     )
     return None
 
 
 def _foreach_addc_inplace(
+    entry: str,
     self: Sequence[torch.Tensor],
     tensor1: Sequence[torch.Tensor],
     tensor2: Sequence[torch.Tensor],
     values: Sequence[float],
-    op_code: int,
 ) -> object:
     """Shared launch path of the in-place foreach addcmul/addcdiv fast ops."""
-    lists = _foreach_metal_f32(self, tensor1, tensor2)
-    if lists is None:
+    unwrapped = _foreach_lists(self, tensor1, tensor2)
+    if unwrapped is None:
         return NOT_HANDLED
-    tensors, firsts, seconds = lists
-    if _foreach_mutation_hazard(tensors, (firsts, seconds)):
+    lists, dtype = unwrapped
+    if _foreach_mutation_hazard(lists[0], (lists[1], lists[2])):
         return NOT_HANDLED
-    metadata = tuple(
-        value
-        for tensor, first, second in zip(tensors, firsts, seconds, strict=True)
-        for value in (tensor._ptr, first._ptr, second._ptr, tensor._numel)
-    )
-    _call_mojo(
-        _OptimizerExtension,
-        "ForeachAddcOp",
-        (op_code, metadata, tuple(values), _ctx_ptr(tensors[0]._device)),
-        arg_dtypes=(DType.float32, DType.float32, DType.float32),
-        output_dtypes=(DType.float32,),
-        flags={"INPLACE": True, "OP_CODE": op_code},
-        keepalive=(tensors, firsts, seconds),
-    )
+    _foreach_launch(entry, lists, dtype, scalars=values)
     return None
 
 
@@ -976,7 +925,7 @@ def fast_aten__foreach_addcmul__scalar(
     if scalar is None:
         return NOT_HANDLED
     return _foreach_addc_inplace(
-        self, tensor1, tensor2, [scalar] * len(self), _FOREACH_EW_ADDCMUL
+        _FOREACH_ADDCMUL, self, tensor1, tensor2, [scalar] * len(self)
     )
 
 
@@ -990,31 +939,17 @@ def fast_aten__foreach_addcdiv__scalarlist(
     values = _foreach_scalar_values(scalars, len(self))
     if values is None:
         return NOT_HANDLED
-    return _foreach_addc_inplace(self, tensor1, tensor2, values, _FOREACH_EW_ADDCDIV)
+    return _foreach_addc_inplace(_FOREACH_ADDCDIV, self, tensor1, tensor2, values)
 
 
 def fast_aten__foreach_sqrt(self: Sequence[torch.Tensor]) -> object:
     """Batched homogeneous FP32 out-of-place elementwise square roots."""
-    lists = _foreach_metal_f32(self)
-    if lists is None:
+    unwrapped = _foreach_lists(self)
+    if unwrapped is None:
         return NOT_HANDLED
-    (tensors,) = lists
-    outputs = [
-        _alloc(tensor._shape, DType.float32, tensor._device) for tensor in tensors
-    ]
-    metadata = tuple(
-        value
-        for tensor, output in zip(tensors, outputs, strict=True)
-        for value in (tensor._ptr, output._ptr, tensor._numel)
-    )
-    _call_mojo(
-        _OptimizerExtension,
-        "ForeachSqrt",
-        (metadata, _ctx_ptr(tensors[0]._device)),
-        arg_dtypes=(DType.float32,),
-        output_dtypes=(DType.float32,),
-        keepalive=(tensors, outputs),
-    )
+    (tensors,), dtype = unwrapped
+    outputs = [_alloc(tensor._shape, dtype, tensor._device) for tensor in tensors]
+    _foreach_launch(_FOREACH_SQRT, (tensors, outputs), dtype)
     return outputs
 
 

--- a/torch_mojo_backend/eager_kernels/elementwise_ops/elementwise_ops.mojo
+++ b/torch_mojo_backend/eager_kernels/elementwise_ops/elementwise_ops.mojo
@@ -57,14 +57,6 @@ from std.utils.numerics import isnan
 
 from max.algorithm import elementwise
 
-from foreach_clip_contract import (
-    FOREACH_CHUNK_ELEMENTS,
-    FOREACH_DESC_CAP,
-    FOREACH_THREADS,
-    ForeachDesc,
-    empty_foreach_desc,
-)
-from foreach_clip_kernels import _chunk_bounds
 from op_utils import (
     FLOAT_DTYPES,
     GS_THREADS,
@@ -1193,131 +1185,6 @@ def _scalar_inplace_go[
     return _raw_ret_none()
 
 
-# Ints per tensor in the `ForeachAddScalar` metadata tuple: (address, numel).
-comptime _FOREACH_ADD_FIELDS = 2
-
-
-@__name(t"foreach_add_scalar_{dtype}_v1")
-def _foreach_add_scalar_kernel[
-    dtype: DType
-](
-    descs: InlineArray[ForeachDesc, FOREACH_DESC_CAP],
-    desc_count_arg: Int64,
-    scalar: Float32,
-):
-    """`t += scalar`, in place, for a whole list of tensors in one launch.
-
-    One block per fixed-size chunk across the CONCATENATION of the list, so a
-    list of 75 one-element tensors and a list of one 75-million-element tensor
-    both land on a grid that describes the work rather than the list: the
-    descriptor's `chunk_end` is a running prefix sum of chunk counts, and
-    `_chunk_bounds` walks it to turn a flat block index back into (tensor,
-    range).  The arithmetic is the same widen-add-narrow that
-    `_scalar_elementwise[dtype, SOP_ADD]` does one tensor at a time, so the
-    result is bit-identical to the `add_.Scalar` path this replaces.
-    """
-    # Int is not device-passable (host/device width mismatch); scalars cross
-    # the launch ABI as Int64 and index math stays in Int.
-    var desc_count = Int(desc_count_arg)
-    var chunk = Int(block_idx.x)
-    var desc, begin, end = _chunk_bounds(descs, desc_count, chunk)
-    var values = _make_ptr[dtype](desc.tensor_addr)
-    var index = begin + Int(thread_idx.x)
-    while index < end:
-        values[index] = (
-            values.load[width=1](index).cast[DType.float32]() + scalar
-        ).cast[dtype]()[0]
-        index += FOREACH_THREADS
-
-
-def _foreach_add_scalar_go(
-    metadata_o: PyObjectPtr,
-    scalar_o: PyObjectPtr,
-    dtype_o: PyObjectPtr,
-    ctx_o: PyObjectPtr,
-) raises -> PyObjectPtr:
-    """`aten::_foreach_add_.Scalar` for one contiguous float dtype.
-
-    Without a PrivateUse1 entry ATen runs the CompositeExplicitAutograd
-    fallback, which is a Python-level loop of `add_.Scalar`: nanoGPT's fused
-    AdamW bumps 75 one-element step counters per step and pays 75 launches for
-    75 additions.  The whole list is one launch here.
-    """
-    var dtype = _raw_dtype_int(dtype_o)
-    var supported = False
-    comptime for dt in FLOAT_DTYPES:
-        if dtype == dt:
-            supported = True
-    if not supported:
-        raise Error("mojo foreach add scalar: unsupported dtype ", dtype)
-    var fields = _raw_tuple_len(metadata_o)
-    if fields % _FOREACH_ADD_FIELDS != 0:
-        raise Error("mojo foreach add scalar: malformed metadata tuple")
-    var record_count = fields // _FOREACH_ADD_FIELDS
-    # ATen's mutable-TensorList contract is all-or-nothing, so every record is
-    # validated before the first launch rather than as it is consumed.
-    for record in range(record_count):
-        var base = record * _FOREACH_ADD_FIELDS
-        if _raw_tuple_int(metadata_o, base + 1) < 0:
-            raise Error("mojo foreach add scalar: negative numel")
-        if (
-            _raw_tuple_int(metadata_o, base + 1) > 0
-            and _raw_tuple_int(metadata_o, base) == 0
-        ):
-            raise Error("mojo foreach add scalar: null pointer")
-    var scalar = Float32(_raw_f64(scalar_o))
-    var ctx = _raw_ctx(ctx_o)
-
-    var record = 0
-    while record < record_count:
-        # `FOREACH_DESC_CAP` bounds ONE launch argument, not the list: a longer
-        # list is several launches of the same compiled kernel.
-        var descs = InlineArray[ForeachDesc, FOREACH_DESC_CAP](
-            fill=empty_foreach_desc()
-        )
-        var desc_count = 0
-        var total_chunks = 0
-        while record < record_count and desc_count < FOREACH_DESC_CAP:
-            var base = record * _FOREACH_ADD_FIELDS
-            var numel = _raw_tuple_int(metadata_o, base + 1)
-            if numel > 0:
-                total_chunks += ceildiv(numel, FOREACH_CHUNK_ELEMENTS)
-            descs[desc_count] = ForeachDesc(
-                _raw_tuple_int(metadata_o, base), 0, numel, total_chunks
-            )
-            record += 1
-            desc_count += 1
-        if total_chunks > 0:
-            comptime for dt in FLOAT_DTYPES:
-                if dtype == dt:
-                    _enqueue_cached[_foreach_add_scalar_kernel[dt]](
-                        ctx,
-                        String(t"foreach_add_scalar_{dt}_v1"),
-                        total_chunks,
-                        1,
-                        1,
-                        FOREACH_THREADS,
-                        descs,
-                        Int64(desc_count),
-                        scalar,
-                    )
-    return _raw_ret_none()
-
-
-def _foreach_add_scalar_dispatcher(
-    py_self: PyObjectPtr,
-    args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
-    nargs: Py_ssize_t,
-) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
-    try:
-        if nargs != 4:
-            raise Error("ForeachAddScalar expects exactly four arguments")
-        return _foreach_add_scalar_go(args[0], args[1], args[2], args[3])
-    except e:
-        return _spec_unsupported(e)
-
-
 def _scalar_inplace_dispatcher[
     op_code: Int
 ](
@@ -1675,15 +1542,6 @@ def PyInit_elementwise_ops() abi("C") -> PythonObject:
                 _scalar_inplace_dispatcher[SOP_MUL],
                 docstring=(
                     "(a_spec, scalar) -> None; a *= scalar, contiguous float"
-                ),
-            )
-        comptime if _op_on["ForeachAddScalar"]():
-            _register_call(
-                b,
-                _foreach_add_scalar_dispatcher,
-                docstring=(
-                    "((addr, numel) * n, scalar, dtype, ctx) -> None; "
-                    "aten::_foreach_add_.Scalar over one contiguous float dtype"
                 ),
             )
         comptime if _op_on["AddScalarIntSpec"]():

--- a/torch_mojo_backend/eager_kernels/foreach_batched_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/foreach_batched_kernels.mojo
@@ -1,0 +1,599 @@
+"""One descriptor-batched kernel body for the whole foreach elementwise family.
+
+`aten::_foreach_*` is a list-of-tensors op: the same elementwise math applied
+to every tensor of a TensorList. Running it as one ATen call per tensor is
+dispatch bound (an optimizer step touches dozens of parameters), so the list
+has to become ONE launch, and the grid has to describe the WORK rather than
+the list.
+
+This file is that single implementation. `_foreach_ew_kernel` is
+comptime-parametrized by
+
+  * `dtype` -- any of `op_utils.FLOAT_DTYPES`; every op computes in FP32 and
+    narrows back, which is exactly what the sequential `elementwise_ops` /
+    `logic_ops` kernels these paths replace do, so the batched result stays
+    bit-compatible with the per-tensor decomposition;
+  * `op` -- which element math to apply: mul/add/div by a host scalar (one per
+    tensor, so `.Scalar` and `.ScalarList` are the same code), multiply by a
+    device-resident scalar tensor, scalar lerp, addcmul, addcdiv, sqrt.
+
+Every tensor is cut into `chunk_elements`-sized chunks and one block takes one
+chunk, with the descriptor's `chunk_end` a running prefix sum of chunk counts
+so a flat block index maps back to (tensor, element range).
+
+`chunk_elements` is a runtime launch argument, and that is the whole
+performance story of this file: a chunk fixed at 65_536 elements gives a
+four-tensor, 1M-elements-each list 64 blocks, which leaves more than half of
+an H100's 114 SMs idle for the entire launch, and gives a sixteen-tensor
+64k-elements-each list 16 blocks. Sizing the chunk from the element count and
+the SM count instead puts both on a few hundred blocks. Being a launch
+argument and not a compile-time parameter, every shape reuses one compiled
+kernel -- no shape is baked in anywhere.
+
+Apple GPUs cannot take this route at all: Metal only translates pointer-typed
+kernel *arguments* into GPU addresses, so a descriptor carrying raw addresses
+reads back as zeros (measured; see `foreach_elementwise_kernels`).
+`_foreach_ew_enqueue` therefore regroups the very same descriptors into that
+file's fixed-arity Metal launches on Apple, and takes the descriptor route
+everywhere else.
+"""
+
+from std.builtin.device_passable import DevicePassable, DeviceTypeEncoder
+from std.collections import InlineArray
+from std.gpu import block_idx, thread_idx
+from max.gpu.host import DeviceContext
+from std.math import ceildiv, min
+from std.sys.info import has_apple_gpu_accelerator, size_of
+
+from foreach_elementwise_kernels import (
+    FEA_ADDCDIV,
+    FEA_ADDCMUL,
+    FES_ADD,
+    FES_DIV,
+    FES_MUL,
+    FOREACH_EW_CHUNK,
+    FOREACH_EW_SLOTS,
+    enqueue_foreach_addc_f32,
+    enqueue_foreach_lerp_f32,
+    enqueue_foreach_mul_tensor_f32,
+    enqueue_foreach_scalar_f32,
+    enqueue_foreach_sqrt_f32,
+)
+from op_utils import _enqueue_cached, _make_ptr, _device_sm_count, ieee_sqrt
+
+
+# Element math selectors. `.Scalar` and `.ScalarList` share a code: the scalar
+# is per tensor either way.
+comptime FEW_MUL = 0  # self *= scalar[i]
+comptime FEW_ADD = 1  # self += scalar[i]
+comptime FEW_DIV = 2  # self /= scalar[i]
+comptime FEW_MUL_TENSOR = 3  # self *= *scalar_addr (a 0-d device tensor)
+comptime FEW_LERP = 4  # self = lerp(self, end, weight)
+comptime FEW_ADDCMUL = 5  # self += scalar[i] * (t1 * t2)
+comptime FEW_ADDCDIV = 6  # self += scalar[i] * (t1 / t2)
+comptime FEW_SQRT = 7  # out = sqrt(in), the one out-of-place member
+
+comptime FEW_THREADS = 256
+
+# Blocks per SM the chunk size aims for. Swept on an H100 PCIe (114 SMs, FP32),
+# ours/stock device time on `benchmarks/test_foreach.py`:
+#                        2       4       8
+#   mul_      4x1M    0.880   0.842   0.884
+#   mul_      16x64k  0.390   0.391   0.596
+#   addcmul_  4x1M    0.856   0.816   0.762
+#   addcmul_  16x64k  0.412   0.438   0.651
+# 8 starves the many-small-tensors regime (its chunk hits FEW_MIN_CHUNK, so each
+# block does one vector step and the descriptor scan dominates); 2 gives up the
+# big-tensor cases. Fitted on this card, but derived from the RUNTIME SM count,
+# so a smaller or larger GPU scales with it rather than inheriting a grid.
+comptime FEW_BLOCKS_PER_SM = 4
+
+# The chunk size is rounded down to a multiple of this many elements, which
+# keeps every chunk boundary 16-byte aligned for every dtype here (512 * 2
+# bytes is the smallest case) so only a tensor's base pointer can be
+# misaligned.
+comptime FEW_CHUNK_GRAIN = 512
+comptime FEW_MIN_CHUNK = 1024
+# A ceiling only bounds per-block work; nothing depends on the exact value.
+comptime FEW_MAX_CHUNK = 65_536
+
+# Descriptors per launch. This bounds ONE launch argument, not the list: a
+# longer TensorList becomes several launches of the same compiled kernel.
+comptime FEW_DESC_CAP = 64
+
+
+@always_inline
+def _few_addrs[op: Int]() -> Int:
+    """Device addresses one metadata record carries for `op`."""
+    comptime if op == FEW_LERP or op == FEW_SQRT:
+        return 2
+    elif op == FEW_ADDCMUL or op == FEW_ADDCDIV:
+        return 3
+    else:
+        return 1
+
+
+@always_inline
+def _few_fields[op: Int]() -> Int:
+    """Ints one metadata record carries: the addresses then the numel."""
+    return _few_addrs[op]() + 1
+
+
+@always_inline
+def _few_has_scalar[op: Int]() -> Bool:
+    """Whether `op` takes one host scalar per tensor."""
+    comptime if (
+        op == FEW_MUL
+        or op == FEW_ADD
+        or op == FEW_DIV
+        or op == FEW_ADDCMUL
+        or op == FEW_ADDCDIV
+    ):
+        return True
+    else:
+        return False
+
+
+@always_inline
+def _few_label[op: Int]() -> StaticString:
+    """Algorithm-and-regime fragment of the kernel name a profiler prints."""
+    comptime if op == FEW_MUL:
+        return "mul_scalar"
+    elif op == FEW_ADD:
+        return "add_scalar"
+    elif op == FEW_DIV:
+        return "div_scalar"
+    elif op == FEW_MUL_TENSOR:
+        return "mul_device_scalar"
+    elif op == FEW_LERP:
+        return "lerp_scalar"
+    elif op == FEW_ADDCMUL:
+        return "addcmul"
+    elif op == FEW_ADDCDIV:
+        return "addcdiv"
+    else:
+        return "sqrt"
+
+
+struct ForeachEwDesc(
+    DevicePassable,
+    ImplicitlyCopyable,
+    TrivialRegisterPassable,
+):
+    """One tensor of the list: its addresses, length, and chunk prefix sum.
+
+    `addr1` / `addr2` are the extra operands (unused ones stay zero and are
+    never dereferenced: which addresses an op reads is a compile-time fact).
+    """
+
+    comptime device_type: AnyType = Self
+
+    var addr0: Int
+    var addr1: Int
+    var addr2: Int
+    var numel: Int
+    var chunk_end: Int
+
+    def __init__(
+        out self, addr0: Int, addr1: Int, addr2: Int, numel: Int, chunk_end: Int
+    ):
+        self.addr0 = addr0
+        self.addr1 = addr1
+        self.addr2 = addr2
+        self.numel = numel
+        self.chunk_end = chunk_end
+
+    def _to_device_type(
+        self,
+        mut encoder: Some[DeviceTypeEncoder],
+        target: MutOpaquePointer[_],
+    ):
+        encoder.encode(self, target)
+
+    @staticmethod
+    def get_type_name() -> String:
+        return "ForeachEwDesc"
+
+
+@always_inline
+def empty_foreach_ew_desc() -> ForeachEwDesc:
+    return ForeachEwDesc(0, 0, 0, 0, 0)
+
+
+@always_inline
+def _few_element[
+    dtype: DType, op: Int, width: Int, alignment: Int
+](
+    a_ptr: UnsafePointer[Scalar[dtype], MutUntrackedOrigin],
+    b_ptr: UnsafePointer[Scalar[dtype], MutUntrackedOrigin],
+    c_ptr: UnsafePointer[Scalar[dtype], MutUntrackedOrigin],
+    out_ptr: UnsafePointer[Scalar[dtype], MutUntrackedOrigin],
+    index: Int,
+    scalar: Float32,
+    weight: Float32,
+    one_minus_weight: Float32,
+    low_branch: Int,
+):
+    """`width` elements of one op at `index`, computed in FP32.
+
+    The single definition of every op's element math. Both the vectorized body
+    and the scalar peel/tail of `_foreach_ew_kernel` are calls to this, and so
+    is nothing else: an op's arithmetic exists once.
+    """
+    var a = a_ptr.load[width=width, alignment=alignment](index).cast[
+        DType.float32
+    ]()
+    var result = a
+    comptime if op == FEW_MUL or op == FEW_MUL_TENSOR:
+        result = a * scalar
+    elif op == FEW_ADD:
+        result = a + scalar
+    elif op == FEW_DIV:
+        result = a / scalar
+    elif op == FEW_SQRT:
+        result = ieee_sqrt(a)
+    elif op == FEW_LERP:
+        # ATen's numerically stable branch pair, selected on the host exactly
+        # like `fast_aten_lerp` does. The scale-and-add is written as one
+        # expression, so the backend may contract it into an fma -- which is
+        # what ATen's own CUDA lerp kernel compiles to, and at most one ulp
+        # from the two-kernel sequential composition this replaces. (The
+        # Metal path in `foreach_elementwise_kernels` blocks that contraction
+        # with `_no_fuse`; the volatile round-trip it needs is not worth
+        # paying here for one ulp.)
+        var finish = b_ptr.load[width=width, alignment=alignment](index).cast[
+            DType.float32
+        ]()
+        var difference = finish - a
+        if low_branch == 0:
+            result = finish - one_minus_weight * difference
+        else:
+            result = a + weight * difference
+    else:
+        var b = b_ptr.load[width=width, alignment=alignment](index).cast[
+            DType.float32
+        ]()
+        var c = c_ptr.load[width=width, alignment=alignment](index).cast[
+            DType.float32
+        ]()
+        comptime if op == FEW_ADDCMUL:
+            result = a + scalar * (b * c)
+        else:
+            result = a + scalar * (b / c)
+    out_ptr.store[width=width, alignment=alignment](index, result.cast[dtype]())
+
+
+@__name(t"foreach_{_few_label[op]()}_desc_{dtype}_t{FEW_THREADS}")
+def _foreach_ew_kernel[
+    dtype: DType, op: Int
+](
+    descs: InlineArray[ForeachEwDesc, FEW_DESC_CAP],
+    scalars: InlineArray[Float32, FEW_DESC_CAP],
+    desc_count_arg: Int64,
+    chunk_elements_arg: Int64,
+    scalar_addr_arg: Int64,
+    weight: Float32,
+    one_minus_weight: Float32,
+    low_branch_arg: Int64,
+):
+    """One block per chunk of the concatenation of the list."""
+    # Int is not device-passable (host/device width mismatch); scalars cross
+    # the launch ABI as Int64 and index math stays in Int.
+    var desc_count = Int(desc_count_arg)
+    var chunk_elements = Int(chunk_elements_arg)
+    var low_branch = Int(low_branch_arg)
+
+    var chunk = Int(block_idx.x)
+    var desc_index = 0
+    while desc_index + 1 < desc_count and chunk >= descs[desc_index].chunk_end:
+        desc_index += 1
+    var desc = descs[desc_index]
+    var first_chunk = 0
+    if desc_index != 0:
+        first_chunk = descs[desc_index - 1].chunk_end
+    var begin = (chunk - first_chunk) * chunk_elements
+    var end = min(begin + chunk_elements, desc.numel)
+
+    var scalar = Float32(0.0)
+    comptime if _few_has_scalar[op]():
+        scalar = scalars[desc_index]
+    comptime if op == FEW_MUL_TENSOR:
+        scalar = _make_ptr[dtype](Int(scalar_addr_arg))[0].cast[DType.float32]()
+
+    var a_ptr = _make_ptr[dtype](desc.addr0)
+    var b_ptr = _make_ptr[dtype](desc.addr1)
+    var c_ptr = _make_ptr[dtype](desc.addr2)
+    var out_ptr = a_ptr
+    comptime if op == FEW_SQRT:
+        out_ptr = b_ptr
+
+    # 16-byte accesses need a 16-byte-aligned address, and a contiguous
+    # tensor may be an offset view of one. Every chunk boundary is 16-byte
+    # aligned (FEW_CHUNK_GRAIN), so one peel of at most 16 bytes per chunk
+    # lands the vector body on a boundary -- as long as all of the op's
+    # operands share the base residue, which co-allocated tensor lists do.
+    comptime item = size_of[dtype]()
+    comptime vector = 16 // item
+    var residue = desc.addr0 % 16
+    var vectorizable = residue % item == 0
+    comptime if _few_addrs[op]() >= 2:
+        if desc.addr1 % 16 != residue:
+            vectorizable = False
+    comptime if _few_addrs[op]() >= 3:
+        if desc.addr2 % 16 != residue:
+            vectorizable = False
+
+    var lane = Int(thread_idx.x)
+    if vectorizable:
+        var body = begin + min(((16 - residue) % 16) // item, end - begin)
+        var head = begin + lane
+        while head < body:
+            _few_element[dtype, op, 1, item](
+                a_ptr,
+                b_ptr,
+                c_ptr,
+                out_ptr,
+                head,
+                scalar,
+                weight,
+                one_minus_weight,
+                low_branch,
+            )
+            head += FEW_THREADS
+        var index = body + lane * vector
+        while index + vector <= end:
+            _few_element[dtype, op, vector, 16](
+                a_ptr,
+                b_ptr,
+                c_ptr,
+                out_ptr,
+                index,
+                scalar,
+                weight,
+                one_minus_weight,
+                low_branch,
+            )
+            index += FEW_THREADS * vector
+        var tail = body + ((end - body) // vector) * vector + lane
+        while tail < end:
+            _few_element[dtype, op, 1, item](
+                a_ptr,
+                b_ptr,
+                c_ptr,
+                out_ptr,
+                tail,
+                scalar,
+                weight,
+                one_minus_weight,
+                low_branch,
+            )
+            tail += FEW_THREADS
+    else:
+        var index = begin + lane
+        while index < end:
+            _few_element[dtype, op, 1, item](
+                a_ptr,
+                b_ptr,
+                c_ptr,
+                out_ptr,
+                index,
+                scalar,
+                weight,
+                one_minus_weight,
+                low_branch,
+            )
+            index += FEW_THREADS
+
+
+def foreach_ew_chunk_elements(total_elements: Int, ctx: DeviceContext) -> Int:
+    """Elements per block: the whole list's work spread over the whole device.
+
+    Apple keeps the fixed chunk its fixed-arity kernels are written against.
+    """
+    comptime if has_apple_gpu_accelerator():
+        return FOREACH_EW_CHUNK
+    else:
+        var blocks = FEW_BLOCKS_PER_SM * _device_sm_count(ctx)
+        var chunk = (
+            ceildiv(total_elements, blocks) if blocks > 0 else total_elements
+        )
+        chunk = (chunk // FEW_CHUNK_GRAIN) * FEW_CHUNK_GRAIN
+        if chunk < FEW_MIN_CHUNK:
+            chunk = FEW_MIN_CHUNK
+        return min(chunk, FEW_MAX_CHUNK)
+
+
+@always_inline
+def _few_backfill(
+    mut addrs: InlineArray[Int, FOREACH_EW_SLOTS], slot_count: Int
+):
+    """Give empty/padding slots a valid dummy address (never dereferenced:
+    those slots own zero chunks). Metal still requires every pointer-typed
+    argument to translate to a real buffer."""
+    var first_addr = 0
+    for slot in range(slot_count):
+        if addrs[slot] != 0:
+            first_addr = addrs[slot]
+            break
+    for slot in range(FOREACH_EW_SLOTS):
+        if addrs[slot] == 0:
+            addrs[slot] = first_addr
+
+
+def _foreach_ew_enqueue_apple[
+    dtype: DType, op: Int
+](
+    descs: InlineArray[ForeachEwDesc, FEW_DESC_CAP],
+    scalars: InlineArray[Float32, FEW_DESC_CAP],
+    desc_count: Int,
+    scalar_addr: Int,
+    weight: Float32,
+    one_minus_weight: Float32,
+    low_branch: Int,
+    ctx: DeviceContext,
+) raises:
+    """Same descriptors, Metal's fixed-arity ABI: FOREACH_EW_SLOTS tensors per
+    launch, every pointer a real kernel argument."""
+    comptime if dtype != DType.float32:
+        raise Error("mojo foreach: the Apple batched path is float32 only")
+    else:
+        var desc_index = 0
+        while desc_index < desc_count:
+            var group_first_chunk = 0
+            if desc_index != 0:
+                group_first_chunk = descs[desc_index - 1].chunk_end
+            var first_addrs = InlineArray[Int, FOREACH_EW_SLOTS](fill=0)
+            var second_addrs = InlineArray[Int, FOREACH_EW_SLOTS](fill=0)
+            var third_addrs = InlineArray[Int, FOREACH_EW_SLOTS](fill=0)
+            var chunk_ends = InlineArray[Int, FOREACH_EW_SLOTS](fill=0)
+            var numels = InlineArray[Int, FOREACH_EW_SLOTS](fill=0)
+            var group_scalars = InlineArray[Float32, FOREACH_EW_SLOTS](fill=0.0)
+            var slot = 0
+            while desc_index < desc_count and slot < FOREACH_EW_SLOTS:
+                var desc = descs[desc_index]
+                first_addrs[slot] = desc.addr0
+                second_addrs[slot] = desc.addr1
+                third_addrs[slot] = desc.addr2
+                numels[slot] = desc.numel
+                chunk_ends[slot] = desc.chunk_end - group_first_chunk
+                group_scalars[slot] = scalars[desc_index]
+                desc_index += 1
+                slot += 1
+            var used_slots = slot
+            var group_chunks = chunk_ends[used_slots - 1]
+            while slot < FOREACH_EW_SLOTS:
+                chunk_ends[slot] = group_chunks
+                slot += 1
+            if group_chunks == 0:
+                continue
+            _few_backfill(first_addrs, used_slots)
+            comptime if _few_addrs[op]() >= 2:
+                _few_backfill(second_addrs, used_slots)
+            comptime if _few_addrs[op]() >= 3:
+                _few_backfill(third_addrs, used_slots)
+
+            comptime if op == FEW_MUL:
+                enqueue_foreach_scalar_f32[FES_MUL](
+                    first_addrs,
+                    chunk_ends,
+                    numels,
+                    group_scalars,
+                    group_chunks,
+                    ctx,
+                )
+            elif op == FEW_ADD:
+                enqueue_foreach_scalar_f32[FES_ADD](
+                    first_addrs,
+                    chunk_ends,
+                    numels,
+                    group_scalars,
+                    group_chunks,
+                    ctx,
+                )
+            elif op == FEW_DIV:
+                enqueue_foreach_scalar_f32[FES_DIV](
+                    first_addrs,
+                    chunk_ends,
+                    numels,
+                    group_scalars,
+                    group_chunks,
+                    ctx,
+                )
+            elif op == FEW_MUL_TENSOR:
+                enqueue_foreach_mul_tensor_f32(
+                    first_addrs,
+                    chunk_ends,
+                    numels,
+                    scalar_addr,
+                    group_chunks,
+                    ctx,
+                )
+            elif op == FEW_LERP:
+                enqueue_foreach_lerp_f32(
+                    first_addrs,
+                    second_addrs,
+                    chunk_ends,
+                    numels,
+                    weight,
+                    one_minus_weight,
+                    low_branch,
+                    group_chunks,
+                    ctx,
+                )
+            elif op == FEW_ADDCMUL:
+                enqueue_foreach_addc_f32[FEA_ADDCMUL](
+                    first_addrs,
+                    second_addrs,
+                    third_addrs,
+                    chunk_ends,
+                    numels,
+                    group_scalars,
+                    group_chunks,
+                    ctx,
+                )
+            elif op == FEW_ADDCDIV:
+                enqueue_foreach_addc_f32[FEA_ADDCDIV](
+                    first_addrs,
+                    second_addrs,
+                    third_addrs,
+                    chunk_ends,
+                    numels,
+                    group_scalars,
+                    group_chunks,
+                    ctx,
+                )
+            else:
+                enqueue_foreach_sqrt_f32(
+                    first_addrs,
+                    second_addrs,
+                    chunk_ends,
+                    numels,
+                    group_chunks,
+                    ctx,
+                )
+
+
+def foreach_ew_enqueue[
+    dtype: DType, op: Int
+](
+    descs: InlineArray[ForeachEwDesc, FEW_DESC_CAP],
+    scalars: InlineArray[Float32, FEW_DESC_CAP],
+    desc_count: Int,
+    total_chunks: Int,
+    chunk_elements: Int,
+    scalar_addr: Int,
+    weight: Float32,
+    one_minus_weight: Float32,
+    low_branch: Int,
+    ctx: DeviceContext,
+) raises:
+    if desc_count <= 0 or total_chunks <= 0:
+        return
+    comptime if has_apple_gpu_accelerator():
+        _foreach_ew_enqueue_apple[dtype, op](
+            descs,
+            scalars,
+            desc_count,
+            scalar_addr,
+            weight,
+            one_minus_weight,
+            low_branch,
+            ctx,
+        )
+    else:
+        _enqueue_cached[_foreach_ew_kernel[dtype, op]](
+            ctx,
+            String(t"FOREACH_EW_{op}_{dtype}_V1"),
+            total_chunks,
+            1,
+            1,
+            FEW_THREADS,
+            descs,
+            scalars,
+            Int64(desc_count),
+            Int64(chunk_elements),
+            Int64(scalar_addr),
+            weight,
+            one_minus_weight,
+            Int64(low_branch),
+        )

--- a/torch_mojo_backend/eager_kernels/foreach_clip_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/foreach_clip_kernels.mojo
@@ -25,9 +25,11 @@ from foreach_clip_contract import (
 from foreach_elementwise_kernels import (
     FOREACH_EW_CHUNK,
     FOREACH_EW_SLOTS,
+    _SlotInts,
     _pick_immut,
     _pick_mut,
     _slot_begin,
+    _slot_ints,
 )
 from op_utils import _enqueue_cached, ieee_sqrt
 
@@ -149,12 +151,12 @@ def _norm_partials_batched_apple(
     v5: _ImmutPtr,
     v6: _ImmutPtr,
     v7: _ImmutPtr,
-    chunk_ends: InlineArray[Int, FOREACH_EW_SLOTS],
-    numels: InlineArray[Int, FOREACH_EW_SLOTS],
+    chunk_ends: _SlotInts,
+    numels: _SlotInts,
 ):
     comptime assert FOREACH_CHUNK_ELEMENTS == FOREACH_EW_CHUNK
     var slot, begin = _slot_begin(chunk_ends, Int(block_idx.x))
-    var end = min(begin + FOREACH_CHUNK_ELEMENTS, numels[slot])
+    var end = min(begin + FOREACH_CHUNK_ELEMENTS, Int(numels[slot]))
     var values = _pick_immut(slot, v0, v1, v2, v3, v4, v5, v6, v7)
     var accum = SIMD[DType.float32, _VEC](0.0)
     var index = begin + Int(thread_idx.x) * _VEC
@@ -190,7 +192,7 @@ def _norm_finalize_batched_apple(
     o6: _MutPtr,
     o7: _MutPtr,
     partials_ptr: _ImmutPtr,
-    chunk_ends: InlineArray[Int, FOREACH_EW_SLOTS],
+    chunk_ends: _SlotInts,
     used_slots_arg: Int64,
 ):
     # Int is not device-passable (host/device width mismatch); scalars cross
@@ -201,10 +203,10 @@ def _norm_finalize_batched_apple(
         return
     var first_chunk = 0
     if slot != 0:
-        first_chunk = chunk_ends[slot - 1]
+        first_chunk = Int(chunk_ends[slot - 1])
     var accum = Float32(0.0)
     for chunk in range(
-        first_chunk + Int(thread_idx.x), chunk_ends[slot], FOREACH_THREADS
+        first_chunk + Int(thread_idx.x), Int(chunk_ends[slot]), FOREACH_THREADS
     ):
         accum += partials_ptr[chunk]
     var total = block.sum[block_size=FOREACH_THREADS, broadcast=False](accum)
@@ -345,8 +347,8 @@ def enqueue_foreach_l2_norm_f32(
                     _ptr(in_addrs[5]).as_unsafe_any_origin().as_immutable(),
                     _ptr(in_addrs[6]).as_unsafe_any_origin().as_immutable(),
                     _ptr(in_addrs[7]).as_unsafe_any_origin().as_immutable(),
-                    chunk_ends,
-                    numels,
+                    _slot_ints(chunk_ends),
+                    _slot_ints(numels),
                 )
             _enqueue_cached[_norm_finalize_batched_apple](
                 ctx,
@@ -364,7 +366,7 @@ def enqueue_foreach_l2_norm_f32(
                 _ptr(out_addrs[6]).as_unsafe_any_origin(),
                 _ptr(out_addrs[7]).as_unsafe_any_origin(),
                 partials.as_immutable(),
-                chunk_ends,
+                _slot_ints(chunk_ends),
                 Int64(used_slots),
             )
     else:

--- a/torch_mojo_backend/eager_kernels/foreach_clip_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/foreach_clip_kernels.mojo
@@ -1,9 +1,10 @@
-"""Runtime-dynamic pure-Mojo FP32 foreach clipping kernels.
+"""Runtime-dynamic pure-Mojo FP32 foreach L2-norm kernels.
 
 Norms use a two-stage reduction. A fixed-size chunk is reduced by one block
 into caller-owned scratch, then one block per tensor reduces its chunk
-partials and writes the ordered scalar result. Multiplication uses the same
-runtime chunk descriptors and applies the device-resident scalar in place.
+partials and writes the ordered scalar result. The rescaling multiply that
+follows a norm is not here: it is `aten::_foreach_mul_.Tensor`, one member of
+the elementwise family `foreach_batched_kernels` serves.
 """
 
 from std.collections import InlineArray
@@ -32,8 +33,6 @@ from op_utils import _enqueue_cached, ieee_sqrt
 
 
 comptime _VEC = 4
-comptime _MUL_THREADS = 128
-comptime _MUL_ILP = 8
 
 
 @always_inline
@@ -214,103 +213,6 @@ def _norm_finalize_batched_apple(
         out_ptr[0] = ieee_sqrt(total)
 
 
-def _mul_tensor_batched_apple(
-    p0: _MutPtr,
-    p1: _MutPtr,
-    p2: _MutPtr,
-    p3: _MutPtr,
-    p4: _MutPtr,
-    p5: _MutPtr,
-    p6: _MutPtr,
-    p7: _MutPtr,
-    scalar_ptr: _ImmutPtr,
-    chunk_ends: InlineArray[Int, FOREACH_EW_SLOTS],
-    numels: InlineArray[Int, FOREACH_EW_SLOTS],
-):
-    var scalar = scalar_ptr[0]
-    var slot, begin = _slot_begin(chunk_ends, Int(block_idx.x))
-    var end = min(begin + FOREACH_CHUNK_ELEMENTS, numels[slot])
-    var values = _pick_mut(slot, p0, p1, p2, p3, p4, p5, p6, p7)
-    var index = begin + Int(thread_idx.x) * _VEC
-    var stride = FOREACH_THREADS * _VEC
-    while index + _VEC <= end:
-        var value = values.load[width=_VEC, alignment=4](index)
-        values.store[width=_VEC, alignment=4](index, value * scalar)
-        index += stride
-
-    index = begin + ((end - begin) // _VEC) * _VEC + Int(thread_idx.x)
-    while index < end:
-        values[index] = values[index] * scalar
-        index += FOREACH_THREADS
-
-
-@__name("foreach_mul_tensor_f32_aligned_streaming_ilp8_t128_v8")
-def _mul_aligned_streaming_ilp8_t128(
-    descs: InlineArray[ForeachDesc, FOREACH_DESC_CAP],
-    desc_count_arg: Int64,
-    scalar_addr_arg: Int64,
-):
-    # Int is not device-passable (host/device width mismatch); scalars cross
-    # the launch ABI as Int64 and index math stays in Int.
-    var desc_count = Int(desc_count_arg)
-    var scalar_addr = Int(scalar_addr_arg)
-    var chunk = Int(block_idx.x)
-    var desc, begin, end = _chunk_bounds(descs, desc_count, chunk)
-    var values = _ptr(desc.tensor_addr)
-    var scalar = _ptr(scalar_addr)[0]
-    var tid = Int(thread_idx.x)
-
-    # Each descriptor may start at any four-byte alignment. Peeling at most
-    # 31 values makes the first full warp access begin on a 128-byte boundary;
-    # all following warp accesses then use exactly four 32-byte sectors instead
-    # of five. Since the fixed chunk is a multiple of 128 bytes, the same
-    # bounded peel applies independently to every chunk.
-    var address = desc.tensor_addr + begin * 4
-    var prefix = ((128 - address % 128) % 128) // 4
-    var body_begin = min(begin + prefix, end)
-    var prefix_index = begin + tid
-    if prefix_index < body_begin:
-        var prefix_value = values.load[width=1, alignment=4, non_temporal=True](
-            prefix_index
-        )[0]
-        values.store[width=1, alignment=4, non_temporal=True](
-            prefix_index, SIMD[DType.float32, 1](prefix_value * scalar)
-        )
-
-    var index = body_begin + tid
-    var stride = _MUL_THREADS * _MUL_ILP
-    while index + (_MUL_ILP - 1) * _MUL_THREADS < end:
-        var loaded = SIMD[DType.float32, _MUL_ILP]()
-        comptime for u in range(_MUL_ILP):
-            loaded[u] = values.load[
-                width=1,
-                alignment=4,
-                non_temporal=True,
-            ](
-                index + u * _MUL_THREADS
-            )[0]
-        loaded *= scalar
-        comptime for u in range(_MUL_ILP):
-            values.store[width=1, alignment=4, non_temporal=True](
-                index + u * _MUL_THREADS,
-                SIMD[DType.float32, 1](loaded[u]),
-            )
-        index += stride
-
-    while index < end:
-        var value = values.load[
-            width=1,
-            alignment=4,
-            non_temporal=True,
-        ](
-            index
-        )[0]
-        values.store[width=1, alignment=4, non_temporal=True](
-            index, SIMD[DType.float32, 1](value * scalar)
-        )
-        index += _MUL_THREADS
-
-
 def _enqueue_norm_partials_cached(
     descs: InlineArray[ForeachDesc, FOREACH_DESC_CAP],
     desc_count: Int,
@@ -379,44 +281,6 @@ def _enqueue_norm_finalize_cached(
         Int64(partials_addr),
         grid_dim=(desc_count,),
         block_dim=(FOREACH_THREADS,),
-    )
-
-
-def _enqueue_mul_cached(
-    descs: InlineArray[ForeachDesc, FOREACH_DESC_CAP],
-    desc_count: Int,
-    total_chunks: Int,
-    scalar_addr: Int,
-    ctx: DeviceContext,
-) raises:
-    var cache_name = String(t"FOREACH_MUL_TENSOR_F32_V1_{ctx.id()}")
-    comptime FuncT = type_of(
-        ctx.compile_function[_mul_aligned_streaming_ilp8_t128]()
-    )
-    if global_ptr := _get_global_or_null(cache_name):
-        var cached = global_ptr.value().bitcast[FuncT]()
-        ctx.enqueue_function(
-            cached[],
-            descs,
-            Int64(desc_count),
-            Int64(scalar_addr),
-            grid_dim=(total_chunks,),
-            block_dim=(_MUL_THREADS,),
-        )
-        return
-    var compiled = ctx.compile_function[_mul_aligned_streaming_ilp8_t128]()
-    var cached = alloc[FuncT](1)
-    cached.init_pointee_move(compiled^)
-    external_call["KGEN_CompilerRT_InsertGlobal", NoneType](
-        StringSlice(cache_name), cached.bitcast[NoneType]()
-    )
-    ctx.enqueue_function(
-        cached[],
-        descs,
-        Int64(desc_count),
-        Int64(scalar_addr),
-        grid_dim=(total_chunks,),
-        block_dim=(_MUL_THREADS,),
     )
 
 
@@ -509,64 +373,3 @@ def enqueue_foreach_l2_norm_f32(
                 descs, desc_count, total_chunks, partials_addr, ctx
             )
         _enqueue_norm_finalize_cached(descs, desc_count, partials_addr, ctx)
-
-
-def enqueue_foreach_mul_tensor_f32(
-    descs: InlineArray[ForeachDesc, FOREACH_DESC_CAP],
-    desc_count: Int,
-    total_chunks: Int,
-    scalar_addr: Int,
-    ctx: DeviceContext,
-) raises:
-    if desc_count <= 0 or total_chunks <= 0:
-        return
-    comptime if has_apple_gpu_accelerator():
-        var scalar = _ptr(scalar_addr).as_unsafe_any_origin().as_immutable()
-        var desc_index = 0
-        while desc_index < desc_count:
-            var group_first_chunk = 0
-            if desc_index != 0:
-                group_first_chunk = descs[desc_index - 1].chunk_end
-            var addrs = InlineArray[Int, FOREACH_EW_SLOTS](fill=0)
-            var chunk_ends = InlineArray[Int, FOREACH_EW_SLOTS](fill=0)
-            var numels = InlineArray[Int, FOREACH_EW_SLOTS](fill=0)
-            var slot = 0
-            while desc_index < desc_count and slot < FOREACH_EW_SLOTS:
-                var desc = descs[desc_index]
-                addrs[slot] = desc.tensor_addr
-                numels[slot] = desc.numel
-                chunk_ends[slot] = desc.chunk_end - group_first_chunk
-                desc_index += 1
-                slot += 1
-            var group_chunks = chunk_ends[slot - 1]
-            while slot < FOREACH_EW_SLOTS:
-                chunk_ends[slot] = group_chunks
-                slot += 1
-            if group_chunks == 0:
-                continue
-            # Padding/empty slots own zero chunks and are never dereferenced,
-            # but Metal still needs a translatable pointer argument.
-            for backfill in range(FOREACH_EW_SLOTS):
-                if addrs[backfill] == 0:
-                    addrs[backfill] = scalar_addr
-            _enqueue_cached[_mul_tensor_batched_apple](
-                ctx,
-                String("FOREACH_MUL_TENSOR_APPLE_B8_F32_V1"),
-                group_chunks,
-                1,
-                1,
-                FOREACH_THREADS,
-                _ptr(addrs[0]).as_unsafe_any_origin(),
-                _ptr(addrs[1]).as_unsafe_any_origin(),
-                _ptr(addrs[2]).as_unsafe_any_origin(),
-                _ptr(addrs[3]).as_unsafe_any_origin(),
-                _ptr(addrs[4]).as_unsafe_any_origin(),
-                _ptr(addrs[5]).as_unsafe_any_origin(),
-                _ptr(addrs[6]).as_unsafe_any_origin(),
-                _ptr(addrs[7]).as_unsafe_any_origin(),
-                scalar,
-                chunk_ends,
-                numels,
-            )
-    else:
-        _enqueue_mul_cached(descs, desc_count, total_chunks, scalar_addr, ctx)

--- a/torch_mojo_backend/eager_kernels/foreach_elementwise_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/foreach_elementwise_kernels.mojo
@@ -9,9 +9,10 @@ Int) reads back zeros — while per-tensor launches are dispatch bound for
 optimizer-sized tensor lists.
 
 So each kernel here takes a fixed arity of FOREACH_EW_SLOTS real pointer
-arguments per tensor list plus plain-Int per-slot chunk offsets/lengths
-(non-pointer data passes fine), and one launch covers up to FOREACH_EW_SLOTS
-tensors, grid-strided over the concatenation of their fixed-size chunks.
+arguments per tensor list plus per-slot chunk offsets/lengths as plain data
+(non-pointer data passes fine, in fixed-width form — see `_SlotInts`), and one
+launch covers up to FOREACH_EW_SLOTS tensors, grid-strided over the
+concatenation of their fixed-size chunks.
 Unused slots repeat a valid pointer with length zero and are never
 dereferenced. `foreach_ew_enqueue` does the regrouping from the shared
 descriptors.
@@ -45,12 +46,28 @@ comptime FEA_ADDCDIV = 1
 comptime _MutPtr = UnsafePointer[Scalar[DType.float32], MutAnyOrigin]
 comptime _ImmutPtr = UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin]
 
+# Per-slot chunk offsets and lengths as they cross the launch ABI. `Int` is
+# not device-passable (its width differs between host and device, and Metal's
+# device `Int` is not the host's), and an `InlineArray` encodes element-wise,
+# so the array element type has to be fixed-width too. Kernels convert back
+# to `Int` at the use site and all index math stays in `Int`.
+comptime _SlotInts = InlineArray[Int64, FOREACH_EW_SLOTS]
+
 
 @always_inline
 def _addr_ptr(addr: Int) -> _MutPtr:
     return UnsafePointer[Scalar[DType.float32], MutUntrackedOrigin](
         unsafe_from_address=addr
     ).as_unsafe_any_origin()
+
+
+@always_inline
+def _slot_ints(values: InlineArray[Int, FOREACH_EW_SLOTS]) -> _SlotInts:
+    """Widen a host-side per-slot `Int` array to the launch ABI type."""
+    var widened = _SlotInts(fill=Int64(0))
+    for slot in range(FOREACH_EW_SLOTS):
+        widened[slot] = Int64(values[slot])
+    return widened^
 
 
 @always_inline
@@ -73,20 +90,18 @@ def _no_fuse[
 
 
 @always_inline
-def _slot_begin(
-    chunk_ends: InlineArray[Int, FOREACH_EW_SLOTS], chunk: Int
-) -> Tuple[Int, Int]:
+def _slot_begin(chunk_ends: _SlotInts, chunk: Int) -> Tuple[Int, Int]:
     """(slot, element offset in that slot's tensor) for a global chunk id.
 
     Empty slots occupy zero chunks (their chunk_end repeats the previous
     one), so the scan naturally steps over them.
     """
     var slot = 0
-    while slot + 1 < FOREACH_EW_SLOTS and chunk >= chunk_ends[slot]:
+    while slot + 1 < FOREACH_EW_SLOTS and chunk >= Int(chunk_ends[slot]):
         slot += 1
     var first_chunk = 0
     if slot != 0:
-        first_chunk = chunk_ends[slot - 1]
+        first_chunk = Int(chunk_ends[slot - 1])
     return slot, (chunk - first_chunk) * FOREACH_EW_CHUNK
 
 
@@ -168,8 +183,8 @@ def _foreach_scalar_kernel[
     p5: _MutPtr,
     p6: _MutPtr,
     p7: _MutPtr,
-    chunk_ends: InlineArray[Int, FOREACH_EW_SLOTS],
-    numels: InlineArray[Int, FOREACH_EW_SLOTS],
+    chunk_ends: _SlotInts,
+    numels: _SlotInts,
     scalars: InlineArray[Float32, FOREACH_EW_SLOTS],
 ):
     """In-place x = x (op) scalar[slot], one scalar per slot.
@@ -178,7 +193,7 @@ def _foreach_scalar_kernel[
     binary kernel (`a / b`) element math exactly.
     """
     var slot, begin = _slot_begin(chunk_ends, Int(block_idx.x))
-    var end = min(begin + FOREACH_EW_CHUNK, numels[slot])
+    var end = min(begin + FOREACH_EW_CHUNK, Int(numels[slot]))
     var values = _pick_mut(slot, p0, p1, p2, p3, p4, p5, p6, p7)
     var scalar = scalars[slot]
 
@@ -220,8 +235,8 @@ def _foreach_mul_tensor_kernel(
     p6: _MutPtr,
     p7: _MutPtr,
     scalar_ptr: _ImmutPtr,
-    chunk_ends: InlineArray[Int, FOREACH_EW_SLOTS],
-    numels: InlineArray[Int, FOREACH_EW_SLOTS],
+    chunk_ends: _SlotInts,
+    numels: _SlotInts,
 ):
     """In-place x = x * scalar[0], the scalar a 0-d device tensor.
 
@@ -230,7 +245,7 @@ def _foreach_mul_tensor_kernel(
     """
     var scalar = scalar_ptr[0]
     var slot, begin = _slot_begin(chunk_ends, Int(block_idx.x))
-    var end = min(begin + FOREACH_EW_CHUNK, numels[slot])
+    var end = min(begin + FOREACH_EW_CHUNK, Int(numels[slot]))
     var values = _pick_mut(slot, p0, p1, p2, p3, p4, p5, p6, p7)
 
     var index = begin + Int(thread_idx.x) * _VEC
@@ -265,8 +280,8 @@ def _foreach_lerp_kernel(
     e5: _ImmutPtr,
     e6: _ImmutPtr,
     e7: _ImmutPtr,
-    chunk_ends: InlineArray[Int, FOREACH_EW_SLOTS],
-    numels: InlineArray[Int, FOREACH_EW_SLOTS],
+    chunk_ends: _SlotInts,
+    numels: _SlotInts,
     weight: Float32,
     one_minus_weight: Float32,
     low_branch_arg: Int64,
@@ -281,7 +296,7 @@ def _foreach_lerp_kernel(
     # the launch ABI as Int64 and index math stays in Int.
     var low_branch = Int(low_branch_arg)
     var slot, begin = _slot_begin(chunk_ends, Int(block_idx.x))
-    var end = min(begin + FOREACH_EW_CHUNK, numels[slot])
+    var end = min(begin + FOREACH_EW_CHUNK, Int(numels[slot]))
     var self_values = _pick_mut(slot, a0, a1, a2, a3, a4, a5, a6, a7)
     var end_values = _pick_immut(slot, e0, e1, e2, e3, e4, e5, e6, e7)
 
@@ -336,8 +351,8 @@ def _foreach_addc_kernel[
     c5: _ImmutPtr,
     c6: _ImmutPtr,
     c7: _ImmutPtr,
-    chunk_ends: InlineArray[Int, FOREACH_EW_SLOTS],
-    numels: InlineArray[Int, FOREACH_EW_SLOTS],
+    chunk_ends: _SlotInts,
+    numels: _SlotInts,
     scalars: InlineArray[Float32, FOREACH_EW_SLOTS],
 ):
     """In-place self = self + value[slot] * (t1 * t2) or (t1 / t2).
@@ -345,7 +360,7 @@ def _foreach_addc_kernel[
     Matches `logic_ops._ternary_bcast` element math exactly.
     """
     var slot, begin = _slot_begin(chunk_ends, Int(block_idx.x))
-    var end = min(begin + FOREACH_EW_CHUNK, numels[slot])
+    var end = min(begin + FOREACH_EW_CHUNK, Int(numels[slot]))
     var self_values = _pick_mut(slot, a0, a1, a2, a3, a4, a5, a6, a7)
     var first_values = _pick_immut(slot, b0, b1, b2, b3, b4, b5, b6, b7)
     var second_values = _pick_immut(slot, c0, c1, c2, c3, c4, c5, c6, c7)
@@ -394,12 +409,12 @@ def _foreach_sqrt_kernel(
     o5: _MutPtr,
     o6: _MutPtr,
     o7: _MutPtr,
-    chunk_ends: InlineArray[Int, FOREACH_EW_SLOTS],
-    numels: InlineArray[Int, FOREACH_EW_SLOTS],
+    chunk_ends: _SlotInts,
+    numels: _SlotInts,
 ):
     """Out-of-place out = sqrt(in), matching `elementwise_ops` UOP_SQRT."""
     var slot, begin = _slot_begin(chunk_ends, Int(block_idx.x))
-    var end = min(begin + FOREACH_EW_CHUNK, numels[slot])
+    var end = min(begin + FOREACH_EW_CHUNK, Int(numels[slot]))
     var in_values = _pick_immut(slot, i0, i1, i2, i3, i4, i5, i6, i7)
     var out_values = _pick_mut(slot, o0, o1, o2, o3, o4, o5, o6, o7)
 
@@ -497,8 +512,8 @@ def enqueue_foreach_scalar_f32[
             _addr_ptr(addrs[5]),
             _addr_ptr(addrs[6]),
             _addr_ptr(addrs[7]),
-            chunk_ends,
-            numels,
+            _slot_ints(chunk_ends),
+            _slot_ints(numels),
             scalars,
         )
     else:
@@ -530,8 +545,8 @@ def enqueue_foreach_mul_tensor_f32(
             _addr_ptr(addrs[6]),
             _addr_ptr(addrs[7]),
             _addr_ptr(scalar_addr).as_immutable(),
-            chunk_ends,
-            numels,
+            _slot_ints(chunk_ends),
+            _slot_ints(numels),
         )
     else:
         raise Error("no GPU accelerator available at compile time")
@@ -572,8 +587,8 @@ def enqueue_foreach_lerp_f32(
             _addr_ptr(end_addrs[5]).as_immutable(),
             _addr_ptr(end_addrs[6]).as_immutable(),
             _addr_ptr(end_addrs[7]).as_immutable(),
-            chunk_ends,
-            numels,
+            _slot_ints(chunk_ends),
+            _slot_ints(numels),
             weight,
             one_minus_weight,
             Int64(low_branch),
@@ -626,8 +641,8 @@ def enqueue_foreach_addc_f32[
             _addr_ptr(second_addrs[5]).as_immutable(),
             _addr_ptr(second_addrs[6]).as_immutable(),
             _addr_ptr(second_addrs[7]).as_immutable(),
-            chunk_ends,
-            numels,
+            _slot_ints(chunk_ends),
+            _slot_ints(numels),
             scalars,
         )
     else:
@@ -666,8 +681,8 @@ def enqueue_foreach_sqrt_f32(
             _addr_ptr(out_addrs[5]),
             _addr_ptr(out_addrs[6]),
             _addr_ptr(out_addrs[7]),
-            chunk_ends,
-            numels,
+            _slot_ints(chunk_ends),
+            _slot_ints(numels),
         )
     else:
         raise Error("no GPU accelerator available at compile time")

--- a/torch_mojo_backend/eager_kernels/foreach_elementwise_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/foreach_elementwise_kernels.mojo
@@ -1,15 +1,20 @@
-"""Fixed-arity batched FP32 foreach elementwise kernels.
+"""Fixed-arity batched FP32 foreach elementwise kernels: the APPLE half.
 
-Metal only translates pointer-typed kernel *arguments* into valid GPU
-addresses; a raw address smuggled as data (a descriptor struct or an Int)
-reads back zeros. The CUDA-style descriptor-batch multi-tensor kernel is
-therefore impossible on Apple GPUs, and per-tensor launches are dispatch
-bound for optimizer-sized tensor lists. These kernels take a fixed arity of
-FOREACH_EW_SLOTS real pointer arguments per tensor list plus plain-Int
-per-slot chunk offsets/lengths (non-pointer data passes fine), so one
-launch covers up to FOREACH_EW_SLOTS tensors, grid-strided over the
-concatenation of their fixed-size chunks. Unused slots repeat a valid
-pointer with length zero and are never dereferenced.
+Every op here is also served by the single descriptor-batched body in
+`foreach_batched_kernels`, which is the route on CUDA and ROCm and the one to
+change when the element math changes. These exist because Metal cannot take
+that route: Metal only translates pointer-typed kernel *arguments* into valid
+GPU addresses, and a raw address smuggled as data (a descriptor struct or an
+Int) reads back zeros — while per-tensor launches are dispatch bound for
+optimizer-sized tensor lists.
+
+So each kernel here takes a fixed arity of FOREACH_EW_SLOTS real pointer
+arguments per tensor list plus plain-Int per-slot chunk offsets/lengths
+(non-pointer data passes fine), and one launch covers up to FOREACH_EW_SLOTS
+tensors, grid-strided over the concatenation of their fixed-size chunks.
+Unused slots repeat a valid pointer with length zero and are never
+dereferenced. `foreach_ew_enqueue` does the regrouping from the shared
+descriptors.
 
 Element math deliberately mirrors the scalar eager kernels these ops fall
 back to (`elementwise_ops`/`logic_ops`), keeping the batched path
@@ -202,6 +207,44 @@ def _foreach_scalar_kernel[
         comptime if op_code == FES_DIV:
             value = value / scalar
         values[index] = value
+        index += FOREACH_EW_THREADS
+
+
+def _foreach_mul_tensor_kernel(
+    p0: _MutPtr,
+    p1: _MutPtr,
+    p2: _MutPtr,
+    p3: _MutPtr,
+    p4: _MutPtr,
+    p5: _MutPtr,
+    p6: _MutPtr,
+    p7: _MutPtr,
+    scalar_ptr: _ImmutPtr,
+    chunk_ends: InlineArray[Int, FOREACH_EW_SLOTS],
+    numels: InlineArray[Int, FOREACH_EW_SLOTS],
+):
+    """In-place x = x * scalar[0], the scalar a 0-d device tensor.
+
+    `aten::_foreach_mul_.Tensor`; element math matches the `mul_.Tensor`
+    sequential fallback.
+    """
+    var scalar = scalar_ptr[0]
+    var slot, begin = _slot_begin(chunk_ends, Int(block_idx.x))
+    var end = min(begin + FOREACH_EW_CHUNK, numels[slot])
+    var values = _pick_mut(slot, p0, p1, p2, p3, p4, p5, p6, p7)
+
+    var index = begin + Int(thread_idx.x) * _VEC
+    var stride = FOREACH_EW_THREADS * _VEC
+    while index + _VEC <= end:
+        var value = values.load[width=_VEC, alignment=4](index)
+        values.store[width=_VEC, alignment=4](index, value * scalar)
+        index += stride
+
+    # The chunk size is divisible by _VEC, so only a tensor's last chunk can
+    # need this scalar tail.
+    index = begin + ((end - begin) // _VEC) * _VEC + Int(thread_idx.x)
+    while index < end:
+        values[index] = values[index] * scalar
         index += FOREACH_EW_THREADS
 
 
@@ -457,6 +500,38 @@ def enqueue_foreach_scalar_f32[
             chunk_ends,
             numels,
             scalars,
+        )
+    else:
+        raise Error("no GPU accelerator available at compile time")
+
+
+def enqueue_foreach_mul_tensor_f32(
+    addrs: InlineArray[Int, FOREACH_EW_SLOTS],
+    chunk_ends: InlineArray[Int, FOREACH_EW_SLOTS],
+    numels: InlineArray[Int, FOREACH_EW_SLOTS],
+    scalar_addr: Int,
+    total_chunks: Int,
+    ctx: DeviceContext,
+) raises:
+    comptime if has_accelerator():
+        _enqueue_cached[_foreach_mul_tensor_kernel](
+            ctx,
+            String("FOREACH_EW_MUL_TENSOR_F32_V1"),
+            total_chunks,
+            1,
+            1,
+            FOREACH_EW_THREADS,
+            _addr_ptr(addrs[0]),
+            _addr_ptr(addrs[1]),
+            _addr_ptr(addrs[2]),
+            _addr_ptr(addrs[3]),
+            _addr_ptr(addrs[4]),
+            _addr_ptr(addrs[5]),
+            _addr_ptr(addrs[6]),
+            _addr_ptr(addrs[7]),
+            _addr_ptr(scalar_addr).as_immutable(),
+            chunk_ends,
+            numels,
         )
     else:
         raise Error("no GPU accelerator available at compile time")

--- a/torch_mojo_backend/eager_kernels/optimizer_ops/optimizer_ops.mojo
+++ b/torch_mojo_backend/eager_kernels/optimizer_ops/optimizer_ops.mojo
@@ -14,14 +14,14 @@ from std.python.bindings import PythonModuleBuilder
 from std.python._cpython import PyObjectPtr, Py_ssize_t
 
 from op_utils import (
+    FLOAT_DTYPES,
     _raw_ctx,
-    _raw_f64,
+    _raw_dtype_int,
     _raw_int,
     _raw_ret_none,
     _raw_tuple_f64,
     _raw_tuple_int,
     _raw_tuple_len,
-    _spec_dispatcher2,
     _spec_dispatcher3,
     _spec_dispatcher4,
     _spec_dispatcher5,
@@ -41,35 +41,40 @@ from foreach_clip_contract import (
     ForeachDesc,
     empty_foreach_desc,
 )
-from foreach_clip_kernels import (
-    enqueue_foreach_l2_norm_f32,
-    enqueue_foreach_mul_tensor_f32,
+from foreach_clip_kernels import enqueue_foreach_l2_norm_f32
+from foreach_batched_kernels import (
+    FEW_ADD,
+    FEW_ADDCDIV,
+    FEW_ADDCMUL,
+    FEW_DESC_CAP,
+    FEW_DIV,
+    FEW_LERP,
+    FEW_MUL,
+    FEW_MUL_TENSOR,
+    FEW_SQRT,
+    ForeachEwDesc,
+    _few_fields,
+    _few_has_scalar,
+    _few_label,
+    empty_foreach_ew_desc,
+    foreach_ew_chunk_elements,
+    foreach_ew_enqueue,
 )
 from foreach_elementwise_kernels import (
-    FEA_ADDCDIV,
-    FEA_ADDCMUL,
-    FES_ADD,
-    FES_DIV,
-    FES_MUL,
-    FOREACH_EW_CHUNK,
     FOREACH_EW_SLOTS,
-    enqueue_foreach_addc_f32,
     enqueue_foreach_gather_scalars_f32,
-    enqueue_foreach_lerp_f32,
-    enqueue_foreach_scalar_f32,
-    enqueue_foreach_sqrt_f32,
 )
 
-from variant_gates import _op_on, _register_call
+from variant_gates import (
+    _dtype_arg_on,
+    _dtype_supported,
+    _op_on,
+    _register_call,
+)
 
 
 comptime _ADAMW_RECORD_FIELDS = 7
 comptime _FOREACH_NORM_RECORD_FIELDS = 3
-comptime _FOREACH_MUL_RECORD_FIELDS = 2
-comptime _FOREACH_EW_SCALAR_RECORD_FIELDS = 2  # (ptr, numel)
-comptime _FOREACH_EW_LERP_RECORD_FIELDS = 3  # (self_ptr, end_ptr, numel)
-comptime _FOREACH_EW_ADDC_RECORD_FIELDS = 4  # (self, t1, t2, numel)
-comptime _FOREACH_EW_SQRT_RECORD_FIELDS = 3  # (in_ptr, out_ptr, numel)
 
 
 def _fused_adamw_go(
@@ -224,61 +229,6 @@ def _foreach_l2_norm_go(
         partial_offset += total_chunks
 
 
-def _foreach_mul_tensor_go(
-    metadata_obj: PyObjectPtr,
-    scalar_ptr_obj: PyObjectPtr,
-    device_context_ptr: PyObjectPtr,
-) raises:
-    var value_count = _raw_tuple_len(metadata_obj)
-    if value_count == 0:
-        raise Error("foreach multiply requires a nonempty TensorList")
-    if value_count % _FOREACH_MUL_RECORD_FIELDS != 0:
-        raise Error("invalid foreach multiply metadata field count")
-    var record_count = value_count // _FOREACH_MUL_RECORD_FIELDS
-    for validation_record in range(record_count):
-        var base = validation_record * _FOREACH_MUL_RECORD_FIELDS
-        var tensor_ptr = _raw_tuple_int(metadata_obj, base + 0)
-        var numel = _raw_tuple_int(metadata_obj, base + 1)
-        if numel < 0:
-            raise Error("foreach multiply tensor numel must be nonnegative")
-        if numel > 0 and tensor_ptr == 0:
-            raise Error("foreach multiply nonempty pointer must be nonzero")
-
-    var ctx = _raw_ctx(device_context_ptr)
-    if ctx.api() == "cpu":
-        raise Error(
-            "foreach multiply fast path requires a Mojo accelerator device"
-        )
-    var scalar_ptr = _raw_int(scalar_ptr_obj)
-    if scalar_ptr == 0:
-        raise Error("foreach multiply scalar pointer must be nonzero")
-
-    var record = 0
-    while record < record_count:
-        var descs = InlineArray[ForeachDesc, FOREACH_DESC_CAP](
-            fill=empty_foreach_desc()
-        )
-        var desc_count = 0
-        var total_chunks = 0
-        while record < record_count and desc_count < FOREACH_DESC_CAP:
-            var base = record * _FOREACH_MUL_RECORD_FIELDS
-            var numel = _raw_tuple_int(metadata_obj, base + 1)
-            if numel > 0:
-                total_chunks += ceildiv(numel, FOREACH_CHUNK_ELEMENTS)
-            descs[desc_count] = ForeachDesc(
-                _raw_tuple_int(metadata_obj, base + 0),
-                0,
-                numel,
-                total_chunks,
-            )
-            record += 1
-            desc_count += 1
-
-        enqueue_foreach_mul_tensor_f32(
-            descs, desc_count, total_chunks, scalar_ptr, ctx
-        )
-
-
 def _foreach_ew_validate(
     metadata_obj: PyObjectPtr, record_fields: Int, op_name: StaticString
 ) raises -> Int:
@@ -305,252 +255,128 @@ def _foreach_ew_validate(
     return record_count
 
 
-@always_inline
-def _foreach_ew_backfill(
-    mut addrs: InlineArray[Int, FOREACH_EW_SLOTS], slot_count: Int
-):
-    """Give empty/padding slots a valid dummy address (never dereferenced:
-    those slots own zero chunks). Metal still requires every pointer-typed
-    argument to translate to a real buffer."""
-    var first_addr = 0
-    for slot in range(slot_count):
-        if addrs[slot] != 0:
-            first_addr = addrs[slot]
-            break
-    for slot in range(FOREACH_EW_SLOTS):
-        if addrs[slot] == 0:
-            addrs[slot] = first_addr
-
-
-def _foreach_scalar_op_go(
-    op_code_obj: PyObjectPtr,
+def _foreach_ew_go[
+    op: Int
+](
     metadata_obj: PyObjectPtr,
     scalars_obj: PyObjectPtr,
+    aux_obj: PyObjectPtr,
+    dtype_obj: PyObjectPtr,
     device_context_ptr: PyObjectPtr,
 ) raises:
-    var op_code = _raw_int(op_code_obj)
-    if op_code < 0 or op_code > 2:
-        raise Error("invalid foreach scalar op code")
-    var record_count = _foreach_ew_validate(
-        metadata_obj, _FOREACH_EW_SCALAR_RECORD_FIELDS, "foreach scalar op"
-    )
-    if _raw_tuple_len(scalars_obj) != record_count:
-        raise Error("foreach scalar op needs one scalar per tensor")
+    """One bridge for the whole `aten::_foreach_*` elementwise family.
+
+    The Python boundary has already validated ATen's mutable-TensorList
+    contract and flattened the list into `metadata_obj`: `_few_fields[op]()`
+    ints per tensor, the operand addresses then the numel. What else an op
+    needs travels in the two small tuples, and which of them it reads is a
+    compile-time fact:
+
+    * `scalars_obj` -- one FP32 scalar per tensor for mul/add/div/addc
+      (`.Scalar` fills the same tuple with one repeated value that
+      `.ScalarList` fills per tensor), or the two lerp weights.
+    * `aux_obj` -- ints: the lerp branch selector, or the address of the 0-d
+      device scalar `_foreach_mul_.Tensor` multiplies by.
+
+    Descriptors are packed `FEW_DESC_CAP` at a time; a longer list becomes
+    several launches of the same compiled kernel. Nothing is allocated, read
+    back, or synchronized here.
+    """
+    comptime fields = _few_fields[op]()
+    comptime label = _few_label[op]()
+    var record_count = _foreach_ew_validate(metadata_obj, fields, label)
+
+    var dtype = _raw_dtype_int(dtype_obj)
+    if not _dtype_supported[List[DType](FLOAT_DTYPES)](dtype):
+        raise Error("mojo foreach ", label, ": unsupported dtype ", dtype)
+
+    var weight = Float32(0.0)
+    var one_minus_weight = Float32(0.0)
+    comptime if _few_has_scalar[op]():
+        if _raw_tuple_len(scalars_obj) != record_count:
+            raise Error("mojo foreach ", label, " needs one scalar per tensor")
+    comptime if op == FEW_LERP:
+        if _raw_tuple_len(scalars_obj) != 2:
+            raise Error("mojo foreach lerp needs both narrowed weights")
+        weight = Float32(_raw_tuple_f64(scalars_obj, 0))
+        one_minus_weight = Float32(_raw_tuple_f64(scalars_obj, 1))
+
+    var low_branch = 0
+    var scalar_addr = 0
+    comptime if op == FEW_LERP:
+        if _raw_tuple_len(aux_obj) != 1:
+            raise Error("mojo foreach lerp needs its branch selector")
+        low_branch = _raw_tuple_int(aux_obj, 0)
+    comptime if op == FEW_MUL_TENSOR:
+        if _raw_tuple_len(aux_obj) != 1:
+            raise Error("mojo foreach multiply needs its scalar address")
+        scalar_addr = _raw_tuple_int(aux_obj, 0)
+        if scalar_addr == 0:
+            raise Error("mojo foreach multiply scalar pointer must be nonzero")
+
     var ctx = _raw_ctx(device_context_ptr)
     if ctx.api() == "cpu":
-        raise Error("foreach scalar op requires a Mojo accelerator device")
-
-    var record = 0
-    while record < record_count:
-        var addrs = InlineArray[Int, FOREACH_EW_SLOTS](fill=0)
-        var chunk_ends = InlineArray[Int, FOREACH_EW_SLOTS](fill=0)
-        var numels = InlineArray[Int, FOREACH_EW_SLOTS](fill=0)
-        var scalars = InlineArray[Float32, FOREACH_EW_SLOTS](fill=0.0)
-        var slot = 0
-        var total_chunks = 0
-        while record < record_count and slot < FOREACH_EW_SLOTS:
-            var base = record * _FOREACH_EW_SCALAR_RECORD_FIELDS
-            var numel = _raw_tuple_int(metadata_obj, base + 1)
-            if numel > 0:
-                total_chunks += ceildiv(numel, FOREACH_EW_CHUNK)
-            addrs[slot] = _raw_tuple_int(metadata_obj, base + 0)
-            numels[slot] = numel
-            chunk_ends[slot] = total_chunks
-            scalars[slot] = Float32(_raw_tuple_f64(scalars_obj, record))
-            record += 1
-            slot += 1
-        var used_slots = slot
-        while slot < FOREACH_EW_SLOTS:
-            chunk_ends[slot] = total_chunks
-            slot += 1
-        if total_chunks == 0:
-            continue
-        _foreach_ew_backfill(addrs, used_slots)
-        if op_code == FES_MUL:
-            enqueue_foreach_scalar_f32[FES_MUL](
-                addrs, chunk_ends, numels, scalars, total_chunks, ctx
-            )
-        elif op_code == FES_ADD:
-            enqueue_foreach_scalar_f32[FES_ADD](
-                addrs, chunk_ends, numels, scalars, total_chunks, ctx
-            )
-        else:
-            enqueue_foreach_scalar_f32[FES_DIV](
-                addrs, chunk_ends, numels, scalars, total_chunks, ctx
-            )
-
-
-def _foreach_lerp_scalar_go(
-    metadata_obj: PyObjectPtr,
-    weight_obj: PyObjectPtr,
-    one_minus_weight_obj: PyObjectPtr,
-    low_branch_obj: PyObjectPtr,
-    device_context_ptr: PyObjectPtr,
-) raises:
-    var record_count = _foreach_ew_validate(
-        metadata_obj, _FOREACH_EW_LERP_RECORD_FIELDS, "foreach lerp"
-    )
-    var weight = Float32(_raw_f64(weight_obj))
-    var one_minus_weight = Float32(_raw_f64(one_minus_weight_obj))
-    var low_branch = _raw_int(low_branch_obj)
-    var ctx = _raw_ctx(device_context_ptr)
-    if ctx.api() == "cpu":
-        raise Error("foreach lerp requires a Mojo accelerator device")
-
-    var record = 0
-    while record < record_count:
-        var self_addrs = InlineArray[Int, FOREACH_EW_SLOTS](fill=0)
-        var end_addrs = InlineArray[Int, FOREACH_EW_SLOTS](fill=0)
-        var chunk_ends = InlineArray[Int, FOREACH_EW_SLOTS](fill=0)
-        var numels = InlineArray[Int, FOREACH_EW_SLOTS](fill=0)
-        var slot = 0
-        var total_chunks = 0
-        while record < record_count and slot < FOREACH_EW_SLOTS:
-            var base = record * _FOREACH_EW_LERP_RECORD_FIELDS
-            var numel = _raw_tuple_int(metadata_obj, base + 2)
-            if numel > 0:
-                total_chunks += ceildiv(numel, FOREACH_EW_CHUNK)
-            self_addrs[slot] = _raw_tuple_int(metadata_obj, base + 0)
-            end_addrs[slot] = _raw_tuple_int(metadata_obj, base + 1)
-            numels[slot] = numel
-            chunk_ends[slot] = total_chunks
-            record += 1
-            slot += 1
-        var used_slots = slot
-        while slot < FOREACH_EW_SLOTS:
-            chunk_ends[slot] = total_chunks
-            slot += 1
-        if total_chunks == 0:
-            continue
-        _foreach_ew_backfill(self_addrs, used_slots)
-        _foreach_ew_backfill(end_addrs, used_slots)
-        enqueue_foreach_lerp_f32(
-            self_addrs,
-            end_addrs,
-            chunk_ends,
-            numels,
-            weight,
-            one_minus_weight,
-            low_branch,
-            total_chunks,
-            ctx,
+        raise Error(
+            "mojo foreach ", label, " requires a Mojo accelerator device"
         )
 
-
-def _foreach_addc_op_go(
-    op_code_obj: PyObjectPtr,
-    metadata_obj: PyObjectPtr,
-    scalars_obj: PyObjectPtr,
-    device_context_ptr: PyObjectPtr,
-) raises:
-    var op_code = _raw_int(op_code_obj)
-    if op_code < 0 or op_code > 1:
-        raise Error("invalid foreach addc op code")
-    var record_count = _foreach_ew_validate(
-        metadata_obj, _FOREACH_EW_ADDC_RECORD_FIELDS, "foreach addc op"
-    )
-    if _raw_tuple_len(scalars_obj) != record_count:
-        raise Error("foreach addc op needs one scalar per tensor")
-    var ctx = _raw_ctx(device_context_ptr)
-    if ctx.api() == "cpu":
-        raise Error("foreach addc op requires a Mojo accelerator device")
-
-    var record = 0
-    while record < record_count:
-        var self_addrs = InlineArray[Int, FOREACH_EW_SLOTS](fill=0)
-        var first_addrs = InlineArray[Int, FOREACH_EW_SLOTS](fill=0)
-        var second_addrs = InlineArray[Int, FOREACH_EW_SLOTS](fill=0)
-        var chunk_ends = InlineArray[Int, FOREACH_EW_SLOTS](fill=0)
-        var numels = InlineArray[Int, FOREACH_EW_SLOTS](fill=0)
-        var scalars = InlineArray[Float32, FOREACH_EW_SLOTS](fill=0.0)
-        var slot = 0
-        var total_chunks = 0
-        while record < record_count and slot < FOREACH_EW_SLOTS:
-            var base = record * _FOREACH_EW_ADDC_RECORD_FIELDS
-            var numel = _raw_tuple_int(metadata_obj, base + 3)
-            if numel > 0:
-                total_chunks += ceildiv(numel, FOREACH_EW_CHUNK)
-            self_addrs[slot] = _raw_tuple_int(metadata_obj, base + 0)
-            first_addrs[slot] = _raw_tuple_int(metadata_obj, base + 1)
-            second_addrs[slot] = _raw_tuple_int(metadata_obj, base + 2)
-            numels[slot] = numel
-            chunk_ends[slot] = total_chunks
-            scalars[slot] = Float32(_raw_tuple_f64(scalars_obj, record))
-            record += 1
-            slot += 1
-        var used_slots = slot
-        while slot < FOREACH_EW_SLOTS:
-            chunk_ends[slot] = total_chunks
-            slot += 1
-        if total_chunks == 0:
-            continue
-        _foreach_ew_backfill(self_addrs, used_slots)
-        _foreach_ew_backfill(first_addrs, used_slots)
-        _foreach_ew_backfill(second_addrs, used_slots)
-        if op_code == FEA_ADDCMUL:
-            enqueue_foreach_addc_f32[FEA_ADDCMUL](
-                self_addrs,
-                first_addrs,
-                second_addrs,
-                chunk_ends,
-                numels,
-                scalars,
-                total_chunks,
-                ctx,
-            )
-        else:
-            enqueue_foreach_addc_f32[FEA_ADDCDIV](
-                self_addrs,
-                first_addrs,
-                second_addrs,
-                chunk_ends,
-                numels,
-                scalars,
-                total_chunks,
-                ctx,
-            )
-
-
-def _foreach_sqrt_go(
-    metadata_obj: PyObjectPtr, device_context_ptr: PyObjectPtr
-) raises:
-    var record_count = _foreach_ew_validate(
-        metadata_obj, _FOREACH_EW_SQRT_RECORD_FIELDS, "foreach sqrt"
-    )
-    var ctx = _raw_ctx(device_context_ptr)
-    if ctx.api() == "cpu":
-        raise Error("foreach sqrt requires a Mojo accelerator device")
-
-    var record = 0
-    while record < record_count:
-        var in_addrs = InlineArray[Int, FOREACH_EW_SLOTS](fill=0)
-        var out_addrs = InlineArray[Int, FOREACH_EW_SLOTS](fill=0)
-        var chunk_ends = InlineArray[Int, FOREACH_EW_SLOTS](fill=0)
-        var numels = InlineArray[Int, FOREACH_EW_SLOTS](fill=0)
-        var slot = 0
-        var total_chunks = 0
-        while record < record_count and slot < FOREACH_EW_SLOTS:
-            var base = record * _FOREACH_EW_SQRT_RECORD_FIELDS
-            var numel = _raw_tuple_int(metadata_obj, base + 2)
-            if numel > 0:
-                total_chunks += ceildiv(numel, FOREACH_EW_CHUNK)
-            in_addrs[slot] = _raw_tuple_int(metadata_obj, base + 0)
-            out_addrs[slot] = _raw_tuple_int(metadata_obj, base + 1)
-            numels[slot] = numel
-            chunk_ends[slot] = total_chunks
-            record += 1
-            slot += 1
-        var used_slots = slot
-        while slot < FOREACH_EW_SLOTS:
-            chunk_ends[slot] = total_chunks
-            slot += 1
-        if total_chunks == 0:
-            continue
-        _foreach_ew_backfill(in_addrs, used_slots)
-        _foreach_ew_backfill(out_addrs, used_slots)
-        enqueue_foreach_sqrt_f32(
-            in_addrs, out_addrs, chunk_ends, numels, total_chunks, ctx
+    # The chunk size is what fills the device, so it is derived from the whole
+    # list's element count once, before any descriptor batch is packed.
+    var total_elements = 0
+    for record in range(record_count):
+        total_elements += _raw_tuple_int(
+            metadata_obj, record * fields + fields - 1
         )
+    var chunk_elements = foreach_ew_chunk_elements(total_elements, ctx)
+
+    var record = 0
+    while record < record_count:
+        var descs = InlineArray[ForeachEwDesc, FEW_DESC_CAP](
+            fill=empty_foreach_ew_desc()
+        )
+        var scalars = InlineArray[Float32, FEW_DESC_CAP](fill=0.0)
+        var desc_count = 0
+        var total_chunks = 0
+        while record < record_count and desc_count < FEW_DESC_CAP:
+            var base = record * fields
+            var numel = _raw_tuple_int(metadata_obj, base + fields - 1)
+            if numel > 0:
+                total_chunks += ceildiv(numel, chunk_elements)
+            var addr1 = 0
+            var addr2 = 0
+            comptime if fields >= 3:
+                addr1 = _raw_tuple_int(metadata_obj, base + 1)
+            comptime if fields >= 4:
+                addr2 = _raw_tuple_int(metadata_obj, base + 2)
+            descs[desc_count] = ForeachEwDesc(
+                _raw_tuple_int(metadata_obj, base),
+                addr1,
+                addr2,
+                numel,
+                total_chunks,
+            )
+            comptime if _few_has_scalar[op]():
+                scalars[desc_count] = Float32(
+                    _raw_tuple_f64(scalars_obj, record)
+                )
+            record += 1
+            desc_count += 1
+
+        comptime for dt in FLOAT_DTYPES:
+            comptime if _dtype_arg_on[0, dt]():
+                if dtype == dt:
+                    foreach_ew_enqueue[dt, op](
+                        descs,
+                        scalars,
+                        desc_count,
+                        total_chunks,
+                        chunk_elements,
+                        scalar_addr,
+                        weight,
+                        one_minus_weight,
+                        low_branch,
+                        ctx,
+                    )
 
 
 def _foreach_gather_scalars_go(
@@ -587,6 +413,28 @@ def _foreach_gather_scalars_go(
         enqueue_foreach_gather_scalars_f32(out_addr, in_addrs, base, count, ctx)
 
 
+comptime _FOREACH_EW_DOC = (
+    "(metadata, scalars, aux, dtype, context_ptr); one batched in-place"
+    " launch for one member of the foreach elementwise family"
+)
+
+
+def _register_foreach_ew[
+    op: Int, name: StaticString
+](mut builder: PythonModuleBuilder) raises:
+    """Expose one member of the foreach elementwise family.
+
+    Each member is its own specialized build (`OP=<name>`), so the .so it
+    compiles holds exactly one instantiation of the shared kernel body.
+    """
+    comptime if _op_on[name]():
+        _register_call(
+            builder,
+            _spec_dispatcher5[_foreach_ew_go[op], name],
+            docstring=_FOREACH_EW_DOC,
+        )
+
+
 @export
 def PyInit_optimizer_ops() abi("C") -> PythonObject:
     try:
@@ -610,42 +458,14 @@ def PyInit_optimizer_ops() abi("C") -> PythonObject:
                     "runtime-dynamic FP32 foreach L2 norms"
                 ),
             )
-        comptime if _op_on["ForeachMulTensor"]():
-            _register_call(
-                builder,
-                _spec_dispatcher3[_foreach_mul_tensor_go, "ForeachMulTensor"],
-                docstring=(
-                    "(metadata, scalar_ptr, context_ptr); runtime-dynamic FP32 "
-                    "foreach in-place device-scalar multiply"
-                ),
-            )
-        comptime if _op_on["ForeachScalarOp"]():
-            _register_call(
-                builder,
-                _spec_dispatcher4[_foreach_scalar_op_go, "ForeachScalarOp"],
-                docstring=(
-                    "(op_code, metadata, scalars, context_ptr); batched FP32 "
-                    "in-place foreach mul/add/div by one host scalar per tensor"
-                ),
-            )
-        comptime if _op_on["ForeachLerpScalar"]():
-            _register_call(
-                builder,
-                _spec_dispatcher5[_foreach_lerp_scalar_go, "ForeachLerpScalar"],
-                docstring=(
-                    "(metadata, weight, one_minus_weight, low_branch, "
-                    "context_ptr); batched FP32 in-place foreach scalar lerp"
-                ),
-            )
-        comptime if _op_on["ForeachAddcOp"]():
-            _register_call(
-                builder,
-                _spec_dispatcher4[_foreach_addc_op_go, "ForeachAddcOp"],
-                docstring=(
-                    "(op_code, metadata, scalars, context_ptr); batched FP32 "
-                    "in-place foreach addcmul/addcdiv with per-tensor scalars"
-                ),
-            )
+        _register_foreach_ew[FEW_MUL, "ForeachMul"](builder)
+        _register_foreach_ew[FEW_ADD, "ForeachAdd"](builder)
+        _register_foreach_ew[FEW_DIV, "ForeachDiv"](builder)
+        _register_foreach_ew[FEW_MUL_TENSOR, "ForeachMulTensor"](builder)
+        _register_foreach_ew[FEW_LERP, "ForeachLerp"](builder)
+        _register_foreach_ew[FEW_ADDCMUL, "ForeachAddcmul"](builder)
+        _register_foreach_ew[FEW_ADDCDIV, "ForeachAddcdiv"](builder)
+        _register_foreach_ew[FEW_SQRT, "ForeachSqrt"](builder)
         comptime if _op_on["ForeachGatherScalars"]():
             _register_call(
                 builder,
@@ -655,15 +475,6 @@ def PyInit_optimizer_ops() abi("C") -> PythonObject:
                 docstring=(
                     "(in_ptrs, out_ptr, context_ptr); batched FP32 gather of "
                     "one scalar per input tensor into a contiguous output"
-                ),
-            )
-        comptime if _op_on["ForeachSqrt"]():
-            _register_call(
-                builder,
-                _spec_dispatcher2[_foreach_sqrt_go, "ForeachSqrt"],
-                docstring=(
-                    "(metadata, context_ptr); batched FP32 out-of-place "
-                    "foreach sqrt"
                 ),
             )
         return builder.finalize()


### PR DESCRIPTION
Follow-up to #379, asked for on that PR: record the Apple foreach benchmark
numbers now that the M4 has a baseline block.

**They were never recorded because the kernels did not build there.** #377 gave
the M4 716 leaves and zero `_foreach_*` entries (only the two `_fused_adamw_`
ones). Running `benchmarks/test_foreach.py` on the Mac fails 18 of its 20 nodes
with an `ImportError` from `mojo build`, on `main` and on #379 alike:

```
constraint failed: Int and UInt do not conform to DevicePassable;
use a fixed-width type such as Int32 or Int64 instead
```

**#379 did not fix it, so this PR does.** The Metal half of the family
(`foreach_elementwise_kernels.mojo` — the fixed-arity kernels Metal needs
because it only translates pointer-typed *arguments* — plus the two batched norm
kernels in `foreach_clip_kernels.mojo`) passes its per-slot chunk offsets and
lengths as `InlineArray[Int, 8]` kernel arguments. `InlineArray` encodes
element-wise, so the *element* type has to be fixed width too, and the mojo-1.0
migration that renamed lone scalar parameters to `x_arg: Int64` never covered
the arrays. They now cross the ABI as `InlineArray[Int64, 8]` (`_SlotInts`),
widened at the enqueue boundary by `_slot_ints` so the host-side regrouping
keeps working in `Int`; kernels convert back at the use site and every index
computation stays in `Int`.

Nothing here is reachable off Metal — the CUDA/ROCm route is the
descriptor-batched body in `foreach_batched_kernels.mojo`, selected by
`comptime if has_apple_gpu_accelerator()` — which is why only a Mac ever saw
this, and why the fix cannot move another architecture.

**sm_90a is byte-identical**: 0 of 22 kernels differ across every `Foreach*`
specialization of `optimizer_ops` in float32 and bfloat16, plus 0 of 16
sidecars for the three ops the scanner finds on its own. Note for whoever runs
this next: `scripts/compare_kernel_asm.py` alone reports a **false all-clear**
here — `optimizer_ops` registers the family through `_register_foreach_ew[op,
name]`, a non-literal gate name, so the source scan marks the module opaque and
builds only `FusedAdamW`, `ForeachL2Norm` and `ForeachGatherScalars`. The eight
`Foreach*` ops have to be forced by name. Host launch geometry is unchanged too:
the only edits outside the Apple-gated branch are the two type names.

## Apple foreach coverage — 17 recorded, 1 refused, 2 already there

| node | L_4x1048576 | L_16x65536 |
| --- | --- | --- |
| `_foreach_add_.Scalar` | 0.918 | 0.773 |
| `_foreach_addcdiv_.ScalarList` | 1.057 | 0.624 |
| `_foreach_addcmul_.Scalar` | 1.055 | 0.635 |
| `_foreach_div_.ScalarList` | 0.927 | 0.802 |
| `_foreach_lerp_.Scalar` | 1.065 | 0.803 |
| `_foreach_mul_.Scalar` | 0.921 | 0.787 |
| `_foreach_mul_.Tensor` | 0.924 | 0.999 |
| `_foreach_norm.Scalar` | 0.843 | 0.587 |
| `_foreach_sqrt` | 1.503 | **refused** |

(ratio ours/stock MPS device time; below 1.0 means we are faster.)

`_foreach_sqrt/f32/L_16x65536` was refused as *too noisy to trust* on two
separate runs — ~150 µs of work, leg spread 67% then 84%, median uncertainty
still above 1.5% after the 12-burst cap on all 3 internal attempts. It stays
unrecorded rather than recorded wrong, so the M4 foreach coverage is **17 of
18** previously-missing nodes. The two `_fused_adamw_` entries #377 already had
still pass unchanged.

Apple config goes 716 → 733 leaves; the H100 block is unchanged key-for-key and
value-for-value, and the hand-written viewer half of `baselines.html` is
byte-identical. `benchmarks/report.py` reads the file and
`benchmarks/test_coverage.py` passes.

## Layering

This branch is **#379's head plus one commit** — the Metal fix is a fix to
#379's files, and the numbers were measured with #379's code — so it should land
**after #379**. #377 needs no special handling: it is already merged into `main`
(58a486c) and #379 has merged `main`, so the file here carries both Apple sets
and this PR only adds to them.

## Unrelated pre-existing failure worth knowing about

On the Mac, `tests/test_eager_optimizer_ops.py` is 50 passed / 2 failed with
this branch, and the same 2 fail identically on unpatched #379 (same 4502
mismatched elements), so they are #379's, not this PR's:
`test_batched_foreach_mul_scalar_reduced_precision[f16]` and `[bf16]`. The Apple
batched path is float32-only, so half-precision lists fall back to a per-tensor
multiply that computes in the narrow dtype and lands one ulp off ATen, which
widens to fp32 and narrows once. Our own `mul_.Scalar` on Metal *is* bit-exact
against the widened reference (checked directly: 0 of 65539 elements differ), so
the gap is in the fallback route the f16 list takes, not in the elementwise
kernel. Benchmarks are f32 only, so the numbers above are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0133Q6PWFo52BNSysckZ3Rke
