### PR TITLE
Fix 4-6x eager masked_fill/where slowness on small (and large) shapes

### DIFF
--- a/benchmarks/baselines.html
+++ b/benchmarks/baselines.html
@@ -7461,14 +7461,14 @@ document.addEventListener("DOMContentLoaded", boot);
               "shapes": {
                 "A_357x789": {
                   "layouts": {
-                    "Scalar": 6.197,
-                    "Tensor": 5.443
+                    "Scalar": 1.008,
+                    "Tensor": 1.067
                   }
                 },
                 "C_4096x4096": {
                   "layouts": {
-                    "Scalar": 2.276,
-                    "Tensor": 2.278
+                    "Scalar": 1.015,
+                    "Tensor": 1.025
                   }
                 }
               }
@@ -7481,14 +7481,14 @@ document.addEventListener("DOMContentLoaded", boot);
               "shapes": {
                 "A_357x789": {
                   "layouts": {
-                    "Scalar": 5.88,
-                    "Tensor": 5.201
+                    "Scalar": 1.041,
+                    "Tensor": 1.101
                   }
                 },
                 "C_16777216": {
                   "layouts": {
-                    "Scalar": 2.27,
-                    "Tensor": 2.263
+                    "Scalar": 1.011,
+                    "Tensor": 1.025
                   }
                 }
               }
@@ -9191,12 +9191,12 @@ document.addEventListener("DOMContentLoaded", boot);
               "shapes": {
                 "A_357x789": {
                   "layouts": {
-                    "contig": 5.327
+                    "contig": 1.053
                   }
                 },
                 "C_4096x4096": {
                   "layouts": {
-                    "contig": 2.918
+                    "contig": 1.0
                   }
                 }
               }
@@ -9205,12 +9205,12 @@ document.addEventListener("DOMContentLoaded", boot);
               "shapes": {
                 "A_357x789": {
                   "layouts": {
-                    "contig": 4.88
+                    "contig": 1.013
                   }
                 },
                 "C_4096x4096": {
                   "layouts": {
-                    "contig": 1.643
+                    "contig": 1.0
                   }
                 }
               }

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -4784,6 +4784,128 @@ def test_fast_bitwise_scalar_operand_match_cpu(mojo_gpu):
             assert torch.equal(op(device, 21).cpu(), op(values, 21)), f"{op}, n={n}"
 
 
+# masked_fill / where.self: the WhereSelect flat-vec tier (`_where_bcast` in
+# data_movement_ops.mojo) and the MaskedFillScalar immediate-value fast path
+# (masked_fill(_).Scalar only -- see `_masked_fill_scalar_operands` in
+# aten_fast.py). Both were 4-6x slower than stock on the tiny A_357x789
+# benchmark shape before those tiers existed: the old code went through the
+# stdlib `elementwise` GPU dispatcher (per-call `compile_function`, plus a
+# six-division rank-4 coordinate decomposition per element even for a fully
+# contiguous, non-broadcasting case), and masked_fill's Scalar overload paid
+# a second full kernel launch (a Fill kernel) just to materialize its value
+# into a 0-d device tensor before WhereSelect could read it.
+_WHERE_FAMILY_DTYPES = [torch.float32, torch.bfloat16, torch.float16]
+
+
+def _where_family_operands(
+    n: int, dtype: torch.dtype
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Deterministic (input, other, mask): mask true on ~1/3 of elements."""
+    left = (torch.arange(n, dtype=torch.float32) % 97 - 48.0).to(dtype)
+    right = (torch.arange(n, dtype=torch.float32) % 61 - 30.0).to(dtype)
+    mask = (torch.arange(n) % 3) == 0
+    return left, right, mask
+
+
+@pytest.mark.parametrize("dtype", _WHERE_FAMILY_DTYPES)
+@pytest.mark.parametrize("n", _MASK_SIZES)
+def test_fast_masked_fill_scalar_vector_width_boundaries_match_cpu(mojo_gpu, n, dtype):
+    """The MaskedFillScalar immediate-value kernel's vector width and ragged
+    tail, functional and in-place: `value` never touches device memory for
+    this overload (see `_masked_fill_scalar_operands`)."""
+    x, _other, mask = _where_family_operands(n, dtype)
+    x_dev, mask_dev = x.to(mojo_gpu), mask.to(mojo_gpu)
+
+    expected = x.masked_fill(mask, -1.5)
+    actual = x_dev.masked_fill(mask_dev, -1.5).cpu()
+    torch.testing.assert_close(actual, expected)
+
+    expected_ip = x.clone()
+    expected_ip.masked_fill_(mask, 2.25)
+    actual_ip = x_dev.clone()
+    actual_ip.masked_fill_(mask_dev, 2.25)
+    torch.testing.assert_close(actual_ip.cpu(), expected_ip)
+
+
+@pytest.mark.parametrize("dtype", _WHERE_FAMILY_DTYPES)
+def test_fast_masked_fill_tensor_value_0d_matches_cpu(mojo_gpu, dtype):
+    """masked_fill's Tensor overload: `value` is a real 0-d device tensor, a
+    stride-0 broadcast operand for the WhereSelect flat-vec kernel (not an
+    immediate) -- exercised across the same vector-width/tail sizes."""
+    for n in _MASK_SIZES:
+        x, _other, mask = _where_family_operands(n, dtype)
+        value = torch.tensor(3.25, dtype=dtype)
+        x_dev, mask_dev = x.to(mojo_gpu), mask.to(mojo_gpu)
+        value_dev = value.to(mojo_gpu)
+
+        expected = x.masked_fill(mask, value)
+        actual = x_dev.masked_fill(mask_dev, value_dev).cpu()
+        torch.testing.assert_close(actual, expected)
+
+        expected_ip = x.clone()
+        expected_ip.masked_fill_(mask, value)
+        actual_ip = x_dev.clone()
+        actual_ip.masked_fill_(mask_dev, value_dev)
+        torch.testing.assert_close(actual_ip.cpu(), expected_ip)
+
+
+@pytest.mark.parametrize("dtype", _WHERE_FAMILY_DTYPES)
+def test_fast_where_self_vector_width_boundaries_match_cpu(mojo_gpu, dtype):
+    for n in _MASK_SIZES:
+        left, right, mask = _where_family_operands(n, dtype)
+        actual = torch.where(
+            mask.to(mojo_gpu), left.to(mojo_gpu), right.to(mojo_gpu)
+        ).cpu()
+        torch.testing.assert_close(actual, torch.where(mask, left, right))
+
+
+@pytest.mark.parametrize("dtype", _WHERE_FAMILY_DTYPES)
+@pytest.mark.parametrize("inplace", [False, True])
+def test_fast_masked_fill_broadcast_mask_matches_cpu(mojo_gpu, dtype, inplace):
+    """A mask that broadcasts up to the input (leading-dim broadcast) is a
+    genuinely strided case for both the Scalar and Tensor overloads: it must
+    fall back off the flat-vec tier (`cond_flat` is false) and still be
+    correct."""
+    x = (
+        (torch.arange(3 * 4 * 5, dtype=torch.float32) % 23 - 11.0)
+        .to(dtype)
+        .reshape(3, 4, 5)
+    )
+    mask = (torch.arange(4 * 5) % 4 == 0).reshape(4, 5)
+    x_dev, mask_dev = x.to(mojo_gpu), mask.to(mojo_gpu)
+
+    for value in (7.0, torch.tensor(7.0, dtype=dtype)):
+        value_dev = value.to(mojo_gpu) if isinstance(value, torch.Tensor) else value
+        if inplace:
+            expected = x.clone()
+            expected.masked_fill_(mask, value)
+            actual = x_dev.clone()
+            actual.masked_fill_(mask_dev, value_dev)
+            actual = actual.cpu()
+        else:
+            expected = x.masked_fill(mask, value)
+            actual = x_dev.masked_fill(mask_dev, value_dev).cpu()
+        torch.testing.assert_close(actual, expected)
+
+
+@pytest.mark.parametrize("dtype", _WHERE_FAMILY_DTYPES)
+def test_fast_masked_fill_noncontiguous_input_matches_cpu(mojo_gpu, dtype):
+    """A transposed (non-contiguous) input must fail the flat-vec alignment
+    gate and take the strided fallback, not silently corrupt. Built by
+    transposing ON DEVICE, not via `.to()`: a cross-device copy is free to
+    re-materialize its destination contiguously regardless of the source
+    layout."""
+    x = (torch.arange(60, dtype=torch.float32) % 41 - 20.0).to(dtype).reshape(6, 10)
+    mask = (torch.arange(60) % 5 == 0).reshape(6, 10)
+    x_dev_t = x.to(mojo_gpu).t()
+    mask_dev_t = mask.to(mojo_gpu).t()
+    assert not x_dev_t.is_contiguous()
+
+    expected = x.t().masked_fill(mask.t(), -3.0)
+    actual = x_dev_t.masked_fill(mask_dev_t, -3.0).cpu()
+    torch.testing.assert_close(actual, expected)
+
+
 @pytest.mark.parametrize("op_name", ["logical_not", "bitwise_not", "isnan"])
 def test_fast_unary_mask_vector_tail_match_cpu(mojo_gpu, op_name):
     """The flat vectorized unary skeleton: same tail and alignment rules, and

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -2393,6 +2393,41 @@ def _launch_where_bcast(
     )
 
 
+def _launch_masked_fill_scalar(
+    out: TorchMojoTensor,
+    cond: TorchMojoTensor,
+    b: TorchMojoTensor,
+    value: float,
+    meta: tuple[list[int], list[int], list[list[int]]],
+    dtype: DType,
+) -> None:
+    """masked_fill(_).Scalar's fast path: `value` is baked into the launch
+    as an argument, never materialized into a device buffer first (that
+    used to cost a whole extra Fill kernel launch -- see MaskedFillScalar's
+    docstring in data_movement_ops.mojo). Only `_MASKED_FILL_SCALAR_DTYPES`
+    (the float dtypes) are wired to this; every other dtype's Scalar
+    overload still goes through `_launch_where_bcast` below."""
+    out_shape, dims, strides = meta
+    cond_strides, b_strides = strides
+    params = tuple(dims) + tuple(cond_strides) + tuple(b_strides)
+    _call_mojo(
+        _DataMovementExtension,
+        "MaskedFillScalar",
+        (
+            out._ptr,
+            cond._ptr,
+            b._ptr,
+            params,
+            value,
+            dtype.value,
+            _ctx_ptr(out._device),
+        ),
+        arg_dtypes=(cond._dtype, b._dtype),
+        output_dtypes=(out._dtype,),
+        keepalive=(out, cond, b),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Elementwise ops
 # ---------------------------------------------------------------------------
@@ -3288,6 +3323,34 @@ def fast_aten_where(condition, input, other):
     return out
 
 
+def _masked_fill_scalar_operands(input, mask, value):
+    """Resolve (in_t, mask_t, value: float, meta) for masked_fill's
+    immediate-scalar fast path, or None.
+
+    Only takes a plain Python scalar `value` (never a 0-d tensor -- that
+    goes through `_masked_fill_operands`/`_launch_where_bcast` instead,
+    since it already has a real device pointer) against one of the float
+    dtypes `MaskedFillScalar` supports (`_FLOAT_DTYPES`; matches
+    `_MASKED_FILL_SCALAR_DTYPES` in data_movement_ops.mojo). Anything else
+    -- a Tensor value, an int/bool tensor, a value that doesn't embed
+    losslessly -- declines here and falls back to the slower
+    materialize-then-WhereSelect path below.
+    """
+    a = _t(input)
+    m = _t(mask)
+    if a is None or m is None or m._dtype != DType.bool or m._device != a._device:
+        return None
+    if a._dtype not in _FLOAT_DTYPES:
+        return None
+    fval = _scalar_embed(value, a._dtype)
+    if fval is None:
+        return None
+    meta = _bcast_meta(m, a)
+    if meta is None or tuple(meta[0]) != tuple(a._shape):
+        return None
+    return a, m, fval, meta
+
+
 def _masked_fill_operands(input, mask, value):
     """Resolve (in_t, mask_t, value_t, meta) for masked_fill, or None.
 
@@ -3332,6 +3395,13 @@ def _masked_fill_operands(input, mask, value):
 
 
 def fast_aten_masked_fill(input, mask, value):
+    scalar_resolved = _masked_fill_scalar_operands(input, mask, value)
+    if scalar_resolved is not None:
+        a, m, fval, meta = scalar_resolved
+        out = _alloc(a._shape, a._dtype, a._device)
+        if out._numel > 0:
+            _launch_masked_fill_scalar(out, m, a, fval, meta, a._dtype)
+        return out
     resolved = _masked_fill_operands(input, mask, value)
     if resolved is None:
         return NOT_HANDLED
@@ -3344,6 +3414,20 @@ def fast_aten_masked_fill(input, mask, value):
 
 def fast_aten_masked_fill_(input, mask, value):
     """In-place masked fill into input. Returns None when unavailable."""
+    scalar_resolved = _masked_fill_scalar_operands(input, mask, value)
+    if scalar_resolved is not None:
+        a, m, fval, meta = scalar_resolved
+        if a._numel > 0:
+            if a._is_contiguous:
+                # Writing out == a is safe: each element reads and writes
+                # the same index (a's strides are the output layout).
+                _launch_masked_fill_scalar(a, m, a, fval, meta, a._dtype)
+            else:
+                result = fast_aten_masked_fill(input, mask, value)
+                if result is NOT_HANDLED:
+                    return None
+                _copy_into(a, result)
+        return input
     resolved = _masked_fill_operands(input, mask, value)
     if resolved is None:
         return None

--- a/torch_mojo_backend/eager_kernels/data_movement_ops/data_movement_ops.mojo
+++ b/torch_mojo_backend/eager_kernels/data_movement_ops/data_movement_ops.mojo
@@ -36,6 +36,9 @@ from op_utils import (
     _BW_MAX_BLOCKS,
     _LLC_BYTES,
     _bw_blocks,
+    _bw_flat_blocks,
+    _fill_bits,
+    _fill_bits_dtype,
     _MAX_GRID_Y,
     _T2D_ROWS,
     _enqueue_cached,
@@ -1303,11 +1306,155 @@ def _narrow_copy_dst_go(
 # strides (0 on broadcast dims), so scalar operands are 1-element buffers
 # with all-zero strides. A pure selection copy — kernels are specialized on
 # element byte-size, not dtype.
+#
+# Tiered like logic_ops' binary dispatch (`_binary_bcast`/`_bin_flat_vec_kernel`):
+# a flat-vec tier for the common case -- cond flat-contiguous over the
+# output's extent, and each of a/b either flat-contiguous too or a single
+# broadcast element (e.g. masked_fill's 0-d value tensor) -- skips the rank-4
+# coordinate decomposition entirely (no integer division at all) and
+# vector-loads/stores 16 bytes per thread; a general strided fallback covers
+# anything else (a genuinely broadcasting mask, a non-contiguous operand, an
+# unaligned view). Both go through `_enqueue_cached`, never the stdlib
+# `elementwise` GPU dispatcher used previously: its per-call
+# `compile_function` plus the six-division coordinate chain run on every
+# element made this kernel 4-5x slower than stock PyTorch on a 357x789 case
+# that should cost single-digit microseconds (see `_cast_vec_kernel`'s
+# comment above for the same fix, applied earlier to CastSpec).
 # ---------------------------------------------------------------------------
 
 
+@__name(t"where_flat_vec_{dtype}")
+def _where_flat_vec_kernel[
+    dtype: DType
+](
+    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    cond_ptr: UnsafePointer[Scalar[DType.bool], ImmutAnyOrigin],
+    a_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    b_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    total_arg: Int64,
+    a_bcast_arg: Int64,
+    b_bcast_arg: Int64,
+):
+    """16-byte-vectorized select for the no-broadcast, all-contiguous case:
+    `cond` is flat over the output's extent (the launcher falls back to the
+    strided kernel on the rare shape where it is not), and each of `a`/`b`
+    is either flat too or a single broadcast element (`a_bcast`/`b_bcast`,
+    e.g. a 0-d scalar operand), read once and splatted. Mirrors
+    `_bin_flat_vec_kernel` in logic_ops.mojo.
+    """
+    comptime VW = 16 // size_of[dtype]()
+    comptime vec_align = VW * size_of[dtype]()
+    comptime cond_align = VW  # bool is 1 byte; matches the launcher's gate
+    var total = Int(total_arg)
+    var tid = Int(block_idx.x) * Int(block_dim.x) + Int(thread_idx.x)
+    var gstride = Int(grid_dim.x) * Int(block_dim.x)
+    var nvec = total // VW
+
+    @always_inline
+    @parameter
+    def pass_over[a_b: Bool, b_b: Bool]():
+        var a_splat = SIMD[dtype, VW](a_ptr[0]) if a_b else SIMD[dtype, VW](0)
+        var b_splat = SIMD[dtype, VW](b_ptr[0]) if b_b else SIMD[dtype, VW](0)
+        var c = tid
+        while c < nvec:
+            var i = c * VW
+            var cond = cond_ptr.load[width=VW, alignment=cond_align](i)
+            var a = a_splat if a_b else a_ptr.load[
+                width=VW, alignment=vec_align
+            ](i)
+            var b = b_splat if b_b else b_ptr.load[
+                width=VW, alignment=vec_align
+            ](i)
+            out_ptr.store[width=VW, alignment=vec_align](i, cond.select(a, b))
+            c += gstride
+        var tail = total - nvec * VW
+        if tid < tail:
+            var i = nvec * VW + tid
+            var a1 = a_splat[0] if a_b else a_ptr[i]
+            var b1 = b_splat[0] if b_b else b_ptr[i]
+            out_ptr[i] = a1 if cond_ptr[i] else b1
+
+    # The splat flags are loop-invariant, so each arm is INSTANTIATED rather
+    # than branched on per iteration (see `_bin_flat_vec_kernel`'s note on
+    # the measured cost of a per-iteration uniform branch).
+    if a_bcast_arg != 0:
+        if b_bcast_arg != 0:
+            pass_over[True, True]()
+        else:
+            pass_over[True, False]()
+    elif b_bcast_arg != 0:
+        pass_over[False, True]()
+    else:
+        pass_over[False, False]()
+
+
+@__name(t"where_strided_{dtype}")
+def _where_bcast_kernel[
+    dtype: DType
+](
+    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    cond_ptr: UnsafePointer[Scalar[DType.bool], ImmutAnyOrigin],
+    a_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    b_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    d1_arg: Int64,
+    d2_arg: Int64,
+    d3_arg: Int64,
+    cs0_arg: Int64,
+    cs1_arg: Int64,
+    cs2_arg: Int64,
+    cs3_arg: Int64,
+    a_s0_arg: Int64,
+    a_s1_arg: Int64,
+    a_s2_arg: Int64,
+    a_s3_arg: Int64,
+    b_s0_arg: Int64,
+    b_s1_arg: Int64,
+    b_s2_arg: Int64,
+    b_s3_arg: Int64,
+    total_arg: Int64,
+):
+    """Fully general arm: any broadcast strides, one element per thread.
+
+    Pays six integer divisions/moduli per element, so the launcher reaches
+    it only when the flat-vec tier's layout does not apply -- a genuinely
+    broadcasting mask/operand, or a non-16-byte-aligned view.
+    """
+    # Int is not device-passable (host/device width mismatch); scalars cross
+    # the launch ABI as Int64 and index math stays in Int.
+    var d1 = Int(d1_arg)
+    var d2 = Int(d2_arg)
+    var d3 = Int(d3_arg)
+    var cs0 = Int(cs0_arg)
+    var cs1 = Int(cs1_arg)
+    var cs2 = Int(cs2_arg)
+    var cs3 = Int(cs3_arg)
+    var a_s0 = Int(a_s0_arg)
+    var a_s1 = Int(a_s1_arg)
+    var a_s2 = Int(a_s2_arg)
+    var a_s3 = Int(a_s3_arg)
+    var b_s0 = Int(b_s0_arg)
+    var b_s1 = Int(b_s1_arg)
+    var b_s2 = Int(b_s2_arg)
+    var b_s3 = Int(b_s3_arg)
+    var total = Int(total_arg)
+    var i = Int(block_idx.x) * Int(block_dim.x) + Int(thread_idx.x)
+    var gstride = Int(grid_dim.x) * Int(block_dim.x)
+    while i < total:
+        var i3 = i % d3
+        var rest = i // d3
+        var i2 = rest % d2
+        rest = rest // d2
+        var i1 = rest % d1
+        var i0 = rest // d1
+        var cbase = i0 * cs0 + i1 * cs1 + i2 * cs2 + i3 * cs3
+        var abase = i0 * a_s0 + i1 * a_s1 + i2 * a_s2 + i3 * a_s3
+        var bbase = i0 * b_s0 + i1 * b_s1 + i2 * b_s2 + i3 * b_s3
+        out_ptr[i] = a_ptr[abase] if cond_ptr[cbase] else b_ptr[bbase]
+        i += gstride
+
+
 @always_inline
-def _where_select[
+def _where_bcast[
     dtype: DType
 ](
     out_addr: Int,
@@ -1332,102 +1479,467 @@ def _where_select[
     total: Int,
     ctx: DeviceContext,
 ) raises:
+    if total == 0:
+        return
     var out_ptr = _make_ptr[dtype](out_addr)
     var cond_ptr = _make_ptr[DType.bool](cond_addr)
     var a_ptr = _make_ptr[dtype](a_addr)
     var b_ptr = _make_ptr[dtype](b_addr)
 
-    # Chunk-of-4 kernel: one thread selects 4 consecutive output elements,
-    # so the div/mod coordinate chain (the cost that dominates the scalar
-    # version — 6 integer divisions per element) runs once per chunk, and
-    # last-dim strides of 1/0 use vector loads / splats.
-    var vec_ok = (
-        (cs3 == 0 or cs3 == 1)
-        and (a_s3 == 0 or a_s3 == 1)
-        and (b_s3 == 0 or b_s3 == 1)
-        and d3 >= 4
-    )
+    if ctx.api() == "cpu":
 
-    @always_inline
-    @parameter
-    @__copy_capture(out_ptr, cond_ptr, a_ptr, b_ptr)
-    def func4[width: Int, alignment: Int = 1](idx: Coord):
-        var i = Int(idx[0].value()) * 4
-        var i3 = i % d3
-        var rest = i // d3
-        var i2 = rest % d2
-        rest = rest // d2
-        var i1 = rest % d1
-        var i0 = rest // d1
-        if i3 + 4 <= d3 and i + 4 <= total:
+        @always_inline
+        @parameter
+        @__copy_capture(out_ptr, cond_ptr, a_ptr, b_ptr)
+        def func[width: Int, alignment: Int = 1](idx: Coord):
+            var i = Int(idx[0].value())
+            var i3 = i % d3
+            var rest = i // d3
+            var i2 = rest % d2
+            rest = rest // d2
+            var i1 = rest % d1
+            var i0 = rest // d1
             var cbase = i0 * cs0 + i1 * cs1 + i2 * cs2 + i3 * cs3
             var abase = i0 * a_s0 + i1 * a_s1 + i2 * a_s2 + i3 * a_s3
             var bbase = i0 * b_s0 + i1 * b_s1 + i2 * b_s2 + i3 * b_s3
-            var cond: SIMD[DType.bool, 4]
-            if cs3 == 1:
-                cond = cond_ptr.load[width=4](cbase)
-            else:
-                cond = SIMD[DType.bool, 4](cond_ptr[cbase])
-            var av: SIMD[dtype, 4]
-            if a_s3 == 1:
-                av = a_ptr.load[width=4](abase)
-            else:
-                av = SIMD[dtype, 4](a_ptr[abase])
-            var bv: SIMD[dtype, 4]
-            if b_s3 == 1:
-                bv = b_ptr.load[width=4](bbase)
-            else:
-                bv = SIMD[dtype, 4](b_ptr[bbase])
-            out_ptr.store(i, cond.select(av, bv))
+            out_ptr[i] = a_ptr[abase] if cond_ptr[cbase] else b_ptr[bbase]
+
+        elementwise[func, simd_width=1](Coord(total), ctx)
+        return
+
+    comptime if dtype == DType.float64 and has_apple_gpu_accelerator():
+        raise Error("float64 is not supported on Apple GPU")
+    else:
+        comptime if not has_accelerator():
+            raise Error("no GPU accelerator available at compile time")
         else:
-            # Chunk crosses a row boundary (or the end): per-element math.
-            for u in range(4):
-                var j = i + u
-                if j >= total:
-                    return
-                var j3 = j % d3
-                var jrest = j // d3
-                var j2 = jrest % d2
-                jrest = jrest // d2
-                var j1 = jrest % d1
-                var j0 = jrest // d1
-                if cond_ptr[j0 * cs0 + j1 * cs1 + j2 * cs2 + j3 * cs3]:
-                    out_ptr[j] = a_ptr[
-                        j0 * a_s0 + j1 * a_s1 + j2 * a_s2 + j3 * a_s3
-                    ]
-                else:
-                    out_ptr[j] = b_ptr[
-                        j0 * b_s0 + j1 * b_s1 + j2 * b_s2 + j3 * b_s3
-                    ]
+            comptime VW = 16 // size_of[dtype]()
+            var d0 = total // max(1, d1 * d2 * d3)
+            var cont3 = d3
+            var cont2 = d2 * d3
+            var cont1 = d1 * d2 * d3
+            # An operand whose every stride is 0 is a single element -- what
+            # masked_fill's 0-d value tensor looks like. The flat kernel
+            # reads it once and splats it, so it neither breaks the flat
+            # layout nor needs 16B alignment.
+            var a_scalar = a_s0 == 0 and a_s1 == 0 and a_s2 == 0 and a_s3 == 0
+            var b_scalar = b_s0 == 0 and b_s1 == 0 and b_s2 == 0 and b_s3 == 0
+            var cond_flat = (
+                (cs3 == 1 or d3 == 1)
+                and (cs2 == cont3 or d2 == 1)
+                and (cs1 == cont2 or d1 == 1)
+                and (cs0 == cont1 or d0 == 1)
+            )
+            var a_flat = a_scalar or (
+                (a_s3 == 1 or d3 == 1)
+                and (a_s2 == cont3 or d2 == 1)
+                and (a_s1 == cont2 or d1 == 1)
+                and (a_s0 == cont1 or d0 == 1)
+            )
+            var b_flat = b_scalar or (
+                (b_s3 == 1 or d3 == 1)
+                and (b_s2 == cont3 or d2 == 1)
+                and (b_s1 == cont2 or d1 == 1)
+                and (b_s0 == cont1 or d0 == 1)
+            )
+            var aligned = (
+                out_addr % 16 == 0
+                and cond_addr % VW == 0
+                and (a_scalar or a_addr % 16 == 0)
+                and (b_scalar or b_addr % 16 == 0)
+            )
+            if aligned and cond_flat and a_flat and b_flat:
+                # Bytes actually moved: a splatted operand reads one element
+                # for the whole launch, so it does not count toward the
+                # residency decision (see `_bw_flat_blocks`).
+                var traffic = total * (
+                    1  # cond: one byte per element, always read
+                    + (0 if a_scalar else size_of[dtype]())
+                    + (0 if b_scalar else size_of[dtype]())
+                    + size_of[dtype]()
+                )
+                var slots = max(1, total // VW)
+                _enqueue_cached[_where_flat_vec_kernel[dtype]](
+                    ctx,
+                    String(t"dm_where_fv_{dtype}"),
+                    _bw_flat_blocks(slots, traffic),
+                    1,
+                    1,
+                    GS_THREADS,
+                    out_ptr.as_unsafe_any_origin(),
+                    cond_ptr.as_unsafe_any_origin().as_immutable(),
+                    a_ptr.as_unsafe_any_origin().as_immutable(),
+                    b_ptr.as_unsafe_any_origin().as_immutable(),
+                    Int64(total),
+                    Int64(a_scalar),
+                    Int64(b_scalar),
+                )
+                return
+
+            _enqueue_cached[_where_bcast_kernel[dtype]](
+                ctx,
+                String(t"dm_where_bc_{dtype}"),
+                _gs_blocks(total),
+                1,
+                1,
+                GS_THREADS,
+                out_ptr.as_unsafe_any_origin(),
+                cond_ptr.as_unsafe_any_origin().as_immutable(),
+                a_ptr.as_unsafe_any_origin().as_immutable(),
+                b_ptr.as_unsafe_any_origin().as_immutable(),
+                Int64(d1),
+                Int64(d2),
+                Int64(d3),
+                Int64(cs0),
+                Int64(cs1),
+                Int64(cs2),
+                Int64(cs3),
+                Int64(a_s0),
+                Int64(a_s1),
+                Int64(a_s2),
+                Int64(a_s3),
+                Int64(b_s0),
+                Int64(b_s1),
+                Int64(b_s2),
+                Int64(b_s3),
+                Int64(total),
+            )
+
+
+# ---------------------------------------------------------------------------
+# MaskedFillScalar: out[i] = cond[i] ? value : b[i], where `value` is a
+# plain scalar baked into the kernel launch -- no device buffer, no separate
+# materialization launch. Serves masked_fill(_).Scalar specifically:
+# masked_fill(_).Tensor and where.self keep going through WhereSelect, whose
+# `a` operand is already a real device tensor, so there is nothing to save
+# there. Before this existed, the Scalar overload materialized `value` into
+# a 0-d device tensor through the Fill kernel first (`_scalar_tensor_0d` in
+# aten_fast.py) and then ran WhereSelect -- a second full kernel launch to
+# move one repeated constant that this kernel now carries as an argument.
+#
+# Shares WhereSelect's rank-4 strided convention and flat-vec/strided
+# tiering, and (like FillSpec) its element-WIDTH dispatch: `value` is
+# narrowed to the real dtype and reinterpreted as same-width bits exactly
+# once, on the host, via `_fill_bits` -- the kernels below never see a
+# floating-point value, only bits to move, so float16/bfloat16 share one
+# uint16 instantiation and so on.
+# ---------------------------------------------------------------------------
+
+
+@__name(t"masked_fill_scalar_flat_vec_{dtype}")
+def _masked_fill_scalar_flat_vec_kernel[
+    dtype: DType
+](
+    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    cond_ptr: UnsafePointer[Scalar[DType.bool], ImmutAnyOrigin],
+    b_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    value: Scalar[dtype],
+    total_arg: Int64,
+    b_bcast_arg: Int64,
+):
+    """`_where_flat_vec_kernel` with `a` fixed to an immediate."""
+    comptime VW = 16 // size_of[dtype]()
+    comptime vec_align = VW * size_of[dtype]()
+    comptime cond_align = VW
+    var total = Int(total_arg)
+    var tid = Int(block_idx.x) * Int(block_dim.x) + Int(thread_idx.x)
+    var gstride = Int(grid_dim.x) * Int(block_dim.x)
+    var nvec = total // VW
+    var a_splat = SIMD[dtype, VW](value)
 
     @always_inline
     @parameter
-    @__copy_capture(out_ptr, cond_ptr, a_ptr, b_ptr)
-    def func[width: Int, alignment: Int = 1](idx: Coord):
-        var i = Int(idx[0].value())
+    def pass_over[b_b: Bool]():
+        var b_splat = SIMD[dtype, VW](b_ptr[0]) if b_b else SIMD[dtype, VW](0)
+        var c = tid
+        while c < nvec:
+            var i = c * VW
+            var cond = cond_ptr.load[width=VW, alignment=cond_align](i)
+            var b = b_splat if b_b else b_ptr.load[
+                width=VW, alignment=vec_align
+            ](i)
+            out_ptr.store[width=VW, alignment=vec_align](
+                i, cond.select(a_splat, b)
+            )
+            c += gstride
+        var tail = total - nvec * VW
+        if tid < tail:
+            var i = nvec * VW + tid
+            var b1 = b_splat[0] if b_b else b_ptr[i]
+            out_ptr[i] = value if cond_ptr[i] else b1
+
+    if b_bcast_arg != 0:
+        pass_over[True]()
+    else:
+        pass_over[False]()
+
+
+@__name(t"masked_fill_scalar_strided_{dtype}")
+def _masked_fill_scalar_bcast_kernel[
+    dtype: DType
+](
+    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    cond_ptr: UnsafePointer[Scalar[DType.bool], ImmutAnyOrigin],
+    b_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    value: Scalar[dtype],
+    d1_arg: Int64,
+    d2_arg: Int64,
+    d3_arg: Int64,
+    cs0_arg: Int64,
+    cs1_arg: Int64,
+    cs2_arg: Int64,
+    cs3_arg: Int64,
+    b_s0_arg: Int64,
+    b_s1_arg: Int64,
+    b_s2_arg: Int64,
+    b_s3_arg: Int64,
+    total_arg: Int64,
+):
+    """`_where_bcast_kernel` with `a` fixed to an immediate."""
+    var d1 = Int(d1_arg)
+    var d2 = Int(d2_arg)
+    var d3 = Int(d3_arg)
+    var cs0 = Int(cs0_arg)
+    var cs1 = Int(cs1_arg)
+    var cs2 = Int(cs2_arg)
+    var cs3 = Int(cs3_arg)
+    var b_s0 = Int(b_s0_arg)
+    var b_s1 = Int(b_s1_arg)
+    var b_s2 = Int(b_s2_arg)
+    var b_s3 = Int(b_s3_arg)
+    var total = Int(total_arg)
+    var i = Int(block_idx.x) * Int(block_dim.x) + Int(thread_idx.x)
+    var gstride = Int(grid_dim.x) * Int(block_dim.x)
+    while i < total:
         var i3 = i % d3
         var rest = i // d3
         var i2 = rest % d2
         rest = rest // d2
         var i1 = rest % d1
         var i0 = rest // d1
-        if cond_ptr[i0 * cs0 + i1 * cs1 + i2 * cs2 + i3 * cs3]:
-            out_ptr[i] = a_ptr[i0 * a_s0 + i1 * a_s1 + i2 * a_s2 + i3 * a_s3]
-        else:
-            out_ptr[i] = b_ptr[i0 * b_s0 + i1 * b_s1 + i2 * b_s2 + i3 * b_s3]
+        var cbase = i0 * cs0 + i1 * cs1 + i2 * cs2 + i3 * cs3
+        var bbase = i0 * b_s0 + i1 * b_s1 + i2 * b_s2 + i3 * b_s3
+        out_ptr[i] = value if cond_ptr[cbase] else b_ptr[bbase]
+        i += gstride
 
-    if vec_ok:
-        _parallel_for[func4]((total + 3) // 4, ctx)
+
+@always_inline
+def _masked_fill_scalar_bcast[
+    dtype: DType
+](
+    out_addr: Int,
+    cond_addr: Int,
+    b_addr: Int,
+    value: Scalar[dtype],
+    d1: Int,
+    d2: Int,
+    d3: Int,
+    cs0: Int,
+    cs1: Int,
+    cs2: Int,
+    cs3: Int,
+    b_s0: Int,
+    b_s1: Int,
+    b_s2: Int,
+    b_s3: Int,
+    total: Int,
+    ctx: DeviceContext,
+) raises:
+    """Same tiering as `_where_bcast`, minus the `a` operand entirely: an
+    element-WIDTH dtype (`_fill_bits_dtype`'s uintN), never the real one --
+    the caller has already narrowed `value` to it."""
+    if total == 0:
+        return
+    var out_ptr = _make_ptr[dtype](out_addr)
+    var cond_ptr = _make_ptr[DType.bool](cond_addr)
+    var b_ptr = _make_ptr[dtype](b_addr)
+
+    if ctx.api() == "cpu":
+
+        @always_inline
+        @parameter
+        @__copy_capture(out_ptr, cond_ptr, b_ptr, value)
+        def func[width: Int, alignment: Int = 1](idx: Coord):
+            var i = Int(idx[0].value())
+            var i3 = i % d3
+            var rest = i // d3
+            var i2 = rest % d2
+            rest = rest // d2
+            var i1 = rest % d1
+            var i0 = rest // d1
+            var cbase = i0 * cs0 + i1 * cs1 + i2 * cs2 + i3 * cs3
+            var bbase = i0 * b_s0 + i1 * b_s1 + i2 * b_s2 + i3 * b_s3
+            out_ptr[i] = value if cond_ptr[cbase] else b_ptr[bbase]
+
+        elementwise[func, simd_width=1](Coord(total), ctx)
+        return
+
+    comptime if not has_accelerator():
+        raise Error("no GPU accelerator available at compile time")
     else:
-        _parallel_for[func](total, ctx)
+        comptime VW = 16 // size_of[dtype]()
+        var d0 = total // max(1, d1 * d2 * d3)
+        var cont3 = d3
+        var cont2 = d2 * d3
+        var cont1 = d1 * d2 * d3
+        var b_scalar = b_s0 == 0 and b_s1 == 0 and b_s2 == 0 and b_s3 == 0
+        var cond_flat = (
+            (cs3 == 1 or d3 == 1)
+            and (cs2 == cont3 or d2 == 1)
+            and (cs1 == cont2 or d1 == 1)
+            and (cs0 == cont1 or d0 == 1)
+        )
+        var b_flat = b_scalar or (
+            (b_s3 == 1 or d3 == 1)
+            and (b_s2 == cont3 or d2 == 1)
+            and (b_s1 == cont2 or d1 == 1)
+            and (b_s0 == cont1 or d0 == 1)
+        )
+        var aligned = (
+            out_addr % 16 == 0
+            and cond_addr % VW == 0
+            and (b_scalar or b_addr % 16 == 0)
+        )
+        if aligned and cond_flat and b_flat:
+            var traffic = total * (
+                1 + (0 if b_scalar else size_of[dtype]()) + size_of[dtype]()
+            )
+            var slots = max(1, total // VW)
+            _enqueue_cached[_masked_fill_scalar_flat_vec_kernel[dtype]](
+                ctx,
+                String(t"dm_mfs_fv_{dtype}"),
+                _bw_flat_blocks(slots, traffic),
+                1,
+                1,
+                GS_THREADS,
+                out_ptr.as_unsafe_any_origin(),
+                cond_ptr.as_unsafe_any_origin().as_immutable(),
+                b_ptr.as_unsafe_any_origin().as_immutable(),
+                value,
+                Int64(total),
+                Int64(b_scalar),
+            )
+            return
+
+        _enqueue_cached[_masked_fill_scalar_bcast_kernel[dtype]](
+            ctx,
+            String(t"dm_mfs_bc_{dtype}"),
+            _gs_blocks(total),
+            1,
+            1,
+            GS_THREADS,
+            out_ptr.as_unsafe_any_origin(),
+            cond_ptr.as_unsafe_any_origin().as_immutable(),
+            b_ptr.as_unsafe_any_origin().as_immutable(),
+            value,
+            Int64(d1),
+            Int64(d2),
+            Int64(d3),
+            Int64(cs0),
+            Int64(cs1),
+            Int64(cs2),
+            Int64(cs3),
+            Int64(b_s0),
+            Int64(b_s1),
+            Int64(b_s2),
+            Int64(b_s3),
+            Int64(total),
+        )
+
+
+# `value` crosses the WIDTH-dispatch boundary as bits (`_fill_bits_dtype`),
+# so this dispatcher is parametrized on the REAL dtype only to narrow the
+# incoming Float64 correctly (float32 vs. its same-width int32/uint32 read
+# very different bit patterns from the same numeric value) -- exactly the
+# split `_fill`/`_fill_contig` already use for the plain Fill kernel.
+# Scoped to the float dtypes masked_fill's fast eager path targets
+# (`_FLOAT_DTYPES` in aten_fast.py); any other dtype's Scalar overload keeps
+# going through the slower materialize-then-WhereSelect route in Python.
+comptime _MASKED_FILL_SCALAR_DTYPES = [
+    DType.float32,
+    DType.float16,
+    DType.bfloat16,
+]
+
+
+def _masked_fill_scalar_go(
+    out_ptr: PyObjectPtr,
+    cond_ptr: PyObjectPtr,
+    b_ptr: PyObjectPtr,
+    params: PyObjectPtr,  # (d0..d3, cs0..cs3, bs0..bs3)
+    value: PyObjectPtr,
+    dtype_o: PyObjectPtr,
+    ctx_ptr: PyObjectPtr,
+) raises:
+    var out_addr = _raw_int(out_ptr)
+    var cond_addr = _raw_int(cond_ptr)
+    var b_addr = _raw_int(b_ptr)
+    var d0 = _raw_tuple_int(params, 0)
+    var d1 = _raw_tuple_int(params, 1)
+    var d2 = _raw_tuple_int(params, 2)
+    var d3 = _raw_tuple_int(params, 3)
+    var cs0 = _raw_tuple_int(params, 4)
+    var cs1 = _raw_tuple_int(params, 5)
+    var cs2 = _raw_tuple_int(params, 6)
+    var cs3 = _raw_tuple_int(params, 7)
+    var b_s0 = _raw_tuple_int(params, 8)
+    var b_s1 = _raw_tuple_int(params, 9)
+    var b_s2 = _raw_tuple_int(params, 10)
+    var b_s3 = _raw_tuple_int(params, 11)
+    var value_v = _raw_f64(value)
+    var dtype_val = _raw_dtype_int(dtype_o)
+    var total = d0 * d1 * d2 * d3
+    var ctx = _raw_ctx(ctx_ptr)
+
+    @always_inline
+    @parameter
+    def run[dt: DType]() raises:
+        comptime BITS = _fill_bits_dtype[dt]()
+        _masked_fill_scalar_bcast[BITS](
+            out_addr,
+            cond_addr,
+            b_addr,
+            _fill_bits[dt, BITS](value_v),
+            d1,
+            d2,
+            d3,
+            cs0,
+            cs1,
+            cs2,
+            cs3,
+            b_s0,
+            b_s1,
+            b_s2,
+            b_s3,
+            total,
+            ctx,
+        )
+
+    # arg_dtypes on the Python side is (cond.dtype, b.dtype) -- index 0 is
+    # always bool (the mask), so the real dtype the kernel specializes on is
+    # index 1, matching `_launch_masked_fill_scalar`'s `arg_dtypes=(cond,
+    # b)` ordering (and `_where_select_go`'s own `_dtype_arg_width_on[1,
+    # ...]`, gated the same way for the same reason).
+    var handled = False
+    comptime for dt in _MASKED_FILL_SCALAR_DTYPES:
+        comptime if _dtype_arg_on[1, dt]():
+            if dtype_val == dt:
+                run[dt]()
+                handled = True
+    if not handled:
+        raise Error(
+            "unsupported dtype for fast masked_fill scalar: "
+            + String(dtype_val)
+        )
 
 
 @always_inline
 def _dtype_size(dtype: DType) raises -> Int:
     """Element size in bytes for WhereSelect's `dtype` arg.
 
-    `_where_select` is a pure bit-move (SIMD select, no arithmetic), so it
-    only needs to be specialized per byte-size, not per exact dtype.
+    `_where_bcast` (and its flat-vec/strided kernels) is a pure bit-move
+    (SIMD select, no arithmetic), so it only needs to be specialized per
+    byte-size, not per exact dtype.
     """
     if dtype == DType.float32 or dtype == DType.int32 or dtype == DType.uint32:
         return 4
@@ -1482,7 +1994,7 @@ def _where_select_go(
     comptime if _dtype_arg_width_on[1, 32]():
         if size != 4:
             raise Error("where specialization/dtype mismatch")
-        _where_select[DType.uint32](
+        _where_bcast[DType.uint32](
             out_addr,
             cond_addr,
             a_addr,
@@ -1508,7 +2020,7 @@ def _where_select_go(
     elif _dtype_arg_width_on[1, 16]():
         if size != 2:
             raise Error("where specialization/dtype mismatch")
-        _where_select[DType.uint16](
+        _where_bcast[DType.uint16](
             out_addr,
             cond_addr,
             a_addr,
@@ -1534,7 +2046,7 @@ def _where_select_go(
     elif _dtype_arg_width_on[1, 64]():
         if size != 8:
             raise Error("where specialization/dtype mismatch")
-        _where_select[DType.uint64](
+        _where_bcast[DType.uint64](
             out_addr,
             cond_addr,
             a_addr,
@@ -1560,7 +2072,7 @@ def _where_select_go(
     elif _dtype_arg_width_on[1, 8]():
         if size != 1:
             raise Error("where specialization/dtype mismatch")
-        _where_select[DType.uint8](
+        _where_bcast[DType.uint8](
             out_addr,
             cond_addr,
             a_addr,
@@ -2802,6 +3314,21 @@ def _where_select_dispatcher(
     return _raw_ret_none()
 
 
+def _masked_fill_scalar_dispatcher(
+    py_self: PyObjectPtr,
+    args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
+    nargs: Py_ssize_t,
+) abi("C") -> PyObjectPtr:
+    var args = UnsafePointer(args_safe)
+    try:
+        _masked_fill_scalar_go(
+            args[0], args[1], args[2], args[3], args[4], args[5], args[6]
+        )
+    except e:
+        return _spec_unsupported(e)
+    return _raw_ret_none()
+
+
 def _tile_copy_dispatcher(
     py_self: PyObjectPtr,
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
@@ -2997,6 +3524,16 @@ def PyInit_data_movement_ops() abi("C") -> PythonObject:
                 b,
                 _where_select_dispatcher,
                 docstring="out = cond ? a : b (broadcast strides, any dtype)",
+            )
+        comptime if _op_on["MaskedFillScalar"]():
+            _register_call(
+                b,
+                _masked_fill_scalar_dispatcher,
+                docstring=(
+                    "out = cond ? value : b (value baked into the launch, no"
+                    " device buffer; masked_fill(_).Scalar fast path, float"
+                    " dtypes only)"
+                ),
             )
         comptime if _op_on["TileCopy"]():
             _register_call(


### PR DESCRIPTION
## Diagnosis

Profiled with `torch.profiler` (kernel names/counts/times) on H100, `A_357x789` (281,673 elements):

| variant | kernels launched | notes |
|---|---|---|
| `masked_fill.Scalar` | 2: `elementwise_r1_w1_b256...` (7.48us) + `fill_contig_32bit_v4...` (0.98us) | Scalar value materialized into a 0-d device tensor (Fill kernel) before WhereSelect reads it |
| `masked_fill.Tensor` | 1: `elementwise_r1_w1_b256...` (7.46us) | |
| `where.self` | 1: `elementwise_r1_w1_b256...` (7.54us) | |
| stock CUDA (all of the above) | 1: `vectorized_elementwise_kernel<4,...>` (~1.5-1.8us) | |

Root cause of the ~7.5us kernel (not the extra Fill launch — that's secondary): `_where_select` in `data_movement_ops.mojo` went through the stdlib `elementwise[..., target="gpu"]` dispatcher instead of `_enqueue_cached`, which the rest of this kernel family (CastSpec, the binary-op family in `logic_ops.mojo`) already migrated off years ago for the same reason (see the comment above `_cast_vec_kernel`). Two costs stack:

1. `elementwise` re-runs `compile_function` on every call instead of caching the compiled `DeviceFunction` (`_enqueue_cached`'s whole reason to exist).
2. The kernel body always decomposes the flat thread index into rank-4 coordinates (6 integer divisions/moduli) via `i % d3`, `i // d3`, etc., even for a fully contiguous, non-broadcasting case where that decomposition is a no-op (`i0*cs0+i1*cs1+i2*cs2+i3*cs3` reduces to `i` when the strides are already row-major). This isn't just a launch-bound-shape problem — the division cost scales with element count, so the large shapes (`C_4096x4096`, `C_16777216`) were *also* regressed (1.6-2.3x), not just the tiny one the task named.

masked_fill's Scalar overload pays a second, independent cost: `_scalar_tensor_0d` (aten_fast.py) launches a full Fill kernel just to materialize a Python scalar into a 1-element device buffer before WhereSelect can read a pointer to it.

## Fix

`data_movement_ops.mojo`:
- **WhereSelect** gets the same flat-vec/strided tiering `logic_ops.mojo`'s binary dispatch (`_binary_bcast`/`_bin_flat_vec_kernel`) already has: a 16-byte-vectorized flat-vec kernel (`_where_flat_vec_kernel`) for the common case — `cond` flat-contiguous over the output's extent, `a`/`b` each either flat-contiguous or a single broadcast element (e.g. masked_fill's 0-d value) — with **zero** coordinate-decomposition division, and a strided fallback (`_where_bcast_kernel`) for genuinely broadcasting masks or non-contiguous operands. Both go through `_enqueue_cached`.
- **New `MaskedFillScalar` op** serves `masked_fill(_).Scalar` specifically: the fill value is baked into the kernel launch as a plain argument, narrowed from `Float64` to same-width bits via the existing `_fill_bits`/`_fill_bits_dtype` helpers (same trick `FillSpec` already uses), so it never touches device memory — the second kernel launch disappears. Scoped to the float dtypes (`float32`/`float16`/`bfloat16`); other dtypes keep the old materialize-then-WhereSelect path unchanged (zero risk there).

`aten_fast.py`: `fast_aten_masked_fill(_)` try the new immediate-value path first (`_masked_fill_scalar_operands` / `_launch_masked_fill_scalar`) when `value` is a raw Python scalar against a float-dtype input; everything else (Tensor overload, non-float dtypes, broadcast masks, non-contiguous inputs) falls through unchanged to the existing `_masked_fill_operands` / `_launch_where_bcast` path.

## Before / after (H100 PCIe, device time, `ours/stock`; pristine `upstream/main` vs this branch)

| node | before | after |
|---|---:|---:|
| `where.self/bf16/C_4096x4096` | 2.681 | **1.000** |
| `where.self/f32/C_4096x4096` | 1.529 | **1.000** |
| `where.self/bf16/A_357x789` | 5.092 | **1.05-1.11** |
| `where.self/f32/A_357x789` | 4.510 | **1.01-1.05** |
| `masked_fill/f32/C_4096x4096/Scalar` | 2.093 | **1.01-1.02** |
| `masked_fill/f32/C_4096x4096/Tensor` | 2.114 | **1.02-1.03** |
| `masked_fill/f32/A_357x789/Scalar` | 5.594 | **1.01-1.05** |
| `masked_fill/f32/A_357x789/Tensor` | 4.918 | **1.07-1.11** |
| `masked_fill_/f32/C_16777216/Scalar` | 2.074 | **1.01-1.02** |
| `masked_fill_/f32/C_16777216/Tensor` | 2.058 | **1.03** |
| `masked_fill_/f32/A_357x789/Scalar` | 5.830 | **1.04-1.05** |
| `masked_fill_/f32/A_357x789/Tensor` | 5.164 | **1.07-1.12** |

Ranges are the spread across several repeated runs of the same node (`benchmarks/`'s own ABBA+clock-pin methodology reports each run's uncertainty at ~0.0-0.7%, but back-to-back full runs of the same node still land anywhere in that band — normal at these tiny absolute magnitudes: A_357x789 is a ~2us kernel).

**Honest gap**: the Tensor-overload variants at the tiny `A_357x789` shape (`masked_fill.Tensor`, `masked_fill_.Tensor`, `where.self` bf16) sit right at the 1.10 line and occasionally land a few % over it on a given run (worst observed: 1.115). `ncu` shows the flat-vec kernel's device-level cost (elapsed cycles, occupancy) is statistically indistinguishable between the Scalar-immediate path and the Tensor-pointer path when replayed in isolation; the small, reproducible-in-aggregate delta (~0.07-0.1us, confirmed via repeated back-to-back `kineto` measurement, not noise) comes from one unavoidable extra global-memory load: the Tensor overload must read its fill/operand value from wherever the caller's device tensor lives (no way around that without `.item()`-style host sync, which stock PyTorch's own masked_fill.Tensor actually does — its profiled kernel is byte-identical to the Scalar overload's — but which this codebase's design deliberately avoids everywhere else to stay queue/async-friendly). I did not add a host sync to chase the last ~5-10%: it would regress every other overlapped-kernel workload to win an isolated microbenchmark. Two grid-size experiments (smaller and capped grids) were tried and both measured worse, not better, so this isn't a tuning gap.

`masked_fill`'s benchmark nodes are `f32`-only (`test_binary.py`/`test_inplace.py` don't parametrize masked_fill over bf16/f16); the fix itself and the new unit tests cover all three float dtypes.

### Collateral (rest of `test_binary.py` + `test_inplace.py`, i.e. every other op sharing this file/imports)

`uv run pytest benchmarks/test_binary.py benchmarks/test_inplace.py` (full, unfiltered): **164 passed, 2 skipped, 0 failed**. No other op's ratio moved outside its existing baseline's 8% band — bitwise/logical/pow/floor_divide/remainder/lerp/clamp/addc{mul,div}/isin/add_/mul_/relu_/fill_/uniform_ all measured within their recorded baselines.

## `baselines.html`

Recorded via `--update-baselines`, scoped to exactly the 12 masked_fill/where nodes above (`git diff --stat`: 12 insertions, 12 deletions — nothing else touched).

## ASM cross-compile check (`scripts/compare_kernel_asm.py`)

Both `sm_90a` (this box's arch) and `gfx942` (AMD, no device here) report the identical result: `18 kernel(s) differ`, `+12/-6`, `0 changed`. Fully explained by the intentional rewrite — nothing unexpected:
- **-6**: the old WhereSelect kernels (2 per dtype x 3 dtypes: `elementwise_r1_w1_b256_gs_{True,False}_*`, the stdlib-dispatched closures) are gone, replaced by differently-named kernels.
- **+12**: WhereSelect's new `where_flat_vec_*`/`where_strided_*` (2 per dtype x 3 dtypes) plus the new op's `masked_fill_scalar_flat_vec_*`/`masked_fill_scalar_strided_*` (2 per dtype x 3 dtypes).
- **0 changed**: no kernel with a stable (hash-masked) name emits different bytes — i.e. nothing outside what I intentionally renamed/added moved on either architecture. No AMD-specific launch-geometry constants were touched (none existed here before either).

## Tests

- New: `tests/test_eager_kernels.py` (mid-file, next to the existing binary/comparison flat-vec-kernel tests) — masked_fill Scalar/Tensor (functional + in-place), where.self, across `float32`/`bfloat16`/`float16`, vector-width/tail boundaries (`_MASK_SIZES`), a 0-d Tensor fill value, a broadcasting mask (forces the strided fallback), and a non-contiguous input (forces the strided fallback + fails the 16B alignment gate). 54 new cases, all pass.
- Existing masked_fill tests (`test_high_level_ops.py`, `test_aten_functions.py`) and the SDPA/log-softmax tests that use masked_fill internally as a causal-mask helper: all pass.
- `uvx pre-commit run --all-files`: clean.

## Blast radius

Only `WhereSelect` and the new `MaskedFillScalar` op changed; every other op in `data_movement_ops.mojo` (CastSpec, PermuteCopy, CatN, TileCopy, RepeatTiled, TriangularCopy, GatherRows, ScatterDim, NarrowCopyDst) is untouched, confirmed by the asm diff and the collateral benchmark run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TFYWf7vJNAv5VadqSz3bRu