### PR TITLE
Re-record 16 stale H100 baselines (#341 best-of-N artifacts)

### DIFF
--- a/benchmarks/baselines.html
+++ b/benchmarks/baselines.html
@@ -5084,12 +5084,12 @@ document.addEventListener("DOMContentLoaded", boot);
               "shapes": {
                 "B1H16S4096D128": {
                   "layouts": {
-                    "contig": 17.509
+                    "contig": 3.137
                   }
                 },
                 "B8H12S1024D64": {
                   "layouts": {
-                    "contig": 14.496
+                    "contig": 3.461
                   }
                 }
               }
@@ -5422,10 +5422,10 @@ document.addEventListener("DOMContentLoaded", boot);
                 },
                 "S4_1024x1024x8192": {
                   "layouts": {
-                    "NN": 9.298,
-                    "NT": 5.959,
-                    "TN": 10.535,
-                    "TT": 8.787
+                    "NN": 6.015,
+                    "NT": 3.569,
+                    "TN": 7.346,
+                    "TT": 5.867
                   }
                 },
                 "S5_357x789x333": {
@@ -6175,7 +6175,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 "S4_8x1024x1024x8192": {
                   "layouts": {
                     "NN": 3.982,
-                    "NT": 3.156,
+                    "NT": 3.682,
                     "TN": 2.204,
                     "TT": 3.621
                   }
@@ -7012,7 +7012,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 },
                 "S4_1024x1024x8192": {
                   "layouts": {
-                    "contig": 6.018
+                    "contig": 3.582
                   }
                 },
                 "S5_357x789x333": {
@@ -7172,7 +7172,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 },
                 "S4_1024x1024x8192": {
                   "layouts": {
-                    "contig": 3.2
+                    "contig": 1.262
                   }
                 },
                 "S5_357x789x333": {
@@ -7759,10 +7759,10 @@ document.addEventListener("DOMContentLoaded", boot);
                 },
                 "S4_1024x1024x8192": {
                   "layouts": {
-                    "NN": 9.317,
-                    "NT": 2.211,
+                    "NN": 1.313,
+                    "NT": 1.327,
                     "TN": 1.151,
-                    "TT": 9.027
+                    "TT": 1.326
                   }
                 },
                 "S5_357x789x333": {
@@ -7777,7 +7777,7 @@ document.addEventListener("DOMContentLoaded", boot);
                   "layouts": {
                     "NN": 1.055,
                     "NT": 1.151,
-                    "TN": 1.626,
+                    "TN": 1.071,
                     "TT": 5.073
                   }
                 },
@@ -7785,7 +7785,7 @@ document.addEventListener("DOMContentLoaded", boot);
                   "layouts": {
                     "NN": 4.178,
                     "NT": 1.014,
-                    "TN": 1.892,
+                    "TN": 1.011,
                     "TT": 4.05
                   }
                 }
@@ -8593,12 +8593,12 @@ document.addEventListener("DOMContentLoaded", boot);
               "shapes": {
                 "B1H16S4096D128": {
                   "layouts": {
-                    "contig": 59.274
+                    "contig": 10.649
                   }
                 },
                 "B8H12S1024D64": {
                   "layouts": {
-                    "contig": 46.149
+                    "contig": 11.073
                   }
                 }
               }


### PR DESCRIPTION
The recorded H100 ratios for several GEMM and SDPA nodes never corresponded to any commit — the #341 recording pass kept best-of-N stock legs. Re-measured today at main (2bb5910) with the standard suite (ABBA quartets, pinned 1395 MHz, `--update-baselines=force`), this PR splices current truth for the 16 entries outside the dead band:

| node | recorded | measured today |
|---|---|---|
| mm/bf16/S4 NN / NT / TT | 9.32 / 2.21 / 9.03 | 1.31 / 1.33 / 1.33 |
| mm/bf16/S6 TN, S7 TN | 1.63, 1.89 | 1.07, 1.01 |
| addmm/bf16/S4 NN / NT / TN / TT | 9.30 / 5.96 / 10.54 / 8.79 | 6.02 / 3.57 / 7.35 / 5.87 |
| addmm/f16/S4 NT | 3.16 | 3.68 |
| linear/bf16/S4 | 6.02 | 3.58 |
| linear_backward/bf16/S4 | 3.20 | 1.26 |
| sdpa/f16 B8H12S1024D64, B1H16S4096D128 | 46.15, 59.27 | 11.07, 10.65 |
| sdpa_efficient/f16 (both shapes) | 14.50, 17.51 | 3.46, 3.14 |

The still-bad entries (addmm S4, sdpa f16) are being fixed in separate in-flight PRs, which will update their own nodes again per the merge-per-entry model; this PR just makes the file stop lying in the meantime. Only the machine-written JSON block changes, no viewer edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TFYWf7vJNAv5VadqSz3bRu