### PR TITLE
Enable f16 for the H100 FA4 fused flash-attention kernel

### DIFF
--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -8278,15 +8278,27 @@ def test_fast_sdpa(mojo_gpu, is_causal, kv_len, dtype):
     torch.testing.assert_close(dev, ref, atol=1e-2, rtol=1e-2)
 
 
-def test_fa4_bf16_causal_gapped_qkv_forward_backward(mojo_h100, monkeypatch):
-    """The cached H100 path stays dynamic for nanoGPT's gapped QKV views."""
+_FA4_DTYPE_SUFFIX = {torch.bfloat16: "bf16", torch.float16: "f16"}
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16], ids=["bf16", "f16"])
+def test_fa4_causal_gapped_qkv_forward_backward(mojo_h100, monkeypatch, dtype):
+    """The cached H100 path stays dynamic for nanoGPT's gapped QKV views.
+
+    bf16 and f16 share the same kernel family (the f16 RS wgmma emitter is a
+    vendored gap-filler for the stdlib's bf16-only register-operand overload,
+    see ``fa4_wgmma_f16.mojo``), so both dtypes are exercised here.
+    """
     from torch_mojo_backend.eager_flash_attention import load_fa4_ops
     from torch_mojo_backend.mojo_device.mojo_device_aten_ops import EAGER_CALL_COUNTERS
 
     module = load_fa4_ops()
     calls = {"forward": 0, "backward": 0}
-    original_forward = module.flash_attention_fwd_bf16_d64_causal_strided_qkv
-    original_backward = module.flash_attention_bwd_bf16_d64_causal_strided_qkv
+    suffix = _FA4_DTYPE_SUFFIX[dtype]
+    forward_name = f"flash_attention_fwd_{suffix}_d64_causal_strided_qkv"
+    backward_name = f"flash_attention_bwd_{suffix}_d64_causal_strided_qkv"
+    original_forward = getattr(module, forward_name)
+    original_backward = getattr(module, backward_name)
 
     def forward_spy(*args):
         calls["forward"] += 1
@@ -8296,12 +8308,8 @@ def test_fa4_bf16_causal_gapped_qkv_forward_backward(mojo_h100, monkeypatch):
         calls["backward"] += 1
         return original_backward(*args)
 
-    monkeypatch.setattr(
-        module, "flash_attention_fwd_bf16_d64_causal_strided_qkv", forward_spy
-    )
-    monkeypatch.setattr(
-        module, "flash_attention_bwd_bf16_d64_causal_strided_qkv", backward_spy
-    )
+    monkeypatch.setattr(module, forward_name, forward_spy)
+    monkeypatch.setattr(module, backward_name, backward_spy)
 
     head_dim = 64
     for seed, batch, seqlen, heads in ((20260718, 1, 128, 4), (20260719, 2, 256, 8)):
@@ -8312,10 +8320,10 @@ def test_fa4_bf16_causal_gapped_qkv_forward_backward(mojo_h100, monkeypatch):
                 batch, seqlen, 3 * width, generator=generator, dtype=torch.float32
             )
             * 0.25
-        ).to(torch.bfloat16)
+        ).to(dtype)
         grad_output = torch.randn(
             batch, heads, seqlen, head_dim, generator=generator, dtype=torch.float32
-        ).to(torch.bfloat16)
+        ).to(dtype)
 
         def qkv_views(fused):
             return tuple(
@@ -8350,7 +8358,7 @@ def test_fa4_bf16_causal_gapped_qkv_forward_backward(mojo_h100, monkeypatch):
             "ScaledDotProductFlashAttentionBackward0"
         )
         assert backward_counter.call_count == calls_before
-        assert actual_output.dtype == torch.bfloat16
+        assert actual_output.dtype == dtype
         assert not actual_output._is_contiguous
         assert actual_output.transpose(1, 2)._is_contiguous
         actual_output.backward(grad_output.to(mojo_h100))
@@ -8368,13 +8376,13 @@ def test_fa4_bf16_causal_gapped_qkv_forward_backward(mojo_h100, monkeypatch):
     assert calls == {"forward": 2, "backward": 2}
 
 
-def test_fa4_direct_flash_aten_returns_real_logsumexp(mojo_h100):
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16], ids=["bf16", "f16"])
+def test_fa4_direct_flash_aten_returns_real_logsumexp(mojo_h100, dtype):
     """The low-level flash op must not substitute zero backward metadata."""
     generator = torch.Generator().manual_seed(20260721)
     shape = (1, 4, 128, 64)
     query, key, value = (
-        (torch.randn(shape, generator=generator) * 0.25).to(torch.bfloat16)
-        for _ in range(3)
+        (torch.randn(shape, generator=generator) * 0.25).to(dtype) for _ in range(3)
     )
     mojo_inputs = [
         tensor.to(mojo_h100).requires_grad_() for tensor in (query, key, value)
@@ -8403,9 +8411,9 @@ def test_fa4_direct_flash_aten_returns_real_logsumexp(mojo_h100):
     assert (max_q, max_k) == (128, 128)
     assert rng.dtype == torch.uint64 and tuple(rng.shape) == (2,)
     assert offset.dtype == torch.uint64 and tuple(offset.shape) == ()
-    assert debug.dtype == torch.bfloat16 and debug.numel() == 0
+    assert debug.dtype == dtype and debug.numel() == 0
 
-    grad_output = torch.randn(shape, generator=generator).to(torch.bfloat16)
+    grad_output = torch.randn(shape, generator=generator).to(dtype)
     expected_output.backward(grad_output.float())
     output.backward(grad_output.to(mojo_h100))
     for actual, expected in zip(mojo_inputs, reference_inputs, strict=True):

--- a/tests/test_fa4_host_wiring.py
+++ b/tests/test_fa4_host_wiring.py
@@ -1,4 +1,4 @@
-"""Host-only contracts for the vendored H100 BF16 FA4 integration."""
+"""Host-only contracts for the vendored H100 FA4 integration (bf16 and f16)."""
 
 import math
 from pathlib import Path
@@ -80,7 +80,7 @@ def test_fa4_rejects_ineligible_regimes_before_loading_or_device_work(
         }
         kwargs.update(overrides)
         assert (
-            aten_fast.fast_fa4_bf16_d64_causal_forward(query, key, value, **kwargs)
+            aten_fast.fast_fa4_16bit_d64_causal_forward(query, key, value, **kwargs)
             is aten_fast.NOT_HANDLED
         )
 
@@ -141,7 +141,7 @@ def test_fa4_forward_bridge_uses_dynamic_bthd_allocations(
         ),
     )
 
-    result = aten_fast.fast_fa4_bf16_d64_causal_forward(
+    result = aten_fast.fast_fa4_16bit_d64_causal_forward(
         *public, is_causal=True, scale=0.125
     )
     output, logsumexp, q_native, k_native, v_native = result
@@ -169,6 +169,120 @@ def test_fa4_forward_bridge_uses_dynamic_bthd_allocations(
     ]
 
 
+def test_fa4_forward_bridge_selects_f16_kernel_symbol_and_allocation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """f16 Q/K/V select the f16 bridge symbol and f16 output allocation.
+
+    Mirrors ``test_fa4_forward_bridge_uses_dynamic_bthd_allocations`` above,
+    only with f16 inputs: the bf16 bridge symbol must not be touched.
+    """
+    import torch_mojo_backend.eager_flash_attention as package
+
+    device = _device()
+    public = [
+        _tensor(
+            name,
+            shape=(3, 12, 256, 64),
+            device=device,
+            ptr=ptr,
+            dtype=aten_fast.DType.float16,
+        )
+        for name, ptr in zip(("q", "k", "v"), (10, 20, 30), strict=True)
+    ]
+    native = {
+        tensor.name: _tensor(
+            f"{tensor.name}_native",
+            shape=(3, 256, 12, 64),
+            device=device,
+            ptr=tensor._ptr + 100,
+            dtype=aten_fast.DType.float16,
+        )
+        for tensor in public
+    }
+    allocations = []
+    bridge_calls = []
+
+    def alloc(shape, dtype, actual_device):
+        result = _tensor(
+            f"alloc{len(allocations)}",
+            shape=shape,
+            dtype=dtype,
+            device=actual_device,
+            ptr=1000 + len(allocations),
+        )
+        allocations.append(result)
+        return result
+
+    def transpose(tensor, dim0, dim1):
+        assert (dim0, dim1) == (1, 2)
+        shape = list(tensor._shape)
+        shape[dim0], shape[dim1] = shape[dim1], shape[dim0]
+        return _tensor(
+            "output", shape, dtype=tensor._dtype, device=device, ptr=tensor._ptr
+        )
+
+    def forbidden(*_args, **_kwargs):
+        raise AssertionError("f16 inputs reached the bf16 bridge symbol")
+
+    monkeypatch.setattr(aten_fast, "_t", lambda tensor: tensor)
+    monkeypatch.setattr(
+        aten_fast, "_fa4_native_bthd", lambda tensor: native[tensor.name]
+    )
+    monkeypatch.setattr(aten_fast, "_alloc", alloc)
+    monkeypatch.setattr(aten_fast, "fast_aten_transpose", transpose)
+    monkeypatch.setattr(aten_fast, "_ctx_ptr", lambda actual_device: 9090)
+    monkeypatch.setattr(
+        package,
+        "load_fa4_ops",
+        lambda: SimpleNamespace(
+            flash_attention_fwd_bf16_d64_causal=forbidden,
+            flash_attention_fwd_f16_d64_causal=lambda *args: bridge_calls.append(args),
+        ),
+    )
+
+    result = aten_fast.fast_fa4_16bit_d64_causal_forward(
+        *public, is_causal=True, scale=0.125
+    )
+    output, logsumexp, q_native, k_native, v_native = result
+
+    assert output._shape == (3, 12, 256, 64)
+    assert output._dtype == aten_fast.DType.float16
+    assert logsumexp._shape == (3, 12, 256)
+    assert (q_native, k_native, v_native) == tuple(native[name] for name in "qkv")
+    assert [(item._shape, item._dtype) for item in allocations] == [
+        ((3, 256, 12, 64), aten_fast.DType.float16),
+        ((3, 12, 256), aten_fast.DType.float32),
+    ]
+    assert bridge_calls == [
+        (
+            110,
+            120,
+            130,
+            allocations[0]._ptr,
+            allocations[1]._ptr,
+            3,
+            256,
+            12,
+            0.125,
+            9090,
+        )
+    ]
+
+
+def test_fa4_rejects_mixed_bf16_f16_inputs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Q/K/V must share one dtype from {bf16, f16} -- mixing is not eligible."""
+    monkeypatch.setattr(aten_fast, "_t", lambda tensor: tensor)
+    device = _device()
+    q = _tensor("q", dtype=aten_fast.DType.bfloat16, device=device)
+    k = _tensor("k", dtype=aten_fast.DType.float16, device=device)
+    v = _tensor("v", dtype=aten_fast.DType.bfloat16, device=device)
+    assert (
+        aten_fast._fa4_16bit_d64_causal_inputs(q, k, v, None, 0.0, True, None, False)
+        is None
+    )
+
+
 def test_fa4_strided_layout_contract_is_strict() -> None:
     shape = (2, 256, 12, 64)
     token_stride = 3 * shape[2] * shape[3]
@@ -177,6 +291,16 @@ def test_fa4_strided_layout_contract_is_strict() -> None:
         "q_native", shape=shape, ptr=0x1000, strides=strides, contiguous=False
     )
     assert aten_fast._fa4_strided_bthd_layout(eligible)
+    # f16 is the same 2-byte width as bf16, so the same layout is eligible.
+    eligible_f16 = _tensor(
+        "q_native_f16",
+        shape=shape,
+        ptr=0x1000,
+        strides=strides,
+        contiguous=False,
+        dtype=aten_fast.DType.float16,
+    )
+    assert aten_fast._fa4_strided_bthd_layout(eligible_f16)
 
     invalid = []
     for updates in (
@@ -188,6 +312,7 @@ def test_fa4_strided_layout_contract_is_strict() -> None:
         {"_strides": (strides[0] + 8, strides[1], 64, 1)},
         {"_strides": (strides[0], strides[1], 64, 2)},
         {"_strides": (strides[0], strides[1] + 2, 64, 1)},
+        {"_dtype": aten_fast.DType.float32, "_itemsize": 4},
     ):
         candidate = SimpleNamespace(**vars(eligible))
         for name, value in updates.items():
@@ -267,7 +392,9 @@ def test_fa4_canonical_fused_qkv_uses_zero_copy_strided_forward_bridge(
     )
 
     output, logsumexp, q_native, k_native, v_native = (
-        aten_fast.fast_fa4_bf16_d64_causal_forward(*public, is_causal=True, scale=0.125)
+        aten_fast.fast_fa4_16bit_d64_causal_forward(
+            *public, is_causal=True, scale=0.125
+        )
     )
 
     physical_strides = (batch_stride, token_stride, head_dim, 1)
@@ -362,7 +489,7 @@ def test_fa4_unsupported_public_layout_copies_and_uses_contiguous_fallback(
         ),
     )
 
-    result = aten_fast.fast_fa4_bf16_d64_causal_forward(
+    result = aten_fast.fast_fa4_16bit_d64_causal_forward(
         *public, is_causal=True, scale=0.125
     )
 
@@ -393,7 +520,7 @@ def test_direct_flash_aten_returns_real_lse_and_cuda_shaped_auxiliaries(
     monkeypatch.setattr(aten_fast, "_t", lambda tensor: tensor)
     monkeypatch.setattr(
         aten_fast,
-        "fast_fa4_bf16_d64_causal_forward",
+        "fast_fa4_16bit_d64_causal_forward",
         lambda *_args: (output, logsumexp, *physical),
     )
 
@@ -476,7 +603,7 @@ def test_direct_flash_backward_materializes_strided_logsumexp(
     monkeypatch.setattr(aten_fast, "_tc", make_contiguous)
     monkeypatch.setattr(
         aten_fast,
-        "fast_fa4_bf16_d64_causal_backward",
+        "fast_fa4_16bit_d64_causal_backward",
         lambda *args: backward_calls.append(args) or "gradients",
     )
 
@@ -561,7 +688,7 @@ def test_fa4_combined_backward_bridge_allocates_exact_scratch(
         ),
     )
 
-    gradients = aten_fast.fast_fa4_bf16_d64_causal_backward(
+    gradients = aten_fast.fast_fa4_16bit_d64_causal_backward(
         q_native, k_native, v_native, output, logsumexp, grad_output, 0.125
     )
 
@@ -689,7 +816,7 @@ def test_fa4_canonical_fused_qkv_uses_strided_backward_bridge(
         ),
     )
 
-    gradients = aten_fast.fast_fa4_bf16_d64_causal_backward(
+    gradients = aten_fast.fast_fa4_16bit_d64_causal_backward(
         q_native, k_native, v_native, output, logsumexp, grad_output, 0.125
     )
 
@@ -750,7 +877,7 @@ def test_fa4_eligible_backward_routes_to_native_flash_with_public_inputs(
     def forbidden(*_args, **_kwargs):
         raise AssertionError("an eligible FA4 call built a custom autograd node")
 
-    monkeypatch.setattr(aten_fast, "_fa4_bf16_d64_causal_inputs", eligible)
+    monkeypatch.setattr(aten_fast, "_fa4_16bit_d64_causal_inputs", eligible)
     monkeypatch.setattr(
         torch.ops.aten._scaled_dot_product_flash_attention, "default", flash
     )

--- a/torch_mojo_backend/eager_flash_attention/fa4_ops.mojo
+++ b/torch_mojo_backend/eager_flash_attention/fa4_ops.mojo
@@ -61,6 +61,55 @@ def flash_attention_fwd_bf16_d64_causal(
     return PythonObject(None)
 
 
+def flash_attention_fwd_f16_d64_causal(
+    mut py_self: PythonObject,
+    mut args: PythonObject,
+) raises -> PythonObject:
+    """Same dense d64 causal forward as the bf16 entry point above, only the
+    comptime ``dtype`` differs. The f16 RS (register-A) wgmma emitters live
+    in ``fa4_wgmma_f16.mojo`` and are selected inside the shared kernel by
+    ``comptime if dtype == DType.float16`` -- bf16 keeps the stdlib path
+    byte-identical."""
+    var q_addr = Int(py=args[0])
+    var k_addr = Int(py=args[1])
+    var v_addr = Int(py=args[2])
+    var out_addr = Int(py=args[3])
+    var lse_addr = Int(py=args[4])
+    var batch = Int(py=args[5])
+    var seqlen = Int(py=args[6])
+    var nheads = Int(py=args[7])
+    var softmax_scale = Float32(py=args[8])
+    var ctx_addr = Int(py=args[9])
+
+    if batch <= 0 or seqlen <= 0 or nheads <= 0:
+        return PythonObject(None)
+
+    launch_fwd_fa4[
+        DType.float16,
+        64,
+        False,
+        True,
+        1,
+        False,
+        False,
+        False,
+        0,
+    ](
+        batch,
+        seqlen,
+        nheads,
+        softmax_scale,
+        q_addr,
+        k_addr,
+        v_addr,
+        out_addr,
+        lse_addr,
+        0,
+        ctx_addr,
+    )
+    return PythonObject(None)
+
+
 def flash_attention_bwd_bf16_d64_causal(
     mut py_self: PythonObject,
     mut args: PythonObject,
@@ -137,6 +186,85 @@ def flash_attention_bwd_bf16_d64_causal(
     return PythonObject(None)
 
 
+def flash_attention_bwd_f16_d64_causal(
+    mut py_self: PythonObject,
+    mut args: PythonObject,
+) raises -> PythonObject:
+    """Same dense d64 causal backward as the bf16 entry point above, only
+    the comptime ``dtype`` differs (see ``flash_attention_fwd_f16_d64_causal``
+    for the f16 RS wgmma note)."""
+    var q_addr = Int(py=args[0])
+    var k_addr = Int(py=args[1])
+    var v_addr = Int(py=args[2])
+    var out_addr = Int(py=args[3])
+    var dout_addr = Int(py=args[4])
+    var lse_addr = Int(py=args[5])
+    var dq_addr = Int(py=args[6])
+    var dk_addr = Int(py=args[7])
+    var dv_addr = Int(py=args[8])
+    var dpsum_addr = Int(py=args[9])
+    var lse_log2_addr = Int(py=args[10])
+    var dq_accum_addr = Int(py=args[11])
+    var batch = Int(py=args[12])
+    var seqlen = Int(py=args[13])
+    var nheads = Int(py=args[14])
+    var softmax_scale = Float32(py=args[15])
+    var ctx_addr = Int(py=args[16])
+
+    if batch <= 0 or seqlen <= 0 or nheads <= 0:
+        return PythonObject(None)
+
+    launch_bwd_preprocess[
+        DType.float16, 64, False, True, 1, False
+    ](
+        batch,
+        seqlen,
+        nheads,
+        out_addr,
+        dout_addr,
+        lse_addr,
+        dpsum_addr,
+        lse_log2_addr,
+        dq_accum_addr,
+        0,
+        0,
+        0,
+        ctx_addr,
+    )
+    launch_bwd_main[
+        DType.float16, 64, False, True, 1, False, False, 0
+    ](
+        batch,
+        seqlen,
+        nheads,
+        softmax_scale,
+        q_addr,
+        k_addr,
+        v_addr,
+        dout_addr,
+        dk_addr,
+        dv_addr,
+        lse_log2_addr,
+        dpsum_addr,
+        dq_accum_addr,
+        0,
+        ctx_addr,
+    )
+    launch_bwd_convert[
+        DType.float16, 64, False, True, 1, False
+    ](
+        batch,
+        seqlen,
+        nheads,
+        softmax_scale,
+        dq_accum_addr,
+        dq_addr,
+        0,
+        ctx_addr,
+    )
+    return PythonObject(None)
+
+
 def _check_strided_qkv_layout(
     name: StaticString,
     addr: Int,
@@ -150,7 +278,9 @@ def _check_strided_qkv_layout(
     """Reject any Q/K/V layout outside the strict zero-copy regime.
 
     Runs BEFORE any descriptor is created or kernel enqueued so a
-    violation never partially launches. Strides are in bf16 ELEMENTS.
+    violation never partially launches. Strides are in Q/K/V dtype
+    ELEMENTS (bf16 or f16 -- shared by both entry-point families since
+    both are 2-byte types with identical 16-byte-multiple math).
     """
     if b_stride <= 0 or s_stride <= 0 or h_stride <= 0 or d_stride <= 0:
         raise Error(
@@ -337,6 +467,105 @@ def flash_attention_fwd_bf16_d64_causal_strided_qkv(
     return PythonObject(None)
 
 
+def flash_attention_fwd_f16_d64_causal_strided_qkv(
+    mut py_self: PythonObject,
+    mut args: PythonObject,
+) raises -> PythonObject:
+    """Same zero-copy strided fwd as the bf16 entry point above (see its
+    docstring for the layout contract), only the comptime ``dtype`` differs.
+    """
+    var q_addr = Int(py=args[0])
+    var q_b_stride = Int(py=args[1])
+    var q_s_stride = Int(py=args[2])
+    var q_h_stride = Int(py=args[3])
+    var q_d_stride = Int(py=args[4])
+    var k_addr = Int(py=args[5])
+    var k_b_stride = Int(py=args[6])
+    var k_s_stride = Int(py=args[7])
+    var k_h_stride = Int(py=args[8])
+    var k_d_stride = Int(py=args[9])
+    var v_addr = Int(py=args[10])
+    var v_b_stride = Int(py=args[11])
+    var v_s_stride = Int(py=args[12])
+    var v_h_stride = Int(py=args[13])
+    var v_d_stride = Int(py=args[14])
+    var out_addr = Int(py=args[15])
+    var lse_addr = Int(py=args[16])
+    var batch = Int(py=args[17])
+    var seqlen = Int(py=args[18])
+    var nheads = Int(py=args[19])
+    var softmax_scale = Float32(py=args[20])
+    var ctx_addr = Int(py=args[21])
+
+    _check_strided_qkv_args(batch, seqlen, nheads)
+    _check_strided_qkv_layout(
+        "q",
+        q_addr,
+        q_b_stride,
+        q_s_stride,
+        q_h_stride,
+        q_d_stride,
+        seqlen,
+        nheads,
+    )
+    _check_strided_qkv_layout(
+        "k",
+        k_addr,
+        k_b_stride,
+        k_s_stride,
+        k_h_stride,
+        k_d_stride,
+        seqlen,
+        nheads,
+    )
+    _check_strided_qkv_layout(
+        "v",
+        v_addr,
+        v_b_stride,
+        v_s_stride,
+        v_h_stride,
+        v_d_stride,
+        seqlen,
+        nheads,
+    )
+
+    launch_fwd_fa4[
+        DType.float16,
+        64,
+        False,
+        True,
+        1,
+        False,
+        False,
+        False,
+        0,
+        strided_qkv=True,
+    ](
+        batch,
+        seqlen,
+        nheads,
+        softmax_scale,
+        q_addr,
+        k_addr,
+        v_addr,
+        out_addr,
+        lse_addr,
+        0,
+        ctx_addr,
+        q_b_stride=q_b_stride,
+        q_s_stride=q_s_stride,
+        q_h_stride=q_h_stride,
+        q_d_stride=q_d_stride,
+        k_s_stride=k_s_stride,
+        k_h_stride=k_h_stride,
+        k_d_stride=k_d_stride,
+        v_s_stride=v_s_stride,
+        v_h_stride=v_h_stride,
+        v_d_stride=v_d_stride,
+    )
+    return PythonObject(None)
+
+
 def flash_attention_bwd_bf16_d64_causal_strided_qkv(
     mut py_self: PythonObject,
     mut args: PythonObject,
@@ -477,6 +706,145 @@ def flash_attention_bwd_bf16_d64_causal_strided_qkv(
     return PythonObject(None)
 
 
+def flash_attention_bwd_f16_d64_causal_strided_qkv(
+    mut py_self: PythonObject,
+    mut args: PythonObject,
+) raises -> PythonObject:
+    """Same zero-copy strided bwd as the bf16 entry point above (see its
+    docstring for the layout contract), only the comptime ``dtype`` differs.
+    """
+    var q_addr = Int(py=args[0])
+    var q_b_stride = Int(py=args[1])
+    var q_s_stride = Int(py=args[2])
+    var q_h_stride = Int(py=args[3])
+    var q_d_stride = Int(py=args[4])
+    var k_addr = Int(py=args[5])
+    var k_b_stride = Int(py=args[6])
+    var k_s_stride = Int(py=args[7])
+    var k_h_stride = Int(py=args[8])
+    var k_d_stride = Int(py=args[9])
+    var v_addr = Int(py=args[10])
+    var v_b_stride = Int(py=args[11])
+    var v_s_stride = Int(py=args[12])
+    var v_h_stride = Int(py=args[13])
+    var v_d_stride = Int(py=args[14])
+    var out_addr = Int(py=args[15])
+    var dout_addr = Int(py=args[16])
+    var lse_addr = Int(py=args[17])
+    var dq_addr = Int(py=args[18])
+    var dk_addr = Int(py=args[19])
+    var dv_addr = Int(py=args[20])
+    var dpsum_addr = Int(py=args[21])
+    var lse_log2_addr = Int(py=args[22])
+    var dq_accum_addr = Int(py=args[23])
+    var batch = Int(py=args[24])
+    var seqlen = Int(py=args[25])
+    var nheads = Int(py=args[26])
+    var softmax_scale = Float32(py=args[27])
+    var ctx_addr = Int(py=args[28])
+
+    # The whole layout contract is validated up front so preprocess
+    # never launches for an unsupported layout.
+    _check_strided_qkv_args(batch, seqlen, nheads)
+    _check_strided_qkv_layout(
+        "q",
+        q_addr,
+        q_b_stride,
+        q_s_stride,
+        q_h_stride,
+        q_d_stride,
+        seqlen,
+        nheads,
+    )
+    _check_strided_qkv_layout(
+        "k",
+        k_addr,
+        k_b_stride,
+        k_s_stride,
+        k_h_stride,
+        k_d_stride,
+        seqlen,
+        nheads,
+    )
+    _check_strided_qkv_layout(
+        "v",
+        v_addr,
+        v_b_stride,
+        v_s_stride,
+        v_h_stride,
+        v_d_stride,
+        seqlen,
+        nheads,
+    )
+
+    launch_bwd_preprocess[
+        DType.float16, 64, False, True, 1, False
+    ](
+        batch,
+        seqlen,
+        nheads,
+        out_addr,
+        dout_addr,
+        lse_addr,
+        dpsum_addr,
+        lse_log2_addr,
+        dq_accum_addr,
+        0,
+        0,
+        0,
+        ctx_addr,
+    )
+    launch_bwd_main[
+        DType.float16,
+        64,
+        False,
+        True,
+        1,
+        False,
+        False,
+        0,
+        strided_qkv=True,
+    ](
+        batch,
+        seqlen,
+        nheads,
+        softmax_scale,
+        q_addr,
+        k_addr,
+        v_addr,
+        dout_addr,
+        dk_addr,
+        dv_addr,
+        lse_log2_addr,
+        dpsum_addr,
+        dq_accum_addr,
+        0,
+        ctx_addr,
+        q_s_stride=q_s_stride,
+        q_h_stride=q_h_stride,
+        q_d_stride=q_d_stride,
+        k_s_stride=k_s_stride,
+        k_h_stride=k_h_stride,
+        k_d_stride=k_d_stride,
+        v_s_stride=v_s_stride,
+        v_h_stride=v_h_stride,
+        v_d_stride=v_d_stride,
+    )
+    launch_bwd_convert[
+        DType.float16, 64, False, True, 1, False
+    ](
+        batch,
+        seqlen,
+        nheads,
+        softmax_scale,
+        dq_accum_addr,
+        dq_addr,
+        0,
+        ctx_addr,
+    )
+    return PythonObject(None)
+
+
 @export
 def PyInit_fa4_ops() abi("C") -> PythonObject:
     try:
@@ -484,14 +852,26 @@ def PyInit_fa4_ops() abi("C") -> PythonObject:
         module.def_py_function[flash_attention_fwd_bf16_d64_causal](
             "flash_attention_fwd_bf16_d64_causal"
         )
+        module.def_py_function[flash_attention_fwd_f16_d64_causal](
+            "flash_attention_fwd_f16_d64_causal"
+        )
         module.def_py_function[flash_attention_bwd_bf16_d64_causal](
             "flash_attention_bwd_bf16_d64_causal"
+        )
+        module.def_py_function[flash_attention_bwd_f16_d64_causal](
+            "flash_attention_bwd_f16_d64_causal"
         )
         module.def_py_function[flash_attention_fwd_bf16_d64_causal_strided_qkv](
             "flash_attention_fwd_bf16_d64_causal_strided_qkv"
         )
+        module.def_py_function[flash_attention_fwd_f16_d64_causal_strided_qkv](
+            "flash_attention_fwd_f16_d64_causal_strided_qkv"
+        )
         module.def_py_function[flash_attention_bwd_bf16_d64_causal_strided_qkv](
             "flash_attention_bwd_bf16_d64_causal_strided_qkv"
+        )
+        module.def_py_function[flash_attention_bwd_f16_d64_causal_strided_qkv](
+            "flash_attention_bwd_f16_d64_causal_strided_qkv"
         )
         return module.finalize()
     except error:

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -6479,7 +6479,7 @@ def _sdpa_masked_math_forward(query, key, value, attn_mask, is_causal, scale):
     return out4, probs4
 
 
-def _fa4_bf16_d64_causal_inputs(
+def _fa4_16bit_d64_causal_inputs(
     query,
     key,
     value,
@@ -6489,7 +6489,16 @@ def _fa4_bf16_d64_causal_inputs(
     scale=None,
     enable_gqa=False,
 ):
-    """Return eligible public BHTD inputs without doing any device work."""
+    """Return eligible public BHTD inputs (bf16 or f16) without doing any
+    device work.
+
+    bf16 and f16 are the same width on Hopper's tensor cores -- same WGMMA
+    tile shapes, same f32 accumulator -- so both share this eligibility
+    gate and the launch cache below; f16 only needs its own RS wgmma
+    emitter because the stdlib's register-operand overload is hardcoded
+    bf16 (see ``fa4_wgmma_f16.mojo``). Q/K/V must all share one dtype from
+    this set -- no bf16/f16 mixing.
+    """
     q = _t(query)
     k = _t(key)
     v = _t(value)
@@ -6507,9 +6516,9 @@ def _fa4_bf16_d64_causal_inputs(
         or q._device != v._device
         or q._device.api != "cuda"
         or q._device.architecture_name != "sm_90a"
-        or q._dtype != DType.bfloat16
-        or k._dtype != DType.bfloat16
-        or v._dtype != DType.bfloat16
+        or q._dtype not in (DType.bfloat16, DType.float16)
+        or k._dtype != q._dtype
+        or v._dtype != q._dtype
         or len(q._shape) != 4
         or tuple(q._shape) != tuple(k._shape)
         or tuple(q._shape) != tuple(v._shape)
@@ -6533,12 +6542,14 @@ def _fa4_strided_bthd_layout(tensor) -> bool:
     The pointer is already adjusted to logical ``[0, 0, 0, 0]`` and strides
     are element strides.  Keep this predicate in lockstep with the defensive
     validation in the Mojo bridge so an unsupported view is materialized
-    before any FA4 launch is selected.
+    before any FA4 launch is selected.  bf16 and f16 are both 2-byte types,
+    so the same byte-alignment math (16-byte-multiple strides) applies to
+    either.
     """
     if (
         tensor is None
-        or tensor._dtype != DType.bfloat16
-        or tensor._itemsize != DType.bfloat16.size_in_bytes
+        or tensor._dtype not in (DType.bfloat16, DType.float16)
+        or tensor._itemsize != tensor._dtype.size_in_bytes
         or len(tensor._shape) != 4
         or len(tensor._strides) != 4
     ):
@@ -6589,7 +6600,7 @@ def _fa4_prepare_qkv_bridge(q_native, k_native, v_native):
     return qkv, False
 
 
-def fast_fa4_bf16_d64_causal_forward(
+def fast_fa4_16bit_d64_causal_forward(
     query,
     key,
     value,
@@ -6599,12 +6610,13 @@ def fast_fa4_bf16_d64_causal_forward(
     scale=None,
     enable_gqa=False,
 ):
-    """Run vendored FA4 and return output/LSE plus saved physical inputs.
+    """Run vendored FA4 (bf16 or f16) and return output/LSE plus saved
+    physical inputs.
 
     Loading the bridge happens before materialization or allocation, so a
     packaging/compiler error cannot leave unnecessary device work queued.
     """
-    inputs = _fa4_bf16_d64_causal_inputs(
+    inputs = _fa4_16bit_d64_causal_inputs(
         query, key, value, attn_mask, dropout_p, is_causal, scale, enable_gqa
     )
     if inputs is None:
@@ -6614,6 +6626,7 @@ def fast_fa4_bf16_d64_causal_forward(
 
     fa4_ops = load_fa4_ops()
     q, k, v = inputs
+    qkv_dtype = q._dtype
     q_native = _fa4_native_bthd(q)
     k_native = _fa4_native_bthd(k)
     v_native = _fa4_native_bthd(v)
@@ -6626,12 +6639,17 @@ def fast_fa4_bf16_d64_causal_forward(
 
     batch, heads, seqlen, head_dim = q._shape
     physical_shape = (batch, seqlen, heads, head_dim)
-    out_native = _alloc(physical_shape, DType.bfloat16, q._device)
+    out_native = _alloc(physical_shape, qkv_dtype, q._device)
     logsumexp = _alloc((batch, heads, seqlen), DType.float32, q._device)
     scale_value = float(scale) if scale is not None else 1.0 / math.sqrt(head_dim)
     if use_strided_qkv:
+        forward_fn = (
+            fa4_ops.flash_attention_fwd_bf16_d64_causal_strided_qkv
+            if qkv_dtype == DType.bfloat16
+            else fa4_ops.flash_attention_fwd_f16_d64_causal_strided_qkv
+        )
         _device_call(
-            fa4_ops.flash_attention_fwd_bf16_d64_causal_strided_qkv,
+            forward_fn,
             q_native._ptr,
             *q_native._strides,
             k_native._ptr,
@@ -6648,8 +6666,13 @@ def fast_fa4_bf16_d64_causal_forward(
             keepalive=(q_native, k_native, v_native, out_native, logsumexp),
         )
     else:
+        forward_fn = (
+            fa4_ops.flash_attention_fwd_bf16_d64_causal
+            if qkv_dtype == DType.bfloat16
+            else fa4_ops.flash_attention_fwd_f16_d64_causal
+        )
         _device_call(
-            fa4_ops.flash_attention_fwd_bf16_d64_causal,
+            forward_fn,
             q_native._ptr,
             k_native._ptr,
             v_native._ptr,
@@ -6668,14 +6691,16 @@ def fast_fa4_bf16_d64_causal_forward(
     return output, logsumexp, q_native, k_native, v_native
 
 
-def fast_fa4_bf16_d64_causal_backward(
+def fast_fa4_16bit_d64_causal_backward(
     q_native, k_native, v_native, output, logsumexp, grad_output, scale
 ):
-    """Enqueue FA4 preprocess/main/convert and return public BHTD grads."""
+    """Enqueue FA4 preprocess/main/convert and return public BHTD grads
+    (bf16 or f16, matching Q/K/V's shared dtype)."""
     from torch_mojo_backend.eager_flash_attention import load_fa4_ops
 
     fa4_ops = load_fa4_ops()
     batch, seqlen, heads, head_dim = q_native._shape
+    qkv_dtype = q_native._dtype
     prepared = _fa4_prepare_qkv_bridge(q_native, k_native, v_native)
     if prepared is None:
         return NOT_HANDLED
@@ -6693,9 +6718,9 @@ def fast_fa4_bf16_d64_causal_backward(
         return NOT_HANDLED
 
     physical_shape = (batch, seqlen, heads, head_dim)
-    dq_native = _alloc(physical_shape, DType.bfloat16, q_native._device)
-    dk_native = _alloc(physical_shape, DType.bfloat16, q_native._device)
-    dv_native = _alloc(physical_shape, DType.bfloat16, q_native._device)
+    dq_native = _alloc(physical_shape, qkv_dtype, q_native._device)
+    dk_native = _alloc(physical_shape, qkv_dtype, q_native._device)
+    dv_native = _alloc(physical_shape, qkv_dtype, q_native._device)
     seqlen_padded = ((seqlen + 127) // 128) * 128
     stats_shape = (batch, heads, seqlen_padded)
     dpsum = _alloc(stats_shape, DType.float32, q_native._device)
@@ -6704,8 +6729,13 @@ def fast_fa4_bf16_d64_causal_backward(
         (batch * heads * seqlen_padded * head_dim,), DType.float32, q_native._device
     )
     if use_strided_qkv:
+        backward_fn = (
+            fa4_ops.flash_attention_bwd_bf16_d64_causal_strided_qkv
+            if qkv_dtype == DType.bfloat16
+            else fa4_ops.flash_attention_bwd_f16_d64_causal_strided_qkv
+        )
         _device_call(
-            fa4_ops.flash_attention_bwd_bf16_d64_causal_strided_qkv,
+            backward_fn,
             q_native._ptr,
             *q_native._strides,
             k_native._ptr,
@@ -6742,8 +6772,13 @@ def fast_fa4_bf16_d64_causal_backward(
             ),
         )
     else:
+        backward_fn = (
+            fa4_ops.flash_attention_bwd_bf16_d64_causal
+            if qkv_dtype == DType.bfloat16
+            else fa4_ops.flash_attention_bwd_f16_d64_causal
+        )
         _device_call(
-            fa4_ops.flash_attention_bwd_bf16_d64_causal,
+            backward_fn,
             q_native._ptr,
             k_native._ptr,
             v_native._ptr,
@@ -7087,7 +7122,7 @@ def fast_aten__scaled_dot_product_flash_attention(
 ):
     if dropout_p != 0.0 or return_debug_mask:
         return NOT_HANDLED
-    result = fast_fa4_bf16_d64_causal_forward(
+    result = fast_fa4_16bit_d64_causal_forward(
         query, key, value, None, 0.0, is_causal, scale, False
     )
     if result is NOT_HANDLED:
@@ -7131,8 +7166,8 @@ def fast_aten__scaled_dot_product_flash_attention_backward(
     *,
     scale=None,
 ):
-    """Dense lower-op autograd bridge for the vendored BF16 FA4 kernel."""
-    inputs = _fa4_bf16_d64_causal_inputs(
+    """Dense lower-op autograd bridge for the vendored bf16/f16 FA4 kernel."""
+    inputs = _fa4_16bit_d64_causal_inputs(
         query, key, value, None, dropout_p, is_causal, scale, False
     )
     grad = _t(grad_out)
@@ -7149,13 +7184,13 @@ def fast_aten__scaled_dot_product_flash_attention_backward(
         or max_k != seqlen
         or grad is None
         or grad._device != q._device
-        or grad._dtype != DType.bfloat16
+        or grad._dtype != q._dtype
         or tuple(grad._shape) != tuple(q._shape)
         or (
             output is not None
             and (
                 output._device != q._device
-                or output._dtype != DType.bfloat16
+                or output._dtype != q._dtype
                 or tuple(output._shape) != tuple(q._shape)
             )
         )
@@ -7163,6 +7198,7 @@ def fast_aten__scaled_dot_product_flash_attention_backward(
             lse is not None
             and (
                 lse._device != q._device
+                # LSE is always float32 regardless of Q/K/V's dtype.
                 or lse._dtype != DType.float32
                 or tuple(lse._shape) != (batch, heads, seqlen)
             )
@@ -7177,7 +7213,7 @@ def fast_aten__scaled_dot_product_flash_attention_backward(
         # payload. Recompute this direct lower-op forward so backward never
         # reads an inaccessible pointer. The high-level SDPA custom autograd
         # path retains its payload and does not take this compatibility path.
-        recomputed = fast_fa4_bf16_d64_causal_forward(
+        recomputed = fast_fa4_16bit_d64_causal_forward(
             q, k, v, None, 0.0, True, scale, False
         )
         if recomputed is NOT_HANDLED:
@@ -7198,7 +7234,7 @@ def fast_aten__scaled_dot_product_flash_attention_backward(
     if lse is None:
         return NOT_HANDLED
     scale_value = float(scale) if scale is not None else 1.0 / math.sqrt(q._shape[-1])
-    return fast_fa4_bf16_d64_causal_backward(
+    return fast_fa4_16bit_d64_causal_backward(
         q_native, k_native, v_native, output, lse, grad, scale_value
     )
 
@@ -8396,7 +8432,7 @@ def fast_aten_scaled_dot_product_attention(
         out, _ = result
         return out
 
-    fa4_result = fast_fa4_bf16_d64_causal_forward(
+    fa4_result = fast_fa4_16bit_d64_causal_forward(
         query, key, value, attn_mask, dropout_p, is_causal, scale, enable_gqa
     )
     if fa4_result is not NOT_HANDLED:

--- a/torch_mojo_backend/mojo_device/mojo_device_autograd.py
+++ b/torch_mojo_backend/mojo_device/mojo_device_autograd.py
@@ -583,7 +583,7 @@ def _scaled_dot_product_attention_autograd(
     # for the generic math/dropout fallback, which has no native backward op.
     if (
         needs_backward
-        and aten_fast._fa4_bf16_d64_causal_inputs(
+        and aten_fast._fa4_16bit_d64_causal_inputs(
             query, key, value, attn_mask, dropout_p, is_causal, scale, enable_gqa
         )
         is not None


### PR DESCRIPTION
## What

Enables f16 (`torch.float16`) for the H100 (sm_90a) FA4 fused flash-attention
kernel family (`torch_mojo_backend/eager_flash_attention/`). Previously only
bf16 reached these kernels; f16 fell through to the slow math decomposition
(or, for the direct `aten::_scaled_dot_product_flash_attention` op, was not
handled at all).

## Why this was cheap

The compute kernels (`fwd_fa4_kernel` / `launch_fwd_fa4` in
`fa4_fwd_kernel.mojo` / `fa4_fwd_launch.mojo`, and the bwd counterparts) are
already `comptime dtype: DType`-parametric, and the f16 register-operand
(RS) WGMMA emitters were **already written** in `fa4_wgmma_f16.mojo` and
already wired at the three RS call sites behind `comptime if dtype ==
DType.float16` (fwd PV, bwd dV, bwd dK — accumulating in f32 either way).
Only the Python/Mojo boundary hardcoded bf16, so f16 never reached any of it:

1. **`fa4_ops.mojo`** only exported bf16 `def_py_function` entries
   (`flash_attention_{fwd,bwd}_bf16_d64_causal[_strided_qkv]`). This PR adds
   the four parallel f16 entries, each instantiating the same launcher with
   `DType.float16` in place of `DType.bfloat16` — otherwise byte-for-byte the
   same as its bf16 sibling. The bf16 functions are untouched.
2. **`aten_fast.py`** hardcoded `DType.bfloat16` in ~6 places (the
   eligibility gate, the strided-layout predicate, two allocation sites, and
   two kernel-symbol selections). These now accept `{bfloat16, float16}`
   (Q/K/V must share one dtype — no mixing), derive the allocation dtype from
   the inputs, and pick the bf16 or f16 bridge symbol based on it. LSE stays
   `float32` unconditionally, as before.
   - `_fa4_bf16_d64_causal_inputs` → `_fa4_16bit_d64_causal_inputs`, and
     `fast_fa4_bf16_d64_causal_{forward,backward}` →
     `fast_fa4_16bit_d64_causal_{forward,backward}` (now genuinely
     dtype-generic; all call sites updated, including
     `mojo_device_autograd.py`).

## Tests

- `tests/test_fa4_host_wiring.py` (host-only, no GPU): added f16 coverage —
  the eligibility gate accepts f16, selects the f16 bridge symbol and f16
  output allocation (mirrors the existing bf16 test), the strided-layout
  predicate accepts an f16 view, and mixed bf16/f16 Q/K/V is rejected.
- `tests/test_eager_kernels.py` (H100 GPU): parametrized
  `test_fa4_causal_gapped_qkv_forward_backward` (gapped/strided QKV,
  forward+backward, two shapes, cache-reuse assertions) and
  `test_fa4_direct_flash_aten_returns_real_logsumexp` (direct
  `_scaled_dot_product_flash_attention` op, real LSE check) over
  `{bf16, f16}`, same tolerances as the existing bf16 cases (`atol=rtol=2e-2`
  output, `5e-2` grads — f16 has *more* mantissa bits than bf16, so this is
  not a loosened bar). `test_fa4_autograd_rejects_saved_tensor_mutation`
  (version-counter guard, dtype-independent) was left bf16-only.
- Result: **all new and existing FA4/SDPA tests pass** — 6/6 new
  parametrized cases, plus the surrounding 53 sdpa/fa4/fused_flash tests in
  `test_eager_kernels.py` (4 pre-existing skips are gfx942-only fused
  kernels, correctly skipped on this H100 box) and 13/13 in
  `test_fa4_host_wiring.py`.
- No numerics bug was found — f16 worked correctly on the first end-to-end
  run (the RS emitters accumulate in f32, as intended).

## Blast radius (asm-compare)

Pristine baseline worktree from `upstream/main` @ `2bb5910` vs this branch,
`scripts/compare_kernel_asm.py --kernel-dir torch_mojo_backend/eager_flash_attention`
(this module has no `-D` gates, so it's an "ungated" single build that
instantiates every device kernel reachable from `PyInit_fa4_ops`, i.e. every
Python-callable entry point).

**sm_90a**: before 5 kernels, after 10 (5 new f16 kernels, as expected — no
kernels vanished). Of the 5 pre-existing (bf16) kernels, the raw diff flags
3 as "changed"; inspecting them shows the *only* difference is a
module-global `extern_ptr_syml_<N>` counter (an auto-numbered symbol for a
kernel's dynamic-shared-memory declaration) shifting because the
compilation unit now contains more kernels overall. Confirmed
byte-identical after normalizing that counter:
```
diff <(sed -E 's/extern_ptr_syml_[0-9]+/extern_ptr_syml_N/g' before/<kernel>.ptx) \
     <(sed -E 's/extern_ptr_syml_[0-9]+/extern_ptr_syml_N/g' after/<kernel>.ptx)
# → identical, for all 3 flagged kernels
```
No bf16 kernel's actual instructions, registers, or control flow changed.

**gfx942**: both before and after **fail identically** to build this module
(`error: failed to run the pass manager for offload functions`) — this
family unconditionally uses Hopper-only TMA/WGMMA (`max.gpu.host.nvidia.tma`),
so it was never reachable on AMD, before or after. AMD is untouched.

## Benchmarks (`benchmarks/test_attention.py`, H100 PCIe, device time only)

Ratio = ours / stock PyTorch (device time), lower is better. "before" =
pristine `upstream/main` worktree, "after" = this branch, same selection
(`-k f16`, which also matches `bf16` test ids as a substring — so this table
covers both dtypes from the same two runs).

| node | shape | dtype | before | after |
|---|---|---|---|---|
| `_scaled_dot_product_flash_attention` (direct op) | B8H12S1024D64 | f16 | **SKIPPED** (not implemented) | **1.352** |
| `_scaled_dot_product_flash_attention` (direct op) | B8H12S1024D64 | bf16 | 1.365 (recorded baseline) | PASS, unchanged (dead band) |
| `_scaled_dot_product_flash_attention_backward` | B8H12S1024D64 | f16 | **SKIPPED** | **0.720** |
| `_scaled_dot_product_flash_attention_backward` | B8H12S1024D64 | bf16 | 0.716 (recorded baseline) | PASS, unchanged (dead band) |
| `_scaled_dot_product_efficient_attention` | B8H12S1024D64 | f16 | 3.455 (decomposition) | **0.725** |
| `scaled_dot_product_attention` (composite) | B8H12S1024D64 | f16 | 11.147 (decomposition) | **2.246** |
| `_scaled_dot_product_flash_attention[_backward]` | B1H16S4096D128 | f16/bf16 | SKIPPED | SKIPPED (unchanged — out of scope, see below) |
| `_scaled_dot_product_efficient_attention` / composite | B1H16S4096D128 | f16 | 3.117 / 10.559 | 3.129 / 10.621 (unchanged, within noise) |

**f16 now measures parity with bf16** on every fused-eligible node (direct
op: 1.352 vs bf16's 1.365; backward: 0.720 vs bf16's 0.716 — backward is
already *faster* than stock). All bf16 nodes passed silently within the
suite's ±8% dead band on both trees (no measurable movement), consistent
with the asm-compare finding of byte-identical bf16 device code.

**Transparency note**: the direct-op forward ratio (1.352/1.365) sits above
the AGENTS.md 10% kernel-acceptance bar in this particular low-level
op-vs-op microbenchmark. This is a **pre-existing gap in the shared bf16/f16
kernel itself**, not something this PR introduces or was scoped to fix — the
goal here was f16 reaching bf16's existing performance, which it does (f16
is marginally *faster* than the last-recorded bf16 number). Backward already
clears the bar. Further closing the ~35% forward gap to stock is a separate
kernel-optimization engagement affecting both dtypes equally.

## Known follow-up (explicitly out of scope)

`B1H16S4096D128` (`head_dim=128`) stays on the math decomposition for both
bf16 and f16 — FA4's dense entry points are `head_dim=64`-only. Not touched
here.

## Rule confirmed unbroken

Per AGENTS.md eager-mode rules: no CUDA/cuDNN/cuBLAS dependency was added
(the f16 path reuses the existing pure-Mojo WGMMA/TMA kernels); shapes
remain fully dynamic (no new hardcoded-shape kernels); f32 accumulation is
preserved for f16 exactly as it already was for bf16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TFYWf7vJNAv5VadqSz3bRu
