### PR TITLE
Fix CI: record a cpu conformance delta for CPU-only runners

### DIFF
--- a/benchmarks/test_coverage.py
+++ b/benchmarks/test_coverage.py
@@ -30,6 +30,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from bench_lib import baselines
+
 from conftest import KEY_DUMP_ENV
 
 BENCH_DIR = Path(__file__).resolve().parent

--- a/conformance/known_unsupported.py
+++ b/conformance/known_unsupported.py
@@ -719,7 +719,100 @@ TABLE_NAMES: dict[str, str] = {
 #         # The tensor-core route this needs is gated on sm_90a.
 #         "test_matches_cpu": {"nn_functional_scaled_dot_product_attention": ()},
 #     },
-_ACCELERATOR_DELTAS: dict[str, dict[str, dict[str, tuple[str, ...]]]] = {}
+#
+# "cpu" is a machine with no accelerator at all -- CI's ubuntu-latest
+# runners. Kernels still run there (MAX has a CPU target), so this is a real
+# measurement, not a stub: some ops raise on this path where they would not
+# on a GPU (declared below under "test_matches_cpu"), and some
+# error_inputs_func cases that provoke a GPU-only failure mode on
+# BASE_ACCELERATOR instead run to completion here, so their base declaration
+# is overridden to the empty tuple (declared below under "test_errors_match").
+# Measured with `regenerate_known_unsupported.py -n 15 --records ...`; see
+# that script's docstring for why `--write` refuses off BASE_ACCELERATOR and
+# a delta has to be hand-derived from the printed diff instead.
+#
+# Not declared here: test_matches_cpu_stack_mojo_int64 segfaults (SIGSEGV,
+# exit 139) on this path, reproducibly and standalone. A declared entry
+# cannot excuse it -- a declared case still calls the operator and only
+# excuses an EXCEPTION it raises; a segfault never raises one, it takes the
+# whole process down before any Python `except` runs. That is a real bug in
+# the stack/cat path for int64 with no accelerator present, out of scope for
+# this table, and it will keep failing (or crashing whatever process runs
+# it, CI shard included) until fixed at the kernel level.
+_ACCELERATOR_DELTAS: dict[str, dict[str, dict[str, tuple[str, ...]]]] = {
+    "cpu": {
+        "test_matches_cpu": {
+            "__rpow__": ("float32", "int64"),
+            "bmm": ("float32", "int64"),
+            "floor_divide": ("bfloat16",),
+            "log_softmax": ("float32", "bfloat16", "float16"),
+            "masked_log_softmax": ("float32", "bfloat16", "float16"),
+            "native_dropout_backward": (
+                "float32",
+                "bfloat16",
+                "float16",
+                "int64",
+                "bool",
+            ),
+            "nn_functional_batch_norm": ("float32", "bfloat16", "float16"),
+            "nn_functional_conv2d": ("bfloat16", "float16", "int64"),
+            "nn_functional_instance_norm": ("float32", "bfloat16", "float16"),
+            "pow": ("float32", "int64"),
+        },
+        "test_errors_match": {
+            "_chunk_cat": (),
+            "diag_embed": (),
+            "diagonal": (),
+            "diagonal_copy": (),
+            "diff": (),
+            "dsplit": (),
+            "fft_fft": (),
+            "fft_fft2": (),
+            "fft_fftn": (),
+            "fft_hfft2": (),
+            "fft_hfftn": (),
+            "fft_ifft": (),
+            "fft_ifft2": (),
+            "fft_ifftn": (),
+            "fft_ihfft": (),
+            "fft_ihfft2": (),
+            "fft_ihfftn": (),
+            "fft_irfft2": (),
+            "fft_irfftn": (),
+            "fft_rfft": (),
+            "fft_rfft2": (),
+            "fft_rfftn": (),
+            "fliplr": (),
+            "flipud": (),
+            "hsplit": (),
+            "isclose": (),
+            "item": (),
+            "linalg_cross": (),
+            "linalg_diagonal": (),
+            "movedim": (),
+            "narrow_copy": (),
+            "nn_functional_adaptive_avg_pool1d": (),
+            "nn_functional_adaptive_avg_pool2d": (),
+            "nn_functional_adaptive_avg_pool3d": (),
+            "nn_functional_adaptive_max_pool1d": (),
+            "nn_functional_group_norm": (),
+            "nn_functional_hardtanh": (),
+            "nn_functional_hinge_embedding_loss": (),
+            "nn_functional_l1_loss": (),
+            "nn_functional_margin_ranking_loss": (),
+            "nn_functional_prelu": (),
+            "nn_functional_rms_norm": (),
+            "nn_functional_rrelu": (),
+            "nn_functional_softshrink": (),
+            "rot90": (),
+            "scatter_add": (),
+            "sum_to_size": (),
+            "uniform": (),
+            "view_copy": (),
+            "vsplit": (),
+        },
+    }
+}
 
 
 def dtype_token(dtype: torch.dtype) -> str:

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,29 @@
+"""Repo-root pytest hooks.
+
+CI shards the whole suite 20 ways (`pytest-split`) and then filters each shard
+with `-k "mojo_device"` or `-k "not mojo_device"`. pytest-split has no
+durations file yet, so it chunks by collection order rather than actual
+runtime, and a shard's slice can legitimately contain zero tests matching the
+keyword filter -- the filter didn't do anything wrong, that shard's tests just
+all belong to the other side of the split. Left alone, pytest reports that as
+`ExitCode.NO_TESTS_COLLECTED` (5), which CI would otherwise have to treat as a
+job failure.
+
+This must stay narrow: a `-k` filter deselecting every collected item is
+expected and fine, but a bare `pytest some/typo`-path collecting nothing is
+still a real mistake and must keep exiting 5.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    """CI shards the suite 20 ways then filters with -k; a shard whose chunk
+    contains no test matching the filter must count as empty, not failed."""
+    if (
+        exitstatus == pytest.ExitCode.NO_TESTS_COLLECTED
+        and session.config.option.keyword
+    ):
+        session.exitstatus = int(pytest.ExitCode.OK)

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -8,6 +8,7 @@ from types import ModuleType, SimpleNamespace
 import pytest
 import torch
 from max.driver import CPU
+from torch.testing._internal.common_methods_invocations import op_db
 
 from torch_mojo_backend import get_accelerators, register_mojo_devices
 
@@ -515,6 +516,58 @@ def test_fast_stack_uses_the_batched_cat(mojo_gpu, dim):
     torch.testing.assert_close(
         torch.stack(device, dim).cpu(), torch.stack(host, dim), rtol=0, atol=0
     )
+
+
+def test_fast_cat_narrow_copy_dst_cpu_alignment_regression(mojo_device):
+    """Regression for a segfault (SIGSEGV) in the CPU fallback of
+    `NarrowCopyDst` (the per-input path `fast_aten_cat` takes when the
+    batched `CatN` kernel is unavailable, i.e. on a `mojo` device with no
+    accelerator -- see `first._device.api != "cpu"` in `fast_aten_cat`).
+
+    Root cause: a CPU-only "func4" fast path in `_narrow_copy_dst`
+    (data_movement_ops.mojo) vectorized 4 elements per store whenever
+    `copy_len`, `dst_stride` and `dst_offset` were all multiples of 4, using
+    `elementwise[..., simd_width=1]`. That primitive does not guarantee
+    calling back exactly `Coord(outer * copy_len // 4)` times with no
+    overrun, and was observed writing one extra width-4 store past `out`'s
+    allocation. Harmless while it lands in heap slack, it corrupts a live
+    allocation once the heap is packed tightly enough. The fix removes the
+    CPU fast path entirely and always stores one element at a time there;
+    the accelerator fast path (a real GPU kernel launch, not this CPU
+    `elementwise` call) is untouched.
+
+    First reproduced via
+    `conformance/test_opinfo.py::TestOpInfoConformancePRIVATEUSE1::test_matches_cpu_stack_mojo_int64`
+    (exit 139), which iterates every `stack` OpInfo sample for int64 in one
+    process. The overrun is real regardless of what runs around it -- it
+    always writes past `out`'s allocation -- but whether that lands in
+    unused heap space or corrupts something live depends on the process's
+    whole allocation history, not just this test's own few small tensors: a
+    hand-picked repro of only the "suspicious" (copy_len, dst_stride,
+    offset) case, or even this same OpInfo replay run standalone outside
+    `instantiate_device_type_tests`' class-wide setup, did not reliably
+    crash, while running it through that real machinery (however lightly,
+    e.g. via plain `unittest`, no pytest needed) did every time. So this is
+    the exact OpInfo sample sequence that overran and corrupted a real
+    allocation -- a faithful repro of the trigger conditions and a real
+    correctness check (`assert_close`, not just "did not crash") -- even
+    though a from-scratch process running only this function is not
+    guaranteed to reproduce the crash exit code if the bug ever regresses.
+    """
+    op = next(
+        candidate
+        for candidate in op_db
+        if candidate.formatted_name == "stack" and candidate.variant_test_name == ""
+    )
+    checked = 0
+    for sample in op.sample_inputs("cpu", torch.int64):
+        host = sample.input
+        device = [tensor.to(mojo_device) for tensor in host]
+        actual = torch.stack(device, *sample.args, **sample.kwargs).cpu()
+        expected = torch.stack(host, *sample.args, **sample.kwargs)
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+        checked += 1
+    assert checked > 0
 
 
 def _repeat_fill(shape: tuple[int, ...], dtype: torch.dtype) -> torch.Tensor:

--- a/torch_mojo_backend/eager_kernels/data_movement_ops/data_movement_ops.mojo
+++ b/torch_mojo_backend/eager_kernels/data_movement_ops/data_movement_ops.mojo
@@ -1200,24 +1200,20 @@ def _narrow_copy_dst[
         else:
             raise Error("no GPU accelerator available at compile time")
 
-    if copy_len % 4 == 0 and dst_stride % 4 == 0 and dst_offset % 4 == 0:
-        comptime vec_align = 4 * size_of[dtype]()
-
-        @always_inline
-        @parameter
-        @__copy_capture(out_ptr, in_ptr)
-        def func4[width: Int, alignment: Int = 1](idx: Coord):
-            var i = Int(idx[0].value()) * 4
-            var o = i // copy_len
-            var j = i % copy_len
-            var v = in_ptr.load[width=4, alignment=vec_align](i)
-            out_ptr.store[width=4, alignment=vec_align](
-                o * dst_stride + dst_offset + j, v
-            )
-
-        elementwise[func4, simd_width=1](Coord(outer * copy_len // 4), ctx)
-        return
-
+    # No CPU-side "func4" fast path here (there was one, briefly): CPU
+    # `elementwise[..., simd_width=1]` does not guarantee exactly
+    # `Coord(outer * copy_len // 4)` calls to the callback with no overrun --
+    # observed writing one extra width-4 store (4 elements) past `out`'s
+    # allocation on this host. Silent when it lands in slack space, a
+    # segfault when it does not: reproduced deterministically via
+    # `test_matches_cpu_stack_mojo_int64`, which concatenates several small
+    # int64 tensors back to back so a later allocation lands where an
+    # earlier call's overrun wrote. The accelerator path above is untouched
+    # -- its "float4" fast path launches a real GPU kernel
+    # (`_narrow_copy_dst_kernel2d` / `kernel4`) with its own explicit
+    # grid/thread bounds, not this CPU `elementwise` call, so it does not
+    # share this bug. One scalar store per element is what CPU gets until
+    # the overrun is root-caused inside `elementwise` itself.
     @always_inline
     @parameter
     @__copy_capture(out_ptr, in_ptr)


### PR DESCRIPTION
## Summary

CI on ubuntu-latest runners (no accelerator) has been red since Aug 14. I found three independent issues, all fixed here:

**1. Missing per-accelerator conformance delta.** `conformance/test_opinfo.py` compares the mojo device against CPU using `known_unsupported.py`'s base tables, which were measured on `sm_90a`. `_ACCELERATOR_DELTAS` was empty, so a CPU-only runner (`accelerator_key()` returns `"cpu"`) got judged against sm_90a expectations and failed dozens of nodes that behave differently with no accelerator present.

   Added `_ACCELERATOR_DELTAS["cpu"]`, hand-derived from a full local run of `regenerate_known_unsupported.py -n 15 --records ...` (measured on this machine, `CUDA_VISIBLE_DEVICES=""`):
   - 10 `test_matches_cpu` operators need additional dtypes declared (e.g. `pow`, `nn_functional_conv2d`, `log_softmax`, `nn_functional_batch_norm`/`instance_norm`, `native_dropout_backward`) — these produce numerically-mismatched results on the CPU execution path that don't occur on real GPU hardware.
   - 50 `test_errors_match` operators whose sm_90a-declared failure now runs to completion on cpu, so their entries flip to the empty tuple (declared-unsupported is the *absence* of an entry; a declared case that starts passing fails the suite by design).

**2. Empty pytest-split shards exit 5.** `pytest --splits 20 --group N -k "..."` exits 5 ("no tests collected") whenever a shard's slice contains zero nodes matching the `-k` filter — pytest-split has no durations file yet, so chunking is uneven, and the `"mojo_device"` filter selects 0 of ~7000 nodes in the tail groups (e.g. groups 19-20).

   I first attempted this as a `.github/workflows/ci.yml` change, but my agent account's GitHub token lacks the `workflow` OAuth scope, so pushing any commit touching a workflow file is rejected by GitHub. Fixed instead with a root-level `conftest.py`: a `pytest_sessionfinish` hook converts `NO_TESTS_COLLECTED` into success **only** when a `-k` filter is active (i.e. the run collected items and the keyword filter deselected all of them) — a bare "no tests collected" with no `-k` filter (a typo'd path, an empty directory) still exits 5, so this doesn't hide a real mistake.

**3. A genuine segfault, `test_matches_cpu_stack_mojo_int64`.** This one isn't a conformance-table gap — a declared-unsupported entry can't fix it, because a declared case still calls the operator and only excuses an *exception* it raises, and a segfault never raises one. Root-caused to a CPU-only "func4" fast path in `_narrow_copy_dst` (`data_movement_ops.mojo`, underlying `aten::stack`/`aten::cat`'s per-input CPU fallback): it vectorized 4 elements per store using `elementwise[..., simd_width=1]`, which does not guarantee calling back with no overrun, and was observed writing one extra width-4 store past the output buffer — harmless in heap slack, a segfault once a live allocation sits there (exactly what stacking several small int64 tensors back to back does). Fixed by removing that fast path on CPU (always one scalar store there now); the accelerator fast path (a real GPU kernel launch, not this CPU `elementwise` call) is untouched. Added a regression test in `tests/test_eager_kernels.py` replaying the exact OpInfo sample sequence that crashed.

## Test plan

All run locally with `CUDA_VISIBLE_DEVICES=""` to simulate the CI runner without touching any GPU:

- [x] `uv run pytest conformance/test_known_unsupported.py -v` — green (7 passed).
- [x] `uv run pytest conformance/ -n 15` — **fully green**: 977 passed, 237 skipped, 1579 xfailed, 0 failed.
- [x] `uv run pytest -v --splits 20 --group N -k "not mojo_device"` for N in 3,4,5,6,7,8,9,10 — all exit 0 (group 6 was previously red on `floor_divide` bf16; group 10 previously crashed with the segfault — both now pass).
- [x] `uv run pytest -v --splits 20 --group N -k "mojo_device"` for N in 19,20 — both now exit 0 via the new `conftest.py` hook (previously exit 5).
- [x] Hook mechanics double-checked directly: a `-k` filter matching nothing now exits 0 (was 5); a real failure selected by `-k` still exits nonzero; a path with zero collectible items and *no* `-k` filter still exits 5.
- [x] `tests/test_eager_kernels.py -k "cat or stack"` (73 tests) and the full suite (339 passed, 0 failed) — no regressions from the kernel fix.
- [x] The crashing conformance node passes 5/5 repeated runs post-fix.
- [x] `uvx pre-commit run --all-files` — clean.

The cpu delta was measured on this one machine; GitHub's own CPU runners may differ marginally (a handful of nodes could behave slightly differently), and this PR's own CI run is the arbiter for any residual gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TFYWf7vJNAv5VadqSz3bRu
