### PR TITLE
FA4 forward: BHSD-native TMA descriptors eliminate the 3 gather-copies (H100)

### DIFF
--- a/benchmarks/baselines.html
+++ b/benchmarks/baselines.html
@@ -5075,7 +5075,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 },
                 "B8H12S1024D64": {
                   "layouts": {
-                    "contig": 0.724
+                    "contig": 0.477
                   }
                 }
               }
@@ -5089,7 +5089,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 },
                 "B8H12S1024D64": {
                   "layouts": {
-                    "contig": 3.461
+                    "contig": 0.478
                   }
                 }
               }
@@ -5102,7 +5102,16 @@ document.addEventListener("DOMContentLoaded", boot);
               "shapes": {
                 "B8H12S1024D64": {
                   "layouts": {
-                    "contig": 1.365
+                    "contig": 0.888
+                  }
+                }
+              }
+            },
+            "f16": {
+              "shapes": {
+                "B8H12S1024D64": {
+                  "layouts": {
+                    "contig": 0.883
                   }
                 }
               }
@@ -5116,6 +5125,15 @@ document.addEventListener("DOMContentLoaded", boot);
                 "B8H12S1024D64": {
                   "layouts": {
                     "contig": 0.716
+                  }
+                }
+              }
+            },
+            "f16": {
+              "shapes": {
+                "B8H12S1024D64": {
+                  "layouts": {
+                    "contig": 0.764
                   }
                 }
               }
@@ -8584,7 +8602,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 },
                 "B8H12S1024D64": {
                   "layouts": {
-                    "contig": 2.255
+                    "contig": 1.468
                   }
                 }
               }
@@ -8598,7 +8616,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 },
                 "B8H12S1024D64": {
                   "layouts": {
-                    "contig": 11.073
+                    "contig": 1.464
                   }
                 }
               }

--- a/benchmarks/baselines.html
+++ b/benchmarks/baselines.html
@@ -5075,7 +5075,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 },
                 "B8H12S1024D64": {
                   "layouts": {
-                    "contig": 0.354
+                    "contig": 0.308
                   }
                 }
               }
@@ -5089,7 +5089,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 },
                 "B8H12S1024D64": {
                   "layouts": {
-                    "contig": 0.355
+                    "contig": 0.31
                   }
                 }
               }
@@ -5107,7 +5107,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 },
                 "B8H12S1024D64": {
                   "layouts": {
-                    "contig": 0.643
+                    "contig": 0.558
                   }
                 }
               }
@@ -5121,7 +5121,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 },
                 "B8H12S1024D64": {
                   "layouts": {
-                    "contig": 0.635
+                    "contig": 0.553
                   }
                 }
               }
@@ -8622,7 +8622,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 },
                 "B8H12S1024D64": {
                   "layouts": {
-                    "contig": 1.066
+                    "contig": 0.912
                   }
                 }
               }
@@ -8636,7 +8636,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 },
                 "B8H12S1024D64": {
                   "layouts": {
-                    "contig": 1.061
+                    "contig": 0.915
                   }
                 }
               }

--- a/benchmarks/baselines.html
+++ b/benchmarks/baselines.html
@@ -5075,7 +5075,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 },
                 "B8H12S1024D64": {
                   "layouts": {
-                    "contig": 0.477
+                    "contig": 0.354
                   }
                 }
               }
@@ -5089,7 +5089,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 },
                 "B8H12S1024D64": {
                   "layouts": {
-                    "contig": 0.478
+                    "contig": 0.355
                   }
                 }
               }
@@ -5107,7 +5107,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 },
                 "B8H12S1024D64": {
                   "layouts": {
-                    "contig": 0.888
+                    "contig": 0.643
                   }
                 }
               }
@@ -5121,7 +5121,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 },
                 "B8H12S1024D64": {
                   "layouts": {
-                    "contig": 0.883
+                    "contig": 0.635
                   }
                 }
               }
@@ -8622,7 +8622,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 },
                 "B8H12S1024D64": {
                   "layouts": {
-                    "contig": 1.468
+                    "contig": 1.066
                   }
                 }
               }
@@ -8636,7 +8636,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 },
                 "B8H12S1024D64": {
                   "layouts": {
-                    "contig": 1.464
+                    "contig": 1.061
                   }
                 }
               }

--- a/benchmarks/baselines.html
+++ b/benchmarks/baselines.html
@@ -5070,7 +5070,7 @@ document.addEventListener("DOMContentLoaded", boot);
               "shapes": {
                 "B1H16S4096D128": {
                   "layouts": {
-                    "contig": 3.147
+                    "contig": 0.249
                   }
                 },
                 "B8H12S1024D64": {
@@ -5084,7 +5084,7 @@ document.addEventListener("DOMContentLoaded", boot);
               "shapes": {
                 "B1H16S4096D128": {
                   "layouts": {
-                    "contig": 3.137
+                    "contig": 0.251
                   }
                 },
                 "B8H12S1024D64": {
@@ -5100,6 +5100,11 @@ document.addEventListener("DOMContentLoaded", boot);
           "dtypes": {
             "bf16": {
               "shapes": {
+                "B1H16S4096D128": {
+                  "layouts": {
+                    "contig": 0.413
+                  }
+                },
                 "B8H12S1024D64": {
                   "layouts": {
                     "contig": 0.888
@@ -5109,6 +5114,11 @@ document.addEventListener("DOMContentLoaded", boot);
             },
             "f16": {
               "shapes": {
+                "B1H16S4096D128": {
+                  "layouts": {
+                    "contig": 0.417
+                  }
+                },
                 "B8H12S1024D64": {
                   "layouts": {
                     "contig": 0.883
@@ -5122,6 +5132,11 @@ document.addEventListener("DOMContentLoaded", boot);
           "dtypes": {
             "bf16": {
               "shapes": {
+                "B1H16S4096D128": {
+                  "layouts": {
+                    "contig": 0.592
+                  }
+                },
                 "B8H12S1024D64": {
                   "layouts": {
                     "contig": 0.716
@@ -5131,6 +5146,11 @@ document.addEventListener("DOMContentLoaded", boot);
             },
             "f16": {
               "shapes": {
+                "B1H16S4096D128": {
+                  "layouts": {
+                    "contig": 0.593
+                  }
+                },
                 "B8H12S1024D64": {
                   "layouts": {
                     "contig": 0.764
@@ -8597,7 +8617,7 @@ document.addEventListener("DOMContentLoaded", boot);
               "shapes": {
                 "B1H16S4096D128": {
                   "layouts": {
-                    "contig": 10.75
+                    "contig": 0.832
                   }
                 },
                 "B8H12S1024D64": {
@@ -8611,7 +8631,7 @@ document.addEventListener("DOMContentLoaded", boot);
               "shapes": {
                 "B1H16S4096D128": {
                   "layouts": {
-                    "contig": 10.649
+                    "contig": 0.835
                   }
                 },
                 "B8H12S1024D64": {

--- a/docs/optimization_backlog.md
+++ b/docs/optimization_backlog.md
@@ -408,23 +408,36 @@ different kind of item.
 ### A2
 **FA4's eligibility gate is extremely narrow**
 
-* **What.** `_fa4_bf16_d64_causal_inputs`, `aten_fast.py:5737-5781`.
-* **Current implementation.** bf16 only, `head_dim == 64` exactly,
+* **Update (head_dim=128, this PR).** `head_dim` is now a compile-time
+  regime with 64 (GPT-2-class) and 128 (Llama-class) both instantiated and
+  gated in: `_fa4_16bit_d64_causal_inputs` / `_fa4_strided_bthd_layout` /
+  `_fa4_symbol` (`aten_fast.py`) derive dtype+head_dim symbol selection at
+  the call site, and `fa4_ops.mojo` exports
+  `flash_attention_{fwd,bwd}_{bf16,f16}_d128_causal{,_strided_qkv,_bhsd}`
+  alongside the pre-existing d64 family (BM/warpgroup-count/register-budget
+  constants were already head_dim-parametric in `fa4_fwd_common.mojo` /
+  `fa4_bwd_common.mojo` before this landed). GQA and non-multiple-of-128
+  sequences are still open below.
+* **What.** `_fa4_16bit_d64_causal_inputs`, `aten_fast.py:6482` (the name
+  predates f16/d128 support and is now imprecise, kept for call-site
+  stability).
+* **Current implementation.** bf16 or f16, `head_dim in (64, 128)`,
   `seqlen % 128 == 0`, `is_causal is True` (identity, not truthiness), no
   dropout, no mask, no GQA, `sm_90a`.
-* **Why it is not optimal.** GPT-2 (`head_dim = 64`) fits; Llama-class models
-  with `head_dim = 128`, anything with GQA, and any non-multiple-of-128 sequence
-  do not, and fall all the way to [A1](#a1).
-* **What the optimized version looks like.** `head_dim` as a compile-time regime
-  with a runtime chooser (64 / 128 / 256), a masked tail for
+* **Why it is not optimal.** GPT-2 (`head_dim = 64`) and Llama-class
+  (`head_dim = 128`) models now fit; anything with GQA, any other head_dim,
+  and any non-multiple-of-128 sequence still fall all the way to [A1](#a1).
+* **What the optimized version looks like.** A masked tail for
   `seqlen % 128 != 0`, and a GQA arm that indexes the KV head instead of
   materializing a repeat. These are compile-time *regimes* selected at runtime,
   which is what AGENTS.md rule 4 asks for — not hardcoded shapes.
-* **Expected win.** **UNMEASURED.** Bounded above by the [A1](#a1) ratio for the
-  shapes it would newly claim.
-* **How to measure it.** `tests/test_fa4_host_wiring.py` covers the gate itself;
-  for timing, `bench_gpt2_batch.py` and a `head_dim = 128` variant of
-  `bench_nanogpt_train.py`.
+* **Expected win.** head_dim=128: measured, see `benchmarks/baselines.html`
+  (`B1H16S4096D128`). GQA / ragged-seqlen: **UNMEASURED**, bounded above by
+  the [A1](#a1) ratio for the shapes they would newly claim.
+* **How to measure it.** `tests/test_fa4_host_wiring.py` and
+  `tests/test_eager_kernels.py` (`test_fa4_*[...-d128]`) cover the gate
+  itself; for timing, `benchmarks/test_attention.py -k D128` and a
+  `head_dim = 128` variant of `bench_nanogpt_train.py`.
 
 ### A3
 **The fused SDPA backward is Apple-only**
@@ -1397,7 +1410,7 @@ fallback runs. This is the answer to "which GPUs run an unoptimized path".
 | Copy-free transposed-A GEMM (`_tn_mfma_route`) | `amdgpu:gfx942` + bf16 | `matmul_ops.mojo:6857-6867` | Python-side copy ([G1](#g1)) |
 | Apple simdgroup GEMM (NN/NT/TN) | `has_apple_gpu_accelerator()` | `matmul_ops.mojo:4056`, `:6416` region | SIMT FFMA tiles (the source says 3–15x behind torch MPS) |
 | Apple transposed-A spec route | `has_apple_gpu_accelerator()` | `matmul_ops.mojo:6755` | copy |
-| FA4 flash attention (fwd + bwd) | `cuda` + `sm_90a` + bf16 + d64 + causal + `seq % 128 == 0` | `aten_fast.py:5763-5774` | math decomposition ([A1](#a1)) |
+| FA4 flash attention (fwd + bwd) | `cuda` + `sm_90a` + bf16/f16 + d64/d128 + causal + `seq % 128 == 0` | `aten_fast.py:6482` | math decomposition ([A1](#a1)) |
 | Fused flash attention (fwd + bwd) | `hip` + `gfx942` | `aten_fast.py:6096-6097` | math decomposition ([A1](#a1)) |
 | Causal batched GEMM (`_try_sdpa_causal_bmm`) | `gfx942` | `aten_fast.py:5448` | dense BMM |
 | Causal BMM (`BmmCausalF32`) | Apple | `matmul_ops.mojo:6321`, raise at `:6369` | dense BMM |

--- a/tests/fa4_selfload_d128_guard_probe.mojo
+++ b/tests/fa4_selfload_d128_guard_probe.mojo
@@ -1,0 +1,53 @@
+# Probe for tests/test_fa4_selfload_ptx_ordering.py::test_selfload_rejects_d128.
+#
+# Ported from agent A2's review artifact (d128_guard_v7.mojo,
+# /scratch/fa4-fwd-harness-2c): instantiating the self-loading kernel at
+# head_dim=128 must fail the BUILD with the comptime assert in
+# fa4_fwd_selfload_kernel.mojo, not silently compute the wrong thing. The
+# self-loading body assumes one 128-thread MMA warpgroup; d128 needs
+# BM=BN=128 with two warpgroups and 224 KiB of smem, which is the
+# phase-2b kernel's job (fa4_fwd_kernel.mojo), not this module's.
+from max.gpu.host import DeviceContext
+from std.memory.unsafe_pointer import pointer_to_int
+
+from fa4_fwd_selfload_launch import launch_fwd_fa4_selfload
+
+
+def main() raises:
+    var ctx = DeviceContext()
+    var ctx_addr = pointer_to_int(ctx._handle)
+    comptime batch: Int = 1
+    comptime heads: Int = 8
+    comptime seq: Int = 512
+    comptime head_dim: Int = 128
+    comptime n: Int = batch * heads * seq * head_dim
+    var q = ctx.enqueue_create_buffer[DType.bfloat16](n)
+    var k = ctx.enqueue_create_buffer[DType.bfloat16](n)
+    var v = ctx.enqueue_create_buffer[DType.bfloat16](n)
+    var o = ctx.enqueue_create_buffer[DType.bfloat16](n)
+    var lse = ctx.enqueue_create_buffer[DType.float32](batch * heads * seq)
+    launch_fwd_fa4_selfload[
+        DType.bfloat16,
+        head_dim,
+        False,
+        True,
+        1,
+        0,
+    ](
+        batch,
+        seq,
+        heads,
+        Float32(0.088),
+        Int(q.unsafe_ptr()),
+        Int(k.unsafe_ptr()),
+        Int(v.unsafe_ptr()),
+        Int(o.unsafe_ptr()),
+        Int(lse.unsafe_ptr()),
+        0,
+        ctx_addr,
+    )
+    _ = q^
+    _ = k^
+    _ = v^
+    _ = o^
+    _ = lse^

--- a/tests/fa4_selfload_ptx_probe.mojo
+++ b/tests/fa4_selfload_ptx_probe.mojo
@@ -1,0 +1,57 @@
+# Probe binary for tests/test_fa4_selfload_ptx_ordering.py.
+#
+# Never run: `mojo build --emit asm` only COMPILES this file, it does not
+# execute `main()`, so no GPU is needed to produce the PTX sidecar this
+# probe exists for (see AGENTS.md's cross-compilation section). Building
+# it forces monomorphization of `fwd_fa4_selfload_kernel` at the same
+# comptime parameters the production dense-causal-bhsd d64 entry points
+# use, which is what makes the sidecar comparable to what actually ships.
+#
+# Build (never under the GPU lock -- this never touches a GPU):
+#   <mojo> build tests/fa4_selfload_ptx_probe.mojo \
+#       -I torch_mojo_backend/eager_flash_attention \
+#       --emit asm --target-accelerator sm_90a -o <out>.s
+from max.gpu.host import DeviceContext
+from std.memory.unsafe_pointer import pointer_to_int
+
+from fa4_fwd_selfload_launch import launch_fwd_fa4_selfload
+
+
+def main() raises:
+    var ctx = DeviceContext()
+    var ctx_addr = pointer_to_int(ctx._handle)
+    comptime batch: Int = 8
+    comptime heads: Int = 12
+    comptime seq: Int = 1024
+    comptime head_dim: Int = 64
+    comptime n: Int = batch * heads * seq * head_dim
+    var q = ctx.enqueue_create_buffer[DType.bfloat16](n)
+    var k = ctx.enqueue_create_buffer[DType.bfloat16](n)
+    var v = ctx.enqueue_create_buffer[DType.bfloat16](n)
+    var o = ctx.enqueue_create_buffer[DType.bfloat16](n)
+    var lse = ctx.enqueue_create_buffer[DType.float32](batch * heads * seq)
+    launch_fwd_fa4_selfload[
+        DType.bfloat16,
+        head_dim,
+        False,
+        True,
+        1,
+        0,
+    ](
+        batch,
+        seq,
+        heads,
+        Float32(0.125),
+        Int(q.unsafe_ptr()),
+        Int(k.unsafe_ptr()),
+        Int(v.unsafe_ptr()),
+        Int(o.unsafe_ptr()),
+        Int(lse.unsafe_ptr()),
+        0,
+        ctx_addr,
+    )
+    _ = q^
+    _ = k^
+    _ = v^
+    _ = o^
+    _ = lse^

--- a/tests/fa4_selfload_soak_probe.mojo
+++ b/tests/fa4_selfload_soak_probe.mojo
@@ -1,0 +1,263 @@
+# ===----------------------------------------------------------------------=== #
+# Self-load race soak, CI-lite (ported from agent A's phase-2c harness,
+# /scratch/fa4-fwd-harness-2c/soak_v7.mojo -- the FULL soak with more
+# shapes, more reps, and multi-clock-pin coverage stays in that harness;
+# this is the permanent-suite regression guard, run by
+# tests/test_fa4_selfload_soak.py).
+#
+# The self-loading kernel (fa4_fwd_selfload_kernel.mojo) deletes the
+# empty[] mbarriers the phase-2b producer/consumer kernel used to prove a
+# slot's smem read had retired before the next TMA refill into that same
+# slot; the substitute proof is `wgmma.wait_group` plus the PREFETCH
+# invariant (see the comment next to PREFETCH's definition in that file).
+# A violation would be TIMING-dependent, so a single pass is weak
+# evidence. This soak attacks it the same way the harness did:
+#
+#   * many iterations per shape (deterministic inputs -> the output must
+#     be BITWISE identical every rep; any bit that moves is
+#     nondeterminism, which for this kernel can only be a race),
+#   * bursts of back-to-back launches with NO sync between them, so CTAs
+#     of consecutive kernels are co-resident and warp scheduling gets
+#     perturbed,
+#   * L2-resident K/V (same buffers reused across the whole burst) so the
+#     refill TMA lands as fast as the hardware can make it -- the worst
+#     case for a write-after-read window,
+#   * every rep also gets a tolerance check against the phase-2b
+#     producer/consumer kernel (structurally different, same math), so a
+#     corruption that happens to be bitwise-stable across reps is still
+#     caught.
+#
+# Build (never under the GPU lock):
+#   <mojo> build tests/fa4_selfload_soak_probe.mojo \
+#       -I torch_mojo_backend/eager_flash_attention -o <out>
+# Run (real GPU; no flock needed for a correctness probe -- see
+# AGENTS.md, the lock is for benchmark timing precision only):
+#   REPS=8 ./<out>
+# ===----------------------------------------------------------------------=== #
+
+from std.os import getenv
+
+from max.gpu.host import DeviceBuffer, DeviceContext
+from std.memory.unsafe_pointer import pointer_to_int
+
+from fa4_fwd_launch import launch_fwd_fa4
+from fa4_fwd_selfload_launch import launch_fwd_fa4_selfload
+
+comptime D: Int = 64
+comptime BURST: Int = 4
+
+
+def _hash_unit(idx: Int, seed: Int) -> Float32:
+    """Deterministic pseudo-random value in [-0.5, 0.5) for (idx, seed)."""
+    var h = (UInt64(idx) + 1) * 0x9E3779B97F4A7C15 + UInt64(
+        seed
+    ) * 0xC2B2AE3D27D4EB4F
+    h = (h ^ (h >> 29)) * 0xBF58476D1CE4E5B9
+    h = h ^ (h >> 32)
+    return Float32(Int(h & 0xFFFF)) / 65536.0 - 0.5
+
+
+def fill_qkv(
+    dst: DeviceBuffer[DType.bfloat16], total: Int, seed: Int, ctx: DeviceContext
+) raises:
+    """Host-filled, deterministic-hash, then copied to device -- a
+    correctness probe has no need for a GPU fill kernel."""
+    var host = ctx.enqueue_create_host_buffer[DType.bfloat16](total)
+    ctx.synchronize()
+    for i in range(total):
+        host[i] = _hash_unit(i, seed).cast[DType.bfloat16]()
+    ctx.enqueue_copy(dst, host)
+
+
+def _soak_shape(
+    batch: Int,
+    heads: Int,
+    seq: Int,
+    reps: Int,
+    ctx: DeviceContext,
+    ctx_addr: Int,
+) raises -> Int:
+    var total = batch * heads * seq * D
+    var lse_total = batch * heads * seq
+    var scale = Float32(0.125)
+
+    var q_b = ctx.enqueue_create_buffer[DType.bfloat16](total)
+    var k_b = ctx.enqueue_create_buffer[DType.bfloat16](total)
+    var v_b = ctx.enqueue_create_buffer[DType.bfloat16](total)
+    var o_ref = ctx.enqueue_create_buffer[DType.bfloat16](total)
+    var lse_ref = ctx.enqueue_create_buffer[DType.float32](lse_total)
+    var o_a = ctx.enqueue_create_buffer[DType.bfloat16](total)
+    var o_c = ctx.enqueue_create_buffer[DType.bfloat16](total)
+    var lse_a = ctx.enqueue_create_buffer[DType.float32](lse_total)
+    var lse_c = ctx.enqueue_create_buffer[DType.float32](lse_total)
+
+    var s0 = 1000 + batch * 31 + heads * 7 + seq
+    fill_qkv(q_b, total, s0, ctx)
+    fill_qkv(k_b, total, s0 + 1, ctx)
+    fill_qkv(v_b, total, s0 + 2, ctx)
+    ctx.synchronize()
+
+    # Phase-2b reference leg: structurally different (producer
+    # warpgroup + empty[] barriers), same math -- a corruption that
+    # happens to be bitwise-stable across self-load reps still shows up
+    # against this leg.
+    launch_fwd_fa4[
+        DType.bfloat16,
+        64,
+        False,
+        True,
+        1,
+        False,
+        False,
+        False,
+        0,
+        bhsd_qkv=True,
+    ](
+        batch,
+        seq,
+        heads,
+        scale,
+        Int(q_b.unsafe_ptr()),
+        Int(k_b.unsafe_ptr()),
+        Int(v_b.unsafe_ptr()),
+        Int(o_ref.unsafe_ptr()),
+        Int(lse_ref.unsafe_ptr()),
+        0,
+        ctx_addr,
+    )
+    ctx.synchronize()
+
+    var host_ref = ctx.enqueue_create_host_buffer[DType.bfloat16](total)
+    ctx.enqueue_copy(host_ref, o_ref)
+    var host_gold = ctx.enqueue_create_host_buffer[DType.bfloat16](total)
+    var host_x = ctx.enqueue_create_host_buffer[DType.bfloat16](total)
+    ctx.synchronize()
+
+    var launches = 0
+    var bit_mismatch = 0
+    var tol_mismatch = 0
+
+    for rep in range(reps):
+        # BURST back-to-back launches, no sync in between: CTAs of
+        # consecutive kernels overlap on the SMs.
+        for j in range(BURST):
+            var o_ptr = Int(o_a.unsafe_ptr()) if (j & 1) == 0 else Int(
+                o_c.unsafe_ptr()
+            )
+            var l_ptr = Int(lse_a.unsafe_ptr()) if (j & 1) == 0 else Int(
+                lse_c.unsafe_ptr()
+            )
+            launch_fwd_fa4_selfload[
+                DType.bfloat16,
+                64,
+                False,
+                True,
+                1,
+                0,
+            ](
+                batch,
+                seq,
+                heads,
+                scale,
+                Int(q_b.unsafe_ptr()),
+                Int(k_b.unsafe_ptr()),
+                Int(v_b.unsafe_ptr()),
+                o_ptr,
+                l_ptr,
+                0,
+                ctx_addr,
+            )
+            launches += 1
+
+        for which in range(2):
+            if which == 0:
+                ctx.enqueue_copy(host_x, o_a)
+            else:
+                ctx.enqueue_copy(host_x, o_c)
+            ctx.synchronize()
+            if rep == 0 and which == 0:
+                for i in range(total):
+                    host_gold[i] = host_x[i]
+            else:
+                for i in range(total):
+                    if host_gold[i] != host_x[i]:
+                        bit_mismatch += 1
+                        if bit_mismatch <= 3:
+                            print(
+                                "  BIT MISMATCH rep",
+                                rep,
+                                "buf",
+                                which,
+                                "flat",
+                                i,
+                                ":",
+                                host_gold[i],
+                                "vs",
+                                host_x[i],
+                            )
+            for i in range(total):
+                var a = host_ref[i].cast[DType.float64]()
+                var b = host_x[i].cast[DType.float64]()
+                if abs(a - b) > 0.05:
+                    tol_mismatch += 1
+                    if tol_mismatch <= 3:
+                        print(
+                            "  TOL MISMATCH rep",
+                            rep,
+                            "flat",
+                            i,
+                            ":",
+                            host_ref[i],
+                            "vs",
+                            host_x[i],
+                        )
+
+    print(
+        "  B",
+        batch,
+        "H",
+        heads,
+        "S",
+        seq,
+        "| self-load launches",
+        launches,
+        "| checked",
+        2 * reps,
+        "| bit-mismatch",
+        bit_mismatch,
+        "| tol-mismatch",
+        tol_mismatch,
+    )
+
+    _ = q_b^
+    _ = k_b^
+    _ = v_b^
+    _ = o_ref^
+    _ = lse_ref^
+    _ = o_a^
+    _ = o_c^
+    _ = lse_a^
+    _ = lse_c^
+    _ = host_ref^
+    _ = host_gold^
+    _ = host_x^
+    return bit_mismatch + tol_mismatch
+
+
+def main() raises:
+    var ctx = DeviceContext()
+    var ctx_addr = pointer_to_int(ctx._handle)
+    var reps_env = getenv("REPS")
+    var reps = 8 if reps_env.byte_length() == 0 else Int(reps_env)
+    print("self-load soak-lite: REPS =", reps, "BURST =", BURST)
+
+    var bad = 0
+    # Two shapes: enough kv trips to wrap the 4-slot ring several times,
+    # one round B/H count and one awkward one (matches the harness's P4
+    # regime -- the shape closest to the self-load kernel's own
+    # break-even wave count, so its ring runs the shallowest margin).
+    bad += _soak_shape(2, 4, 1024, reps, ctx, ctx_addr)
+    bad += _soak_shape(3, 5, 1152, reps, ctx, ctx_addr)
+    if bad != 0:
+        raise Error(String("SOAK FAILED: ", bad, " mismatches"))
+    print("SOAK PASS")

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -8615,6 +8615,14 @@ _FA4_BHSD_D64_TAIL_SHAPES = (
     (2, 3, 127),  # ceil(127/64) = 2 m-blocks; last block has 63/64 valid rows
     (2, 3, 193),  # ceil(193/64) = 4 m-blocks; last block has ONE valid row,
     #                deeper into the KV walk than the 65 case
+    # The three shapes above stay under one wave, so the bridge's wave gate
+    # routes them to the v2b kernel -- its tail/clamp logic gets exercised,
+    # but the SELFLOAD kernel carries its own copy of that logic and
+    # selfload+partial-tail is reachable through the bridge (nothing below
+    # the Python gate enforces seqlen % 128). batch*heads here is large
+    # enough to cross the >=2-waves-at-3-CTAs/SM gate on any H100:
+    # 16*12*ceil(193/64) = 768 CTAs >= 2*3*132.
+    (16, 12, 193),
 )
 
 

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -8493,6 +8493,146 @@ def test_fa4_direct_flash_aten_returns_real_logsumexp(mojo_h100, dtype):
         )
 
 
+# (batch, heads, seqlen): S residues mod BM=192 reachable under the FA4
+# seqlen % 128 == 0 eligibility gate -- ported from agent A's pure-Mojo fwd
+# harness (test_fa4_fwd.mojo in /scratch/fa4-fwd-harness), which validates the
+# same shapes' numerics against an fp64 host reference on sampled rows plus a
+# bitwise BTHD-vs-BHSD leg comparison. Skips harness shape (1, 16, 4096): a
+# full fp32 CPU SDPA reference there allocates a ~1 GB causal score matrix,
+# which the pure-Mojo harness already covers far more cheaply.
+_FA4_BHSD_TAIL_SHAPES = (
+    (1, 1, 128),  # single m-block, single plane
+    (1, 1, 256),  # tail 64
+    (2, 3, 384),  # exact 2*BM
+    (1, 2, 640),  # tail 64, 4 kv tiles + LPT
+    (5, 7, 896),  # tail 128, odd plane count
+    (3, 5, 1152),  # exact 6*BM (awkward B/H)
+    (2, 4, 1024),  # tail 64, LPT swizzle > 1
+)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16], ids=["bf16", "f16"])
+@pytest.mark.parametrize("batch,heads,seqlen", _FA4_BHSD_TAIL_SHAPES)
+def test_fa4_bhsd_native_forward_backward_matches_reference(
+    mojo_h100, monkeypatch, batch, heads, seqlen, dtype
+):
+    """Public contiguous, 16-byte-aligned (B, H, S, D) Q/K/V take the
+    BHSD-native TMA path (no BTHD gather-copy materialization) across every
+    BM=192 tail-residue class reachable under seqlen % 128 == 0."""
+    from torch_mojo_backend.eager_flash_attention import load_fa4_ops
+
+    module = load_fa4_ops()
+    suffix = _FA4_DTYPE_SUFFIX[dtype]
+    bhsd_name = f"flash_attention_fwd_{suffix}_d64_causal_bhsd"
+    original_bhsd = getattr(module, bhsd_name)
+    calls = {"count": 0}
+
+    def bhsd_spy(*args):
+        calls["count"] += 1
+        return original_bhsd(*args)
+
+    monkeypatch.setattr(module, bhsd_name, bhsd_spy)
+
+    head_dim = 64
+    generator = torch.Generator().manual_seed(20260816 + seqlen)
+    query, key, value = (
+        (torch.randn(batch, heads, seqlen, head_dim, generator=generator) * 0.25).to(
+            dtype
+        )
+        for _ in range(3)
+    )
+    grad_output = torch.randn(batch, heads, seqlen, head_dim, generator=generator).to(
+        dtype
+    )
+
+    reference_inputs = [
+        tensor.float().detach().requires_grad_() for tensor in (query, key, value)
+    ]
+    reference_output = torch.nn.functional.scaled_dot_product_attention(
+        *reference_inputs, dropout_p=0.0, is_causal=True
+    )
+    reference_output.backward(grad_output.float())
+
+    mojo_inputs = [
+        tensor.to(mojo_h100).detach().requires_grad_() for tensor in (query, key, value)
+    ]
+    for tensor in mojo_inputs:
+        assert tensor._is_contiguous
+        assert tensor._ptr % 16 == 0
+
+    actual_output = torch.nn.functional.scaled_dot_product_attention(
+        *mojo_inputs, dropout_p=0.0, is_causal=True
+    )
+    assert calls["count"] == 1
+    actual_output.backward(grad_output.to(mojo_h100))
+
+    torch.testing.assert_close(
+        actual_output.cpu().float(), reference_output, atol=2e-2, rtol=2e-2
+    )
+    for actual, reference in zip(mojo_inputs, reference_inputs, strict=True):
+        assert actual.grad is not None
+        torch.testing.assert_close(
+            actual.grad.cpu().float(), reference.grad, atol=5e-2, rtol=5e-2
+        )
+
+
+def test_fa4_bhsd_gate_rejects_misaligned_offset_view(mojo_h100, monkeypatch):
+    """A public (B, H, S, D) tensor that is a genuine offset slice of a
+    larger buffer is fully contiguous but its base pointer is not 16-byte
+    aligned -- ``_fa4_bhsd_layout`` must reject it (TMA descriptor creation
+    needs 16-byte-aligned base addresses) and fall back to the existing
+    BTHD-materialize-and-copy path. Still produces correct output."""
+    from torch_mojo_backend.eager_flash_attention import load_fa4_ops
+
+    module = load_fa4_ops()
+    calls = {"bhsd": 0, "dense": 0}
+    original_bhsd = module.flash_attention_fwd_bf16_d64_causal_bhsd
+    original_dense = module.flash_attention_fwd_bf16_d64_causal
+
+    def bhsd_spy(*args):
+        calls["bhsd"] += 1
+        return original_bhsd(*args)
+
+    def dense_spy(*args):
+        calls["dense"] += 1
+        return original_dense(*args)
+
+    monkeypatch.setattr(module, "flash_attention_fwd_bf16_d64_causal_bhsd", bhsd_spy)
+    monkeypatch.setattr(module, "flash_attention_fwd_bf16_d64_causal", dense_spy)
+
+    batch, heads, seqlen, head_dim = 1, 4, 128, 64
+    numel = batch * heads * seqlen * head_dim
+    generator = torch.Generator().manual_seed(20260816)
+
+    def offset_qkv() -> torch.Tensor:
+        # One extra element (2 bytes) ahead of a fresh allocation: the
+        # [1:] slice is still fully contiguous once viewed, but its base
+        # pointer is no longer a multiple of 16.
+        host = (
+            torch.randn(numel + 1, generator=generator, dtype=torch.float32) * 0.25
+        ).to(torch.bfloat16)
+        view = host.to(mojo_h100)[1:].view(batch, heads, seqlen, head_dim)
+        assert view._is_contiguous
+        assert view._ptr % 16 != 0
+        return view
+
+    query, key, value = (offset_qkv() for _ in range(3))
+
+    reference_inputs = [tensor.detach().cpu().float() for tensor in (query, key, value)]
+    reference_output = torch.nn.functional.scaled_dot_product_attention(
+        *reference_inputs, dropout_p=0.0, is_causal=True
+    )
+
+    actual_output = torch.nn.functional.scaled_dot_product_attention(
+        query, key, value, dropout_p=0.0, is_causal=True
+    )
+
+    assert calls == {"bhsd": 0, "dense": 1}
+    torch.testing.assert_close(
+        actual_output.cpu().float(), reference_output, atol=2e-2, rtol=2e-2
+    )
+
+
 @pytest.mark.parametrize("mutated", ["query", "output"])
 def test_fa4_autograd_rejects_saved_tensor_mutation(mojo_h100, mutated):
     """The physical FA4 copies must not bypass PyTorch version checks."""

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -8602,14 +8602,15 @@ def test_fa4_bhsd_native_forward_backward_matches_reference(
 
 # (batch, heads, seqlen): genuine BM=64 partial-tail shapes at d64 -- ported
 # from agent A's phase-2b harness (test_fa4_fwd.mojo). None divides evenly
-# by 128, so the public seqlen % 128 == 0 eligibility gate would decline
-# every one of them and route to a different backend entirely, never
-# reaching FA4 -- these call the compiled bhsd bridge function directly
-# (bypassing the Python gate, the same bridge fast_fa4_16bit_d64_causal_forward
-# calls) so the new BM=64 tail machinery (zero-fill load past seq_len, store
-# clamp, the partial-row LSE predicate, and the causal boundary predicate
-# for a warpgroup entirely past seq_len) is exercised by the permanent suite
-# at all.
+# by 128. The public eligibility gate now lets a no-grad, contiguous-BHSD
+# call reach FA4 at these seqlens too (see test_aten_functions.py's
+# test_sdpa_fa4_odd_seqlen_* for that path) -- this test instead calls the
+# compiled bhsd bridge function directly with hand-built device buffers,
+# bypassing the Python gate and its allocation/dtype/layout plumbing
+# entirely, so the new BM=64 tail machinery (zero-fill load past seq_len,
+# store clamp, the partial-row LSE predicate, and the causal boundary
+# predicate for a warpgroup entirely past seq_len) is exercised in
+# isolation.
 _FA4_BHSD_D64_TAIL_SHAPES = (
     (2, 3, 65),  # ceil(65/64) = 2 m-blocks; last block has ONE valid row
     (2, 3, 127),  # ceil(127/64) = 2 m-blocks; last block has 63/64 valid rows
@@ -8629,15 +8630,14 @@ _FA4_BHSD_D64_TAIL_SHAPES = (
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16], ids=["bf16", "f16"])
 @pytest.mark.parametrize("batch,heads,seqlen", _FA4_BHSD_D64_TAIL_SHAPES)
 def test_fa4_bhsd_d64_direct_partial_tail_block(mojo_h100, batch, heads, seqlen, dtype):
-    """BM=64 partial last m-block, called directly past the %128 gate.
+    """BM=64 partial last m-block, calling the compiled bridge directly.
 
-    Production never routes these seqlens to FA4 (``_fa4_16bit_d64_causal_inputs``
-    requires seqlen % 128 == 0), so this calls
-    ``flash_attention_fwd_{bf16,f16}_d64_causal_bhsd`` the same way
-    ``fast_fa4_16bit_d64_causal_forward`` does internally, with hand-built
-    Q/K/V/out/LSE device buffers, to reach the BM=64 tail path the phase-2b
-    harness measured but the public eligibility gate would otherwise hide
-    from the permanent suite entirely.
+    This calls ``flash_attention_fwd_{bf16,f16}_d64_causal_bhsd`` the same
+    way ``fast_fa4_16bit_d64_causal_forward`` does internally, with
+    hand-built Q/K/V/out/LSE device buffers, to reach the BM=64 tail path
+    the phase-2b harness measured directly rather than through the public
+    SDPA/flash-op eligibility gate (see test_aten_functions.py for that
+    coverage) or the forward's own allocation/dtype/layout plumbing.
     """
     from torch_mojo_backend.eager_flash_attention import load_fa4_ops
     from torch_mojo_backend.eager_kernels.aten_fast import _ctx_ptr
@@ -8690,6 +8690,210 @@ def test_fa4_bhsd_d64_direct_partial_tail_block(mojo_h100, batch, heads, seqlen,
     causal_mask = torch.ones(seqlen, seqlen, dtype=torch.bool).tril()
     expected_lse = expected_lse.masked_fill(~causal_mask, float("-inf")).logsumexp(-1)
     torch.testing.assert_close(logsumexp.cpu(), expected_lse, atol=2e-2, rtol=2e-2)
+
+
+# (batch, heads, seqlen): seqlens NOT a multiple of 128 -- the relaxed public
+# eligibility gate (PR #391 review thread: "relax the seqlen % 128 == 0
+# eligibility gate for the bhsd route") now reaches FA4 through the actual
+# public API (torch.nn.functional.scaled_dot_product_attention / the flash
+# op), not just the compiled bridge directly. Batch/heads stay modest at the
+# larger seqlens so the CPU fp32 causal reference (O(seqlen^2) score matrix)
+# stays cheap, same reasoning as _FA4_BHSD_TAIL_SHAPES above.
+_FA4_ODD_SEQLEN_SHAPES = (
+    (2, 3, 65),
+    (2, 3, 127),
+    (2, 3, 193),
+    (2, 4, 1023),
+    (1, 2, 4095),
+)
+
+
+@pytest.mark.parametrize("head_dim", [64, 128], ids=["d64", "d128"])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16], ids=["bf16", "f16"])
+@pytest.mark.parametrize("batch,heads,seqlen", _FA4_ODD_SEQLEN_SHAPES)
+def test_fa4_sdpa_odd_seqlen_forward_matches_reference(
+    mojo_h100, monkeypatch, batch, heads, seqlen, dtype, head_dim
+):
+    """No-grad SDPA at an odd seqlen reaches FA4's BHSD-native path.
+
+    Public, contiguous, 16-byte-aligned Q/K/V with no gradient to track is
+    exactly the regime the relaxed gate targets: this asserts the BHSD
+    bridge actually ran (not just that the numbers happen to match, which
+    the math decomposition would also produce) and that its output matches
+    a CPU fp32 reference.
+    """
+    from torch_mojo_backend.eager_flash_attention import load_fa4_ops
+
+    module = load_fa4_ops()
+    suffix = _FA4_DTYPE_SUFFIX[dtype]
+    bhsd_name = f"flash_attention_fwd_{suffix}_d{head_dim}_causal_bhsd"
+    original_bhsd = getattr(module, bhsd_name)
+    calls = {"count": 0}
+
+    def bhsd_spy(*args):
+        calls["count"] += 1
+        return original_bhsd(*args)
+
+    monkeypatch.setattr(module, bhsd_name, bhsd_spy)
+
+    generator = torch.Generator().manual_seed(20260817 + seqlen)
+    query, key, value = (
+        (torch.randn(batch, heads, seqlen, head_dim, generator=generator) * 0.25).to(
+            dtype
+        )
+        for _ in range(3)
+    )
+    reference_inputs = [tensor.float() for tensor in (query, key, value)]
+    reference_output = torch.nn.functional.scaled_dot_product_attention(
+        *reference_inputs, dropout_p=0.0, is_causal=True
+    )
+
+    mojo_inputs = [tensor.to(mojo_h100) for tensor in (query, key, value)]
+    for tensor in mojo_inputs:
+        assert tensor._is_contiguous
+        assert tensor._ptr % 16 == 0
+
+    actual_output = torch.nn.functional.scaled_dot_product_attention(
+        *mojo_inputs, dropout_p=0.0, is_causal=True
+    )
+
+    assert calls["count"] == 1
+    torch.testing.assert_close(
+        actual_output.cpu().float(), reference_output, atol=2e-2, rtol=2e-2
+    )
+
+
+_FA4_ODD_SEQLEN_FLASH_OP_SHAPES = ((2, 3, 193), (2, 4, 1023))
+
+
+@pytest.mark.parametrize("head_dim", [64, 128], ids=["d64", "d128"])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16], ids=["bf16", "f16"])
+@pytest.mark.parametrize("batch,heads,seqlen", _FA4_ODD_SEQLEN_FLASH_OP_SHAPES)
+def test_fa4_direct_flash_aten_odd_seqlen_forward_matches_reference(
+    mojo_h100, batch, heads, seqlen, dtype, head_dim
+):
+    """The lower ``aten::_scaled_dot_product_flash_attention`` op, called
+    directly with no grad to track (as
+    ``test_fa4_direct_flash_aten_returns_real_logsumexp`` does at
+    seqlen % 128 == 0), also reaches FA4 at an odd seqlen -- this exercises
+    the aten-op bridge's own metadata plumbing (LSE shape/dtype, rng/debug-
+    mask stand-ins) at the relaxed gate, not just the higher-level SDPA
+    wrapper above."""
+    generator = torch.Generator().manual_seed(20260817 + seqlen)
+    query, key, value = (
+        (torch.randn(batch, heads, seqlen, head_dim, generator=generator) * 0.25).to(
+            dtype
+        )
+        for _ in range(3)
+    )
+    mojo_inputs = [tensor.to(mojo_h100) for tensor in (query, key, value)]
+
+    result = torch.ops.aten._scaled_dot_product_flash_attention.default(
+        *mojo_inputs, 0.0, True, False
+    )
+    output, logsumexp, cum_q, cum_k, max_q, max_k, rng, offset, debug = result
+
+    reference_inputs = [tensor.float() for tensor in (query, key, value)]
+    reference_output = torch.nn.functional.scaled_dot_product_attention(
+        *reference_inputs, dropout_p=0.0, is_causal=True
+    )
+    scores = reference_inputs[0] @ reference_inputs[1].transpose(-2, -1)
+    scores *= 1.0 / math.sqrt(head_dim)
+    causal = torch.ones(seqlen, seqlen, dtype=torch.bool).tril()
+    expected_lse = scores.masked_fill(~causal, float("-inf")).logsumexp(-1)
+
+    torch.testing.assert_close(
+        output.cpu().float(), reference_output, atol=2e-2, rtol=2e-2
+    )
+    torch.testing.assert_close(logsumexp.cpu(), expected_lse, atol=2e-2, rtol=2e-2)
+    assert cum_q is None and cum_k is None
+    assert (max_q, max_k) == (seqlen, seqlen)
+    assert rng.dtype == torch.uint64 and tuple(rng.shape) == (2,)
+    assert offset.dtype == torch.uint64 and tuple(offset.shape) == ()
+    assert debug.dtype == dtype and debug.numel() == 0
+
+
+@pytest.mark.parametrize("head_dim", [64, 128], ids=["d64", "d128"])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16], ids=["bf16", "f16"])
+def test_fa4_sdpa_odd_seqlen_requires_grad_uses_decomposition(
+    mojo_h100, monkeypatch, dtype, head_dim
+):
+    """A training-shaped call (grad enabled, requires_grad Q/K/V) at an odd
+    seqlen must NOT take the native FA4 forward/backward pair: the bwd tile
+    machinery has never been proven correct on a partial last tile (unlike
+    the BHSD-native forward, see ``fast_fa4_16bit_d64_causal_forward``'s
+    docstring), so a silently wrong gradient is exactly the outcome to
+    avoid. The autograd wrapper's ``needs_backward`` branch in
+    ``mojo_device_autograd.py`` keeps requiring seqlen % 128 == 0, so this
+    falls through to the existing generic math/dropout
+    ``_ScaledDotProductAttentionAutograd`` Function instead -- which still
+    produces correct gradients, proven here against a CPU fp32 reference.
+    """
+    from torch_mojo_backend.eager_flash_attention import load_fa4_ops
+
+    module = load_fa4_ops()
+    suffix = _FA4_DTYPE_SUFFIX[dtype]
+    watched_names = {
+        f"flash_attention_fwd_{suffix}_d{head_dim}_causal_bhsd",
+        f"flash_attention_fwd_{suffix}_d{head_dim}_causal",
+        f"flash_attention_fwd_{suffix}_d{head_dim}_causal_strided_qkv",
+        f"flash_attention_bwd_{suffix}_d{head_dim}_causal",
+        f"flash_attention_bwd_{suffix}_d{head_dim}_causal_strided_qkv",
+    }
+    calls = dict.fromkeys(watched_names, 0)
+    for name in watched_names:
+        original = getattr(module, name)
+
+        def wrapper(*args, _name=name, _original=original):
+            calls[_name] += 1
+            return _original(*args)
+
+        monkeypatch.setattr(module, name, wrapper)
+
+    batch, heads, seqlen = 2, 3, 193
+    generator = torch.Generator().manual_seed(20260817 + seqlen)
+    query, key, value = (
+        (torch.randn(batch, heads, seqlen, head_dim, generator=generator) * 0.25).to(
+            dtype
+        )
+        for _ in range(3)
+    )
+    grad_output = torch.randn(batch, heads, seqlen, head_dim, generator=generator).to(
+        dtype
+    )
+
+    reference_inputs = [
+        tensor.float().detach().requires_grad_() for tensor in (query, key, value)
+    ]
+    reference_output = torch.nn.functional.scaled_dot_product_attention(
+        *reference_inputs, dropout_p=0.0, is_causal=True
+    )
+    reference_output.backward(grad_output.float())
+
+    mojo_inputs = [
+        tensor.to(mojo_h100).detach().requires_grad_() for tensor in (query, key, value)
+    ]
+
+    actual_output = torch.nn.functional.scaled_dot_product_attention(
+        *mojo_inputs, dropout_p=0.0, is_causal=True
+    )
+    # The decomposition Function's autograd node, not the native flash pair
+    # (see test_fa4_causal_gapped_qkv_forward_backward for that name).
+    assert (
+        type(actual_output.grad_fn).__name__
+        != "ScaledDotProductFlashAttentionBackward0"
+    )
+    actual_output.backward(grad_output.to(mojo_h100))
+
+    assert calls == dict.fromkeys(watched_names, 0)
+    torch.testing.assert_close(
+        actual_output.cpu().float(), reference_output, atol=2e-2, rtol=2e-2
+    )
+    for actual, reference in zip(mojo_inputs, reference_inputs, strict=True):
+        assert actual.grad is not None
+        torch.testing.assert_close(
+            actual.grad.cpu().float(), reference.grad, atol=5e-2, rtol=5e-2
+        )
 
 
 @pytest.mark.parametrize("head_dim", [64, 128], ids=["d64", "d128"])

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -8351,13 +8351,20 @@ def test_fast_sdpa(mojo_gpu, is_causal, kv_len, dtype):
 _FA4_DTYPE_SUFFIX = {torch.bfloat16: "bf16", torch.float16: "f16"}
 
 
+@pytest.mark.parametrize("head_dim", [64, 128], ids=["d64", "d128"])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16], ids=["bf16", "f16"])
-def test_fa4_causal_gapped_qkv_forward_backward(mojo_h100, monkeypatch, dtype):
+def test_fa4_causal_gapped_qkv_forward_backward(
+    mojo_h100, monkeypatch, dtype, head_dim
+):
     """The cached H100 path stays dynamic for nanoGPT's gapped QKV views.
 
     bf16 and f16 share the same kernel family (the f16 RS wgmma emitter is a
     vendored gap-filler for the stdlib's bf16-only register-operand overload,
-    see ``fa4_wgmma_f16.mojo``), so both dtypes are exercised here.
+    see ``fa4_wgmma_f16.mojo``), so both dtypes are exercised here. head_dim
+    64 (GPT-2-class, BM=192, 3 MMA warpgroups) and 128 (Llama-class, BM=128,
+    2 MMA warpgroups) are two distinct comptime tile configs (see
+    ``fa4_fwd_common.mojo``/``fa4_bwd_common.mojo``), not one kernel with a
+    runtime dimension -- both get their own cached launch here.
     """
     from torch_mojo_backend.eager_flash_attention import load_fa4_ops
     from torch_mojo_backend.mojo_device.mojo_device_aten_ops import EAGER_CALL_COUNTERS
@@ -8365,8 +8372,8 @@ def test_fa4_causal_gapped_qkv_forward_backward(mojo_h100, monkeypatch, dtype):
     module = load_fa4_ops()
     calls = {"forward": 0, "backward": 0}
     suffix = _FA4_DTYPE_SUFFIX[dtype]
-    forward_name = f"flash_attention_fwd_{suffix}_d64_causal_strided_qkv"
-    backward_name = f"flash_attention_bwd_{suffix}_d64_causal_strided_qkv"
+    forward_name = f"flash_attention_fwd_{suffix}_d{head_dim}_causal_strided_qkv"
+    backward_name = f"flash_attention_bwd_{suffix}_d{head_dim}_causal_strided_qkv"
     original_forward = getattr(module, forward_name)
     original_backward = getattr(module, backward_name)
 
@@ -8381,7 +8388,6 @@ def test_fa4_causal_gapped_qkv_forward_backward(mojo_h100, monkeypatch, dtype):
     monkeypatch.setattr(module, forward_name, forward_spy)
     monkeypatch.setattr(module, backward_name, backward_spy)
 
-    head_dim = 64
     for seed, batch, seqlen, heads in ((20260718, 1, 128, 4), (20260719, 2, 256, 8)):
         width = heads * head_dim
         generator = torch.Generator().manual_seed(seed)
@@ -8446,11 +8452,12 @@ def test_fa4_causal_gapped_qkv_forward_backward(mojo_h100, monkeypatch, dtype):
     assert calls == {"forward": 2, "backward": 2}
 
 
+@pytest.mark.parametrize("head_dim", [64, 128], ids=["d64", "d128"])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16], ids=["bf16", "f16"])
-def test_fa4_direct_flash_aten_returns_real_logsumexp(mojo_h100, dtype):
+def test_fa4_direct_flash_aten_returns_real_logsumexp(mojo_h100, dtype, head_dim):
     """The low-level flash op must not substitute zero backward metadata."""
     generator = torch.Generator().manual_seed(20260721)
-    shape = (1, 4, 128, 64)
+    shape = (1, 4, 128, head_dim)
     query, key, value = (
         (torch.randn(shape, generator=generator) * 0.25).to(dtype) for _ in range(3)
     )
@@ -8499,31 +8506,36 @@ def test_fa4_direct_flash_aten_returns_real_logsumexp(mojo_h100, dtype):
 # same shapes' numerics against an fp64 host reference on sampled rows plus a
 # bitwise BTHD-vs-BHSD leg comparison. Skips harness shape (1, 16, 4096): a
 # full fp32 CPU SDPA reference there allocates a ~1 GB causal score matrix,
-# which the pure-Mojo harness already covers far more cheaply.
+# which the pure-Mojo harness already covers far more cheaply. head_dim=128's
+# BM is 128 (kFa4BlockM), which the seqlen % 128 == 0 gate always divides
+# evenly -- no partial m-tile is reachable there, but the same shape set
+# still stresses multi-plane LPT scheduling at the second tile config.
 _FA4_BHSD_TAIL_SHAPES = (
     (1, 1, 128),  # single m-block, single plane
-    (1, 1, 256),  # tail 64
-    (2, 3, 384),  # exact 2*BM
-    (1, 2, 640),  # tail 64, 4 kv tiles + LPT
-    (5, 7, 896),  # tail 128, odd plane count
-    (3, 5, 1152),  # exact 6*BM (awkward B/H)
-    (2, 4, 1024),  # tail 64, LPT swizzle > 1
+    (1, 1, 256),  # tail 64 at d64
+    (2, 3, 384),  # exact 2*BM at d64
+    (1, 2, 640),  # tail 64 at d64, 4 kv tiles + LPT
+    (5, 7, 896),  # tail 128 at d64, odd plane count
+    (3, 5, 1152),  # exact 6*BM at d64 (awkward B/H)
+    (2, 4, 1024),  # tail 64 at d64, LPT swizzle > 1
 )
 
 
+@pytest.mark.parametrize("head_dim", [64, 128], ids=["d64", "d128"])
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16], ids=["bf16", "f16"])
 @pytest.mark.parametrize("batch,heads,seqlen", _FA4_BHSD_TAIL_SHAPES)
 def test_fa4_bhsd_native_forward_backward_matches_reference(
-    mojo_h100, monkeypatch, batch, heads, seqlen, dtype
+    mojo_h100, monkeypatch, batch, heads, seqlen, dtype, head_dim
 ):
     """Public contiguous, 16-byte-aligned (B, H, S, D) Q/K/V take the
     BHSD-native TMA path (no BTHD gather-copy materialization) across every
-    BM=192 tail-residue class reachable under seqlen % 128 == 0."""
+    BM=192 tail-residue class reachable under seqlen % 128 == 0, for both
+    the d64 and d128 tile configs."""
     from torch_mojo_backend.eager_flash_attention import load_fa4_ops
 
     module = load_fa4_ops()
     suffix = _FA4_DTYPE_SUFFIX[dtype]
-    bhsd_name = f"flash_attention_fwd_{suffix}_d64_causal_bhsd"
+    bhsd_name = f"flash_attention_fwd_{suffix}_d{head_dim}_causal_bhsd"
     original_bhsd = getattr(module, bhsd_name)
     calls = {"count": 0}
 
@@ -8533,7 +8545,6 @@ def test_fa4_bhsd_native_forward_backward_matches_reference(
 
     monkeypatch.setattr(module, bhsd_name, bhsd_spy)
 
-    head_dim = 64
     generator = torch.Generator().manual_seed(20260816 + seqlen)
     query, key, value = (
         (torch.randn(batch, heads, seqlen, head_dim, generator=generator) * 0.25).to(
@@ -8576,18 +8587,23 @@ def test_fa4_bhsd_native_forward_backward_matches_reference(
         )
 
 
-def test_fa4_bhsd_gate_rejects_misaligned_offset_view(mojo_h100, monkeypatch):
+@pytest.mark.parametrize("head_dim", [64, 128], ids=["d64", "d128"])
+def test_fa4_bhsd_gate_rejects_misaligned_offset_view(mojo_h100, monkeypatch, head_dim):
     """A public (B, H, S, D) tensor that is a genuine offset slice of a
     larger buffer is fully contiguous but its base pointer is not 16-byte
     aligned -- ``_fa4_bhsd_layout`` must reject it (TMA descriptor creation
     needs 16-byte-aligned base addresses) and fall back to the existing
-    BTHD-materialize-and-copy path. Still produces correct output."""
+    BTHD-materialize-and-copy path. Still produces correct output. A 2-byte
+    (one bf16 element) offset breaks 16-byte alignment independently of
+    head_dim, so this is exercised at both tile configs."""
     from torch_mojo_backend.eager_flash_attention import load_fa4_ops
 
     module = load_fa4_ops()
     calls = {"bhsd": 0, "dense": 0}
-    original_bhsd = module.flash_attention_fwd_bf16_d64_causal_bhsd
-    original_dense = module.flash_attention_fwd_bf16_d64_causal
+    bhsd_name = f"flash_attention_fwd_bf16_d{head_dim}_causal_bhsd"
+    dense_name = f"flash_attention_fwd_bf16_d{head_dim}_causal"
+    original_bhsd = getattr(module, bhsd_name)
+    original_dense = getattr(module, dense_name)
 
     def bhsd_spy(*args):
         calls["bhsd"] += 1
@@ -8597,10 +8613,10 @@ def test_fa4_bhsd_gate_rejects_misaligned_offset_view(mojo_h100, monkeypatch):
         calls["dense"] += 1
         return original_dense(*args)
 
-    monkeypatch.setattr(module, "flash_attention_fwd_bf16_d64_causal_bhsd", bhsd_spy)
-    monkeypatch.setattr(module, "flash_attention_fwd_bf16_d64_causal", dense_spy)
+    monkeypatch.setattr(module, bhsd_name, bhsd_spy)
+    monkeypatch.setattr(module, dense_name, dense_spy)
 
-    batch, heads, seqlen, head_dim = 1, 4, 128, 64
+    batch, heads, seqlen = 1, 4, 128
     numel = batch * heads * seqlen * head_dim
     generator = torch.Generator().manual_seed(20260816)
 

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -8361,10 +8361,12 @@ def test_fa4_causal_gapped_qkv_forward_backward(
     bf16 and f16 share the same kernel family (the f16 RS wgmma emitter is a
     vendored gap-filler for the stdlib's bf16-only register-operand overload,
     see ``fa4_wgmma_f16.mojo``), so both dtypes are exercised here. head_dim
-    64 (GPT-2-class, BM=192, 3 MMA warpgroups) and 128 (Llama-class, BM=128,
-    2 MMA warpgroups) are two distinct comptime tile configs (see
-    ``fa4_fwd_common.mojo``/``fa4_bwd_common.mojo``), not one kernel with a
-    runtime dimension -- both get their own cached launch here.
+    64 (GPT-2-class, BM=64, 1 MMA warpgroup, 2 CTAs/SM -- phase 2b's
+    causal-tile-quantization fix, see ``fa4_fwd_common.mojo``) and 128
+    (Llama-class, BM=128, 2 MMA warpgroups, unchanged) are two distinct
+    comptime tile configs (see ``fa4_fwd_common.mojo``/``fa4_bwd_common.mojo``),
+    not one kernel with a runtime dimension -- both get their own cached
+    launch here.
     """
     from torch_mojo_backend.eager_flash_attention import load_fa4_ops
     from torch_mojo_backend.mojo_device.mojo_device_aten_ops import EAGER_CALL_COUNTERS
@@ -8500,7 +8502,7 @@ def test_fa4_direct_flash_aten_returns_real_logsumexp(mojo_h100, dtype, head_dim
         )
 
 
-# (batch, heads, seqlen): S residues mod BM=192 reachable under the FA4
+# (batch, heads, seqlen): S residues mod BM reachable under the FA4
 # seqlen % 128 == 0 eligibility gate -- ported from agent A's pure-Mojo fwd
 # harness (test_fa4_fwd.mojo in /scratch/fa4-fwd-harness), which validates the
 # same shapes' numerics against an fp64 host reference on sampled rows plus a
@@ -8510,14 +8512,25 @@ def test_fa4_direct_flash_aten_returns_real_logsumexp(mojo_h100, dtype, head_dim
 # BM is 128 (kFa4BlockM), which the seqlen % 128 == 0 gate always divides
 # evenly -- no partial m-tile is reachable there, but the same shape set
 # still stresses multi-plane LPT scheduling at the second tile config.
+#
+# NOTE (phase 2b, BM=64 at d64): the per-shape "tail N" comments below were
+# written for the pre-phase-2b BM=192 tile, where seqlen % 128 == 0 still
+# left a partial last m-block most of the time. 128 is a multiple of the new
+# BM=64, so under this SAME seqlen % 128 == 0 gate every d64 block below is
+# now a FULL 64-row block -- these shapes now only exercise multi-block/LPT
+# scheduling at d64, not a partial tail. The genuine BM=64 partial-tail path
+# (zero-fill load, store clamp, partial-row LSE predicate) needs seqlen NOT
+# a multiple of 128, which the production eligibility gate never routes to
+# FA4 -- see _FA4_BHSD_D64_TAIL_SHAPES below, which calls the bhsd bridge
+# directly to reach it anyway.
 _FA4_BHSD_TAIL_SHAPES = (
     (1, 1, 128),  # single m-block, single plane
-    (1, 1, 256),  # tail 64 at d64
-    (2, 3, 384),  # exact 2*BM at d64
-    (1, 2, 640),  # tail 64 at d64, 4 kv tiles + LPT
-    (5, 7, 896),  # tail 128 at d64, odd plane count
-    (3, 5, 1152),  # exact 6*BM at d64 (awkward B/H)
-    (2, 4, 1024),  # tail 64 at d64, LPT swizzle > 1
+    (1, 1, 256),  # 2 full BM=64 blocks at d64 (was: tail 64 at BM=192)
+    (2, 3, 384),  # exact 2*BM at d128 / 6 full blocks at d64
+    (1, 2, 640),  # 10 full BM=64 blocks at d64, 4 kv tiles + LPT
+    (5, 7, 896),  # 14 full BM=64 blocks at d64, odd plane count
+    (3, 5, 1152),  # exact 6*BM at d128 / 18 full blocks at d64 (awkward B/H)
+    (2, 4, 1024),  # 16 full BM=64 blocks at d64, LPT swizzle > 1
 )
 
 
@@ -8585,6 +8598,90 @@ def test_fa4_bhsd_native_forward_backward_matches_reference(
         torch.testing.assert_close(
             actual.grad.cpu().float(), reference.grad, atol=5e-2, rtol=5e-2
         )
+
+
+# (batch, heads, seqlen): genuine BM=64 partial-tail shapes at d64 -- ported
+# from agent A's phase-2b harness (test_fa4_fwd.mojo). None divides evenly
+# by 128, so the public seqlen % 128 == 0 eligibility gate would decline
+# every one of them and route to a different backend entirely, never
+# reaching FA4 -- these call the compiled bhsd bridge function directly
+# (bypassing the Python gate, the same bridge fast_fa4_16bit_d64_causal_forward
+# calls) so the new BM=64 tail machinery (zero-fill load past seq_len, store
+# clamp, the partial-row LSE predicate, and the causal boundary predicate
+# for a warpgroup entirely past seq_len) is exercised by the permanent suite
+# at all.
+_FA4_BHSD_D64_TAIL_SHAPES = (
+    (2, 3, 65),  # ceil(65/64) = 2 m-blocks; last block has ONE valid row
+    (2, 3, 127),  # ceil(127/64) = 2 m-blocks; last block has 63/64 valid rows
+    (2, 3, 193),  # ceil(193/64) = 4 m-blocks; last block has ONE valid row,
+    #                deeper into the KV walk than the 65 case
+)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16], ids=["bf16", "f16"])
+@pytest.mark.parametrize("batch,heads,seqlen", _FA4_BHSD_D64_TAIL_SHAPES)
+def test_fa4_bhsd_d64_direct_partial_tail_block(mojo_h100, batch, heads, seqlen, dtype):
+    """BM=64 partial last m-block, called directly past the %128 gate.
+
+    Production never routes these seqlens to FA4 (``_fa4_16bit_d64_causal_inputs``
+    requires seqlen % 128 == 0), so this calls
+    ``flash_attention_fwd_{bf16,f16}_d64_causal_bhsd`` the same way
+    ``fast_fa4_16bit_d64_causal_forward`` does internally, with hand-built
+    Q/K/V/out/LSE device buffers, to reach the BM=64 tail path the phase-2b
+    harness measured but the public eligibility gate would otherwise hide
+    from the permanent suite entirely.
+    """
+    from torch_mojo_backend.eager_flash_attention import load_fa4_ops
+    from torch_mojo_backend.eager_kernels.aten_fast import _ctx_ptr
+
+    module = load_fa4_ops()
+    suffix = _FA4_DTYPE_SUFFIX[dtype]
+    forward_fn = getattr(module, f"flash_attention_fwd_{suffix}_d64_causal_bhsd")
+
+    head_dim = 64
+    generator = torch.Generator().manual_seed(20260817 + seqlen)
+    query, key, value = (
+        (torch.randn(batch, heads, seqlen, head_dim, generator=generator) * 0.25).to(
+            dtype
+        )
+        for _ in range(3)
+    )
+    reference_inputs = [tensor.float() for tensor in (query, key, value)]
+    reference_output = torch.nn.functional.scaled_dot_product_attention(
+        *reference_inputs, dropout_p=0.0, is_causal=True
+    )
+
+    q, k, v = (tensor.to(mojo_h100) for tensor in (query, key, value))
+    for tensor in (q, k, v):
+        assert tensor._is_contiguous
+        assert tensor._ptr % 16 == 0
+    out = torch.empty(batch, heads, seqlen, head_dim, dtype=dtype, device=mojo_h100)
+    logsumexp = torch.empty(batch, heads, seqlen, dtype=torch.float32, device=mojo_h100)
+    assert out._ptr % 16 == 0
+    scale = 1.0 / math.sqrt(head_dim)
+
+    result = forward_fn(
+        q._ptr,
+        k._ptr,
+        v._ptr,
+        out._ptr,
+        logsumexp._ptr,
+        batch,
+        seqlen,
+        heads,
+        scale,
+        _ctx_ptr(q._device),
+    )
+    assert result is None
+
+    torch.testing.assert_close(
+        out.cpu().float(), reference_output, atol=2e-2, rtol=2e-2
+    )
+
+    expected_lse = reference_inputs[0] @ reference_inputs[1].transpose(-2, -1) * scale
+    causal_mask = torch.ones(seqlen, seqlen, dtype=torch.bool).tril()
+    expected_lse = expected_lse.masked_fill(~causal_mask, float("-inf")).logsumexp(-1)
+    torch.testing.assert_close(logsumexp.cpu(), expected_lse, atol=2e-2, rtol=2e-2)
 
 
 @pytest.mark.parametrize("head_dim", [64, 128], ids=["d64", "d128"])

--- a/tests/test_fa4_host_wiring.py
+++ b/tests/test_fa4_host_wiring.py
@@ -735,6 +735,112 @@ def test_direct_flash_backward_materializes_strided_logsumexp(
     assert backward_calls[0][4] is contiguous_lse
 
 
+def test_fa4_saved_variable_recompute_rederives_natives_independently(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression test for the SavedVariable-recompute fallback (``out``/
+    ``logsumexp`` unpacked as bare tensors without their Python payload).
+
+    Before this fix, the recompute branch trusted the *natives* returned by
+    the inner ``fast_fa4_16bit_d64_causal_forward`` recompute call. Now that
+    the BHSD-eligible fast path returns the untouched PUBLIC q/k/v as those
+    same tuple slots (see ``fast_fa4_16bit_d64_causal_forward``), blindly
+    reusing them here would feed BHSD-shaped tensors into the BTHD-only bwd
+    kernel ABI. This test simulates exactly that: the mocked recompute
+    returns the public q/k/v unchanged (mirroring the BHSD fast path's
+    contract), and asserts the backward bridge is handed independently
+    rederived BTHD natives instead -- never the recompute's raw tuple
+    elements.
+    """
+    device = _device()
+    shape = (2, 4, 128, 64)
+    query, key, value = (
+        _tensor(name, shape=shape, device=device, ptr=ptr)
+        for name, ptr in zip(("q", "k", "v"), (0x1000, 0x2000, 0x3000), strict=True)
+    )
+    grad = _tensor("grad", shape=shape, device=device, ptr=0x4000)
+    recomputed_output = _tensor(
+        "recomputed_output", shape=shape, device=device, ptr=0x5000
+    )
+    recomputed_lse = _tensor(
+        "recomputed_lse",
+        shape=(2, 4, 128),
+        dtype=aten_fast.DType.float32,
+        device=device,
+        ptr=0x6000,
+    )
+    bthd_native = {
+        tensor.name: _tensor(
+            f"{tensor.name}_bthd_native",
+            shape=(2, 128, 4, 64),
+            device=device,
+            ptr=tensor._ptr,
+        )
+        for tensor in (query, key, value)
+    }
+    native_calls = []
+    backward_calls = []
+
+    monkeypatch.setattr(aten_fast, "_t", lambda tensor: tensor)
+    monkeypatch.setattr(
+        aten_fast, "_fa4_16bit_d64_causal_inputs", lambda *args: (query, key, value)
+    )
+
+    def fake_recompute(q, k, v, *_args):
+        # Mirrors the real BHSD fast path's contract: the "natives" slots
+        # are the untouched PUBLIC q/k/v, not BTHD-shaped tensors.
+        assert (q, k, v) == (query, key, value)
+        return recomputed_output, recomputed_lse, q, k, v
+
+    monkeypatch.setattr(aten_fast, "fast_fa4_16bit_d64_causal_forward", fake_recompute)
+
+    def fake_native_bthd(tensor):
+        native_calls.append(tensor)
+        return bthd_native[tensor.name]
+
+    monkeypatch.setattr(aten_fast, "_fa4_native_bthd", fake_native_bthd)
+    monkeypatch.setattr(aten_fast, "_tc", lambda tensor: tensor)
+    monkeypatch.setattr(
+        aten_fast,
+        "fast_fa4_16bit_d64_causal_backward",
+        lambda *args: backward_calls.append(args) or "gradients",
+    )
+
+    result = aten_fast.fast_aten__scaled_dot_product_flash_attention_backward(
+        grad,
+        query,
+        key,
+        value,
+        None,  # out: unpacked as a bare tensor, triggers the recompute path
+        None,  # logsumexp: ditto
+        None,
+        None,
+        128,
+        128,
+        0.0,
+        True,
+        None,
+        None,
+        scale=0.125,
+    )
+
+    assert result == "gradients"
+    # Every one of q/k/v must have been independently rederived...
+    assert native_calls == [query, key, value]
+    assert len(backward_calls) == 1
+    q_native, k_native, v_native = backward_calls[0][:3]
+    # ...and the backward call must have received those rederived BTHD
+    # natives, never the recompute's raw (public-shaped) return values. This
+    # is the exact bug the fix closes: pre-fix, q_native/k_native/v_native
+    # here would have been `query`/`key`/`value` themselves.
+    assert (q_native, k_native, v_native) == (
+        bthd_native["q"],
+        bthd_native["k"],
+        bthd_native["v"],
+    )
+    assert q_native is not query and k_native is not key and v_native is not value
+
+
 def test_fa4_combined_backward_bridge_allocates_exact_scratch(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_fa4_host_wiring.py
+++ b/tests/test_fa4_host_wiring.py
@@ -423,15 +423,24 @@ def test_fa4_canonical_fused_qkv_uses_zero_copy_strided_forward_bridge(
     ]
 
 
-def test_fa4_unsupported_public_layout_copies_and_uses_contiguous_fallback(
+def test_fa4_offset_view_public_layout_copies_and_uses_contiguous_fallback(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """A public (B, H, S, D) tensor that is fully contiguous but whose base
+    pointer is NOT 16-byte aligned (e.g. a sliced/offset view into a larger
+    buffer) must be rejected by ``_fa4_bhsd_layout`` and fall back to the
+    existing BTHD-materialize-and-copy path -- TMA descriptor creation for
+    the BHSD-native path requires 16-byte alignment and a misaligned base
+    pointer violates that even though the tensor is otherwise eligible.
+    """
     import torch_mojo_backend.eager_flash_attention as package
 
     device = _device()
+    # +2 bytes (one bf16/f16 element) off a 16-byte-aligned address: still
+    # fully contiguous, but ptr % 16 != 0.
     public = tuple(
         _tensor(name, shape=(2, 12, 256, 64), device=device, ptr=ptr)
-        for name, ptr in zip("qkv", (0x1000, 0x2000, 0x3000), strict=True)
+        for name, ptr in zip("qkv", (0x1002, 0x2002, 0x3002), strict=True)
     )
     copied = []
     old_calls = []
@@ -497,6 +506,102 @@ def test_fa4_unsupported_public_layout_copies_and_uses_contiguous_fallback(
     assert [tensor.name for tensor in copied] == ["q", "k", "v"]
     assert len(old_calls) == 1
     assert old_calls[0][:3] == (0x5000, 0x6000, 0x7000)
+
+
+def test_fa4_forward_bridge_uses_bhsd_native_path_for_aligned_contiguous_public_qkv(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A public (B, H, S, D) tensor that is fully contiguous AND 16-byte
+    aligned skips BTHD materialization entirely: no transpose, no copy, and
+    the output is allocated directly in the (B, H, S, D) layout and
+    returned as-is."""
+    import torch_mojo_backend.eager_flash_attention as package
+
+    device = _device()
+    public = tuple(
+        _tensor(name, shape=(3, 12, 256, 64), device=device, ptr=ptr)
+        for name, ptr in zip("qkv", (0x1000, 0x2000, 0x3000), strict=True)
+    )
+    allocations = []
+    bridge_calls = []
+
+    def alloc(shape, dtype, actual_device):
+        result = _tensor(
+            f"alloc{len(allocations)}",
+            shape=shape,
+            dtype=dtype,
+            device=actual_device,
+            ptr=0x9000 + len(allocations) * 0x1000,
+        )
+        allocations.append(result)
+        return result
+
+    def forbidden(*_args, **_kwargs):
+        raise AssertionError(
+            "aligned contiguous public QKV reached a copy or a non-bhsd bridge"
+        )
+
+    monkeypatch.setattr(aten_fast, "_t", lambda tensor: tensor)
+    monkeypatch.setattr(aten_fast, "_fa4_native_bthd", forbidden)
+    monkeypatch.setattr(aten_fast, "_tc", forbidden)
+    monkeypatch.setattr(aten_fast, "fast_aten_transpose", forbidden)
+    monkeypatch.setattr(aten_fast, "_alloc", alloc)
+    monkeypatch.setattr(aten_fast, "_ctx_ptr", lambda actual_device: 5050)
+    monkeypatch.setattr(
+        package,
+        "load_fa4_ops",
+        lambda: SimpleNamespace(
+            flash_attention_fwd_bf16_d64_causal=forbidden,
+            flash_attention_fwd_bf16_d64_causal_strided_qkv=forbidden,
+            flash_attention_fwd_bf16_d64_causal_bhsd=lambda *args: bridge_calls.append(
+                args
+            ),
+        ),
+    )
+
+    result = aten_fast.fast_fa4_16bit_d64_causal_forward(
+        *public, is_causal=True, scale=0.125
+    )
+    output, logsumexp, q_native, k_native, v_native = result
+
+    assert output is allocations[0]
+    assert output._shape == (3, 12, 256, 64)
+    assert logsumexp._shape == (3, 12, 256)
+    assert (q_native, k_native, v_native) == public
+    assert bridge_calls == [
+        (
+            0x1000,
+            0x2000,
+            0x3000,
+            allocations[0]._ptr,
+            allocations[1]._ptr,
+            3,
+            256,
+            12,
+            0.125,
+            5050,
+        )
+    ]
+
+
+def test_fa4_bhsd_layout_requires_contiguity_and_16_byte_alignment() -> None:
+    base = _tensor("q", shape=(3, 12, 256, 64), ptr=0x1000)
+    assert aten_fast._fa4_bhsd_layout(base)
+
+    misaligned = SimpleNamespace(**vars(base))
+    misaligned._ptr = base._ptr + 2
+    assert not aten_fast._fa4_bhsd_layout(misaligned)
+
+    non_contiguous = SimpleNamespace(**vars(base))
+    non_contiguous._is_contiguous = False
+    assert not aten_fast._fa4_bhsd_layout(non_contiguous)
+
+    wrong_dtype = SimpleNamespace(**vars(base))
+    wrong_dtype._dtype = aten_fast.DType.float32
+    wrong_dtype._itemsize = 4
+    assert not aten_fast._fa4_bhsd_layout(wrong_dtype)
+
+    assert not aten_fast._fa4_bhsd_layout(None)
 
 
 def test_direct_flash_aten_returns_real_lse_and_cuda_shaped_auxiliaries(
@@ -900,13 +1005,16 @@ def test_vendored_fa4_sources_have_no_torch_cuda_or_internal_sync() -> None:
     assert "torch.cuda" not in sources
     assert "ctx.synchronize()" not in sources
 
-    # All five launches share compiled code by specialization and raw context
-    # identity.  B/S/H, pointers, descriptors, and launch grids stay runtime
-    # values, so changing model or batch shapes does not force recompilation.
+    # All six launches -- dense fwd, strided_qkv fwd, and BHSD-native fwd in
+    # fa4_fwd_launch.mojo, plus bwd preprocess/main/convert in
+    # fa4_bwd_launch.mojo -- share compiled code by specialization and raw
+    # context identity.  B/S/H, pointers, descriptors, and launch grids stay
+    # runtime values, so changing model or batch shapes does not force
+    # recompilation.
     launchers = (
         source_by_name["fa4_fwd_launch.mojo"] + source_by_name["fa4_bwd_launch.mojo"]
     )
     cache = source_by_name["fa4_launch_cache.mojo"]
-    assert launchers.count("enqueue_fa4_cached[") == 5
+    assert launchers.count("enqueue_fa4_cached[") == 6
     assert ".compile_function[" not in launchers
     assert "_CTX{context_identity}" in cache

--- a/tests/test_fa4_host_wiring.py
+++ b/tests/test_fa4_host_wiring.py
@@ -1111,16 +1111,19 @@ def test_vendored_fa4_sources_have_no_torch_cuda_or_internal_sync() -> None:
     assert "torch.cuda" not in sources
     assert "ctx.synchronize()" not in sources
 
-    # All six launches -- dense fwd, strided_qkv fwd, and BHSD-native fwd in
-    # fa4_fwd_launch.mojo, plus bwd preprocess/main/convert in
+    # All seven launches -- dense fwd, strided_qkv fwd, and BHSD-native fwd
+    # in fa4_fwd_launch.mojo, the phase-2c self-loading BHSD-native fwd in
+    # fa4_fwd_selfload_launch.mojo, plus bwd preprocess/main/convert in
     # fa4_bwd_launch.mojo -- share compiled code by specialization and raw
     # context identity.  B/S/H, pointers, descriptors, and launch grids stay
     # runtime values, so changing model or batch shapes does not force
     # recompilation.
     launchers = (
-        source_by_name["fa4_fwd_launch.mojo"] + source_by_name["fa4_bwd_launch.mojo"]
+        source_by_name["fa4_fwd_launch.mojo"]
+        + source_by_name["fa4_fwd_selfload_launch.mojo"]
+        + source_by_name["fa4_bwd_launch.mojo"]
     )
     cache = source_by_name["fa4_launch_cache.mojo"]
-    assert launchers.count("enqueue_fa4_cached[") == 6
+    assert launchers.count("enqueue_fa4_cached[") == 7
     assert ".compile_function[" not in launchers
     assert "_CTX{context_identity}" in cache

--- a/tests/test_fa4_selfload_ptx_ordering.py
+++ b/tests/test_fa4_selfload_ptx_ordering.py
@@ -1,0 +1,215 @@
+"""PTX ordering regression check for the self-loading FA4 fwd kernel.
+
+``fa4_fwd_selfload_kernel.mojo`` deleted the empty[] mbarriers a phase-2b
+producer/consumer split used to prove a ring slot's smem read had retired
+before the next TMA refill into that same slot. The substitute proof is
+program order plus ``wgmma.wait_group`` (see the PREFETCH invariant comment
+next to its definition in that file): the refill's `cp.async.bulk.tensor` /
+`mbarrier.arrive.expect_tx` must be textually emitted AFTER the
+`wgmma.wait_group` that proves the slot is free. That is true of today's
+Mojo/LLVM toolchain, but ``wgmma.wait_group`` carries no LLVM memory
+clobber, so nothing stops a *future* toolchain from reordering a refill
+ahead of its wait -- this test is the regression guard for that drift, not
+a check on this PR's own logic (which the soak in
+``test_fa4_selfload_soak.py`` covers at runtime).
+
+Cross-compiles with ``mojo build --emit asm --target-accelerator sm_90a``
+(needs no GPU, never touches ``/tmp/gpu_lock_0.lock``) the same way
+``scripts/compare_kernel_asm.py`` does, and greps the emitted PTX.
+
+Builds land in a STABLE directory (``tests/__mojocache__/...``, matching the
+already-gitignored ``__mojocache__/`` pattern), not a fresh temp dir per run:
+Mojo's own transform cache is keyed by kernel content hash independent of
+``-o``, and replays a previously built kernel's sidecar to the path it was
+FIRST built at -- a fresh ``tempfile.TemporaryDirectory()`` each run means
+that path is already gone by the second run in one session (see
+``compare_kernel_asm.py``'s own docstring: "Both trees are built into one
+shared directory per specialization, which is load-bearing").
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.compare_kernel_asm import build_env, mojo_cli
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_PROBE = Path(__file__).resolve().parent / "fa4_selfload_ptx_probe.mojo"
+_D128_GUARD_PROBE = (
+    Path(__file__).resolve().parent / "fa4_selfload_d128_guard_probe.mojo"
+)
+_FA4_DIR = _REPO_ROOT / "torch_mojo_backend" / "eager_flash_attention"
+_BUILD_DIR = Path(__file__).resolve().parent / "__mojocache__" / "fa4_selfload_ptx"
+_D128_GUARD_BUILD_DIR = (
+    Path(__file__).resolve().parent / "__mojocache__" / "fa4_selfload_d128_guard"
+)
+
+_WAIT_GROUP_RE = re.compile(r"\bwgmma\.wait_group\.sync\.aligned\b")
+_REFILL_COPY_RE = re.compile(r"\bcp\.async\.bulk\.tensor\b.*mbarrier::complete_tx")
+_EXPECT_TX_RE = re.compile(r"\bmbarrier\.arrive\.expect_tx\b")
+
+
+def _build_probe_ptx(out_dir: Path) -> str:
+    try:
+        mojo = mojo_cli()
+    except FileNotFoundError:
+        pytest.skip("mojo compiler not found")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    # Stale sidecars from a previous source edit would otherwise accumulate
+    # (the directory is stable across runs -- see the module docstring) and
+    # break the "exactly one .ptx" sanity check below.
+    for stale in list(out_dir.glob("*.ptx")) + list(out_dir.glob("*.s")):
+        stale.unlink()
+    out_stem = out_dir / "fa4_selfload_ptx_probe"
+    command = [
+        str(mojo),
+        "build",
+        str(_PROBE),
+        "-I",
+        str(_FA4_DIR),
+        "--emit",
+        "asm",
+        "--target-accelerator",
+        "sm_90a",
+        "-o",
+        str(out_stem) + ".s",
+    ]
+    result = subprocess.run(
+        command,
+        cwd=str(_REPO_ROOT),
+        env=build_env(),
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    assert result.returncode == 0, (
+        "mojo build --emit asm failed for the self-load fwd probe:\n"
+        f"{result.stderr or result.stdout}"
+    )
+    ptx_files = sorted(out_dir.glob("*.ptx"))
+    assert ptx_files, (
+        "mojo build --emit asm produced no .ptx sidecar -- the probe did"
+        " not reach a GPU kernel instantiation"
+    )
+    selfload_ptx = [p for p in ptx_files if "selfload" in p.name]
+    assert selfload_ptx, (
+        f"no PTX sidecar named for the self-load kernel among {ptx_files}"
+        " -- check fwd_fa4_selfload_kernel's naming"
+    )
+    assert len(selfload_ptx) == 1, (
+        f"expected exactly one self-load kernel instantiation, got {selfload_ptx}"
+    )
+    return selfload_ptx[0].read_text()
+
+
+@pytest.fixture(scope="module")
+def selfload_ptx() -> str:
+    return _build_probe_ptx(_BUILD_DIR)
+
+
+def _line_numbers(pattern: re.Pattern[str], text: str) -> list[int]:
+    return [i for i, line in enumerate(text.splitlines()) if pattern.search(line)]
+
+
+def _assert_every_event_follows_a_wait(
+    events: list[tuple[int, str]], event_label: str
+) -> None:
+    """Walk (line_no, kind) events in line order: every 'event_label' kind
+    must have a 'wait' kind since the previous 'event_label' (or since the
+    start of the region, for the first one)."""
+    waits_since_last_event = 0
+    seen_event = 0
+    for _line_no, kind in sorted(events):
+        if kind == "wait":
+            waits_since_last_event += 1
+        else:
+            assert waits_since_last_event >= 1, (
+                f"a {event_label} at line {_line_no} has no preceding"
+                " wgmma.wait_group since the previous one (or region start)"
+                " -- the refill was not textually ordered after the wait"
+                " that proves its slot is free"
+            )
+            waits_since_last_event = 0
+            seen_event += 1
+    assert seen_event >= 3, (
+        f"only {seen_event} {event_label} event(s) found after the first"
+        " wgmma.wait_group -- expected at least 3 (1 prologue refill + 2"
+        " per loop trip), the check would otherwise be nearly vacuous"
+    )
+
+
+def test_selfload_refills_follow_their_wait_group(selfload_ptx: str) -> None:
+    """Every K/V refill TMA copy is textually ordered after a wgmma.wait_group.
+
+    The prologue's initial fill (Q plus the first PREFETCH tile-pairs) has
+    no preceding wait -- there is nothing to wait for, no read has happened
+    yet -- so this only checks copies/expects that occur AFTER the first
+    wgmma.wait_group in the file, which excludes exactly that initial fill.
+    """
+    wait_lines = _line_numbers(_WAIT_GROUP_RE, selfload_ptx)
+    assert len(wait_lines) >= 3, (
+        f"expected at least 3 wgmma.wait_group sites (prologue + 2 per loop"
+        f" trip), found {len(wait_lines)} -- the probe may not have reached"
+        " the kernel body"
+    )
+    first_wait = wait_lines[0]
+
+    refill_lines = _line_numbers(_REFILL_COPY_RE, selfload_ptx)
+    expect_lines = _line_numbers(_EXPECT_TX_RE, selfload_ptx)
+
+    wait_events = [(line, "wait") for line in wait_lines if line >= first_wait]
+    refill_events = wait_events + [
+        (line, "refill") for line in refill_lines if line > first_wait
+    ]
+    _assert_every_event_follows_a_wait(refill_events, "cp.async.bulk.tensor refill")
+
+    expect_events = wait_events + [
+        (line, "expect_tx") for line in expect_lines if line > first_wait
+    ]
+    _assert_every_event_follows_a_wait(expect_events, "mbarrier.arrive.expect_tx")
+
+
+def test_selfload_rejects_d128_at_compile_time() -> None:
+    """Scope enforcement, not just documentation: instantiating the
+    self-loading kernel at head_dim=128 must fail the BUILD (ported from
+    agent A2's review artifact, d128_guard_v7.mojo)."""
+    try:
+        mojo = mojo_cli()
+    except FileNotFoundError:
+        pytest.skip("mojo compiler not found")
+    _D128_GUARD_BUILD_DIR.mkdir(parents=True, exist_ok=True)
+    out_path = _D128_GUARD_BUILD_DIR / "d128_guard.s"
+    command = [
+        str(mojo),
+        "build",
+        str(_D128_GUARD_PROBE),
+        "-I",
+        str(_FA4_DIR),
+        "--emit",
+        "asm",
+        "--target-accelerator",
+        "sm_90a",
+        "-o",
+        str(out_path),
+    ]
+    result = subprocess.run(
+        command,
+        cwd=str(_REPO_ROOT),
+        env=build_env(),
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    output = result.stderr + result.stdout
+    assert result.returncode != 0, (
+        "instantiating the self-load kernel at head_dim=128 built"
+        " successfully -- the d64-only comptime assert did not fire"
+    )
+    assert "d64-only" in output, (
+        f"build failed for an unexpected reason (not the d64-only scope"
+        f" guard):\n{output}"
+    )

--- a/tests/test_fa4_selfload_soak.py
+++ b/tests/test_fa4_selfload_soak.py
@@ -1,0 +1,84 @@
+"""Race regression soak for the self-loading FA4 fwd kernel (CI-lite).
+
+Ported from agent A's phase-2c harness
+(``/scratch/fa4-fwd-harness-2c/soak_v7.mojo``), shortened to two shapes and
+fewer reps for the permanent suite: bursts of back-to-back self-load kernel
+launches with no inter-launch sync (so consecutive kernels' CTAs are
+co-resident and warp scheduling gets perturbed), checked for bitwise
+determinism across reps plus a tolerance check against the structurally
+different phase-2b kernel. The full soak (more shapes, more reps, multiple
+clock pins) stays in the harness; see ``tests/fa4_selfload_soak_probe.mojo``
+for what this CI-lite variant covers and why (the PREFETCH invariant this
+guards is documented next to its definition in
+``fa4_fwd_selfload_kernel.mojo``).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.compare_kernel_asm import build_env, mojo_cli
+from torch_mojo_backend import get_accelerators
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_PROBE = Path(__file__).resolve().parent / "fa4_selfload_soak_probe.mojo"
+_FA4_DIR = _REPO_ROOT / "torch_mojo_backend" / "eager_flash_attention"
+
+
+@pytest.fixture(scope="module")
+def selfload_soak_binary(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    accelerators = list(get_accelerators())
+    if (
+        not accelerators
+        or accelerators[0].api != "cuda"
+        or (accelerators[0].architecture_name != "sm_90a")
+    ):
+        pytest.skip("the self-load FA4 fwd kernel is H100 (sm_90a) only")
+    try:
+        mojo = mojo_cli()
+    except FileNotFoundError:
+        pytest.skip("mojo compiler not found")
+
+    out_dir = tmp_path_factory.mktemp("fa4_selfload_soak")
+    out_path = out_dir / "fa4_selfload_soak_probe"
+    command = [
+        str(mojo),
+        "build",
+        str(_PROBE),
+        "-I",
+        str(_FA4_DIR),
+        "-o",
+        str(out_path),
+    ]
+    result = subprocess.run(
+        command,
+        cwd=str(_REPO_ROOT),
+        env=build_env(),
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    assert result.returncode == 0, (
+        "mojo build failed for the self-load soak probe:\n"
+        f"{result.stderr or result.stdout}"
+    )
+    return out_path
+
+
+def test_selfload_soak_no_race(selfload_soak_binary: Path) -> None:
+    """64 back-to-back self-load launches per shape must be bitwise
+    deterministic and match the phase-2b kernel within tolerance."""
+    result = subprocess.run(
+        [str(selfload_soak_binary)],
+        cwd=str(_REPO_ROOT),
+        env=build_env(),
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    output = result.stdout + result.stderr
+    assert result.returncode == 0, f"self-load soak failed:\n{output}"
+    assert "SOAK PASS" in output, f"self-load soak did not report PASS:\n{output}"

--- a/torch_mojo_backend/eager_flash_attention/fa4_bwd_launch.mojo
+++ b/torch_mojo_backend/eager_flash_attention/fa4_bwd_launch.mojo
@@ -215,17 +215,19 @@ def launch_bwd_main[
     v_d_stride: Int = 1,
 ) raises:
     # Strided Q/K/V (zero-copy fused-QKV views) is scoped to the
-    # dense d64 path in this port; the caller validates the layout
-    # contract (d_stride==1, b_stride==S*s_stride, 16 B-aligned
-    # strides) before this launcher runs.
+    # dense path in this port (d64 or d128); the caller validates the
+    # layout contract (d_stride==1, b_stride==S*s_stride, 16 B-aligned
+    # strides, h_stride==head_dim) before this launcher runs. Q/K/V
+    # descriptor construction below is already head_dim-generic (no
+    # rank-4 tail-tile branch the way the fwd launcher needs).
     comptime assert (not strided_qkv) or (
-        head_dim == 64
+        (head_dim == 64 or head_dim == 128)
         and causal
         and not varlen
         and not window
         and gqa_ratio == 1
         and softcap_x1000 == 0
-    ), "strided_qkv supports only dense d64 MHA"
+    ), "strided_qkv supports only dense d64/d128 MHA"
     var ctx = _ctx_and_stream(ctx_handle_addr)
     var stream_opaque = OpaquePointer[MutAnyOrigin](
         unsafe_from_address=stream_handle_addr

--- a/torch_mojo_backend/eager_flash_attention/fa4_fwd_common.mojo
+++ b/torch_mojo_backend/eager_flash_attention/fa4_fwd_common.mojo
@@ -1,26 +1,51 @@
-"""Shared comptime constants for the FA4-target fwd kernel.
+"""V2 comptime constants for the FA4 fwd kernel (phase 2 deliverable).
 
-Mirrors Tri Dao FA4's sm90 configs (see reference_ptx/README.md and
-reference_ptx/hdim64_port_spec.md):
-- head_dim 128: tile 128x128, 2 MMA warpgroups + 1 producer, 384
-  threads, setmaxnreg 24/240.
-- head_dim 64: tile 192x128, 3 MMA warpgroups + 1 producer, 512
-  threads, setmaxnreg 32/160 (the pool 3*128*160 + 128*32 = 65536 is
-  exactly the register file).
-All are comptime functions of head_dim; the hdim128 evaluations must
-keep the original kernels' PTX byte-identical.
+head_dim 64 moves from tile 192x128 (3 MMA warpgroups + producer, 512
+threads, setmaxnreg 32/160, 1 CTA/SM) to tile 64x128 (1 MMA warpgroup +
+producer, 256 threads, setmaxnreg 24/232, TWO CTAs PER SM via
+`nvvm.minctasm`=2 — the pool 2*(128*232 + 128*24) = 65536 is exactly the
+register file).
+
+WHY (measured, see NOTES.md phase 2): causal tile-quantization
+overcompute. BM=192 > BN=128 makes the diagonal band span two 128-col
+tiles per 192 rows: at S=1024 the kernel computes 1.500x the causal
+triangle vs 1.125x at BM=64 (cuDNN's 66.7us P0 kernel runs 64x128 at
+1.125x). The second CTA per SM replaces the third warpgroup's latency
+hiding (a 2-WG BM=128 single-CTA variant measured WORSE per unit: each
+WG's ~850-cycle softmax overruns its 512-cycle tensor slot).
+
+head_dim 128 keeps the production config (tile 128x128, 2 MMA
+warpgroups + producer, 384 threads, 24/240) — evaluations must stay
+byte-identical.
+
+SCOPE: these constants are a pure function of head_dim and feed every
+d64 instantiation in fa4_ops.mojo — dense causal, the strided-QKV ABI,
+and the BHSD-native path all share this one kernel body, so all three
+move to BM=64/1-warpgroup/2-CTAs-per-SM together (verified bitwise
+against the BM=192 kernel on 11 edge shapes, benchmarked on the
+dense/bhsd routes). `varlen` and `window` are comptime parameters on
+`fwd_fa4_kernel`/`launch_fwd_fa4` but, as of this change, no entry
+point in fa4_ops.mojo instantiates either at ANY head_dim — there is
+no shipped varlen/window route today for these constants to affect.
+The causal mask arms most sensitive to BM (see the diagonal-predicate
+comment in fa4_fwd_kernel.mojo) already fall back to the pre-existing,
+unoptimized-but-safe `kv_trips <= 2` rule whenever `varlen or window`,
+so a future varlen/window entry point inherits a correct (if
+unaccelerated) mask for free; re-measure it before relying on its
+performance, and re-run this file's edge-shape tests before trusting
+its BM=64 tiling once one is added.
 """
 
 
 def kFa4BlockM(head_dim: Int) -> Int:
-    return 192 if head_dim == 64 else 128
+    return 64 if head_dim == 64 else 128
 
 
 comptime kFa4BlockN: Int = 128
 
 
 def kFa4NMmaWarpgroups(head_dim: Int) -> Int:
-    return 3 if head_dim == 64 else 2
+    return 1 if head_dim == 64 else 2
 
 
 def kFa4NThreads(head_dim: Int) -> Int:
@@ -28,13 +53,15 @@ def kFa4NThreads(head_dim: Int) -> Int:
 
 
 def kFa4ProducerRegs(head_dim: Int) -> Int:
-    return 32 if head_dim == 64 else 24
+    return 24
 
 
 def kFa4ConsumerRegs(head_dim: Int) -> Int:
-    return 160 if head_dim == 64 else 240
+    return 232 if head_dim == 64 else 240
 
 
 # K/V shared-memory ring: K(n) lives in slot (2n) % kFa4KVStages,
-# V(n) in slot (2n+1) % kFa4KVStages.
+# V(n) in slot (2n+1) % kFa4KVStages. (Ring depth is not the limiter:
+# 8 stages measured within noise of 6 at BM=128; 6 fits 2 CTAs/SM at
+# BM=64: 8 KiB Q + 96 KiB ring + mbar < 113.5 KiB per CTA.)
 comptime kFa4KVStages: Int = 6

--- a/torch_mojo_backend/eager_flash_attention/fa4_fwd_kernel.mojo
+++ b/torch_mojo_backend/eager_flash_attention/fa4_fwd_kernel.mojo
@@ -81,7 +81,10 @@ comptime WGMMA_K: Int = 16
 @__llvm_metadata(
     MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](
         Int32(kFa4NThreads(head_dim))
-    )
+    ),
+    `nvvm.minctasm`=SIMDLength(
+        2 if kFa4NMmaWarpgroups(head_dim) == 1 else 1
+    ),
 )
 @__llvm_arg_metadata(q_tma, `nvvm.grid_constant`)
 @__llvm_arg_metadata(k_tma, `nvvm.grid_constant`)
@@ -143,6 +146,15 @@ def fwd_fa4_kernel[
     comptime NUM_CONSUMER_REGS: Int = kFa4ConsumerRegs(head_dim)
     comptime accum_type: DType = DType.float32
     comptime swizzle: TensorMapSwizzle = TensorMapSwizzle.SWIZZLE_128B
+    # Tree-shaped row reductions (phase 2b), scoped to the geometry they
+    # were profiled on: the d64 tile (BM=64, ONE MMA warpgroup, 232 regs,
+    # 2 CTAs/SM), where `wait` (fixed-latency dependency) was the top ncu
+    # stall. On the d128 tile (BM=BN=128, two warpgroups, 240 regs, 1
+    # CTA/SM) they measured NEUTRAL -- 1.036 vs an A/A control of 1.038
+    # at B8 H12 S1024 -- so d128 keeps a4e8462's codegen (and its exact
+    # rowsum summation order) rather than taking an unproven change.
+    # Ungating is safe if a later measurement wants one code path.
+    comptime TREE_REDUCE: Bool = kFa4NMmaWarpgroups(head_dim) == 1
 
     comptime q_smem_layout = tile_layout_k_major[
         dtype, BM, D, swizzle_mode=swizzle
@@ -437,7 +449,7 @@ def fwd_fa4_kernel[
                 row += row_step
                 slot += 2
                 wrap += 1
-                if wrap == 3:
+                if wrap == STAGES // 2:
                     wrap = 0
                     slot = 0
                     phase ^= 1
@@ -461,8 +473,15 @@ def fwd_fa4_kernel[
     # warpgroup arrives at the *other* one's barrier after committing
     # its GEMM pair, so issue phases alternate and each warpgroup's
     # softmax overlaps the other's GEMMs. WG0 self-arms its barrier.
-    if wg == 0:
-        named_barrier_arrive[Int32(SCHED_BAR_N)](Int32(1))
+    # At NWG == 1 the pingpong ring degenerates to a SELF ring: the
+    # warpgroup's wait on barrier 1 is satisfied by its own arrive from
+    # the previous trip, so it orders nothing (the K/V mbarriers carry
+    # every real dependency) while costing two BAR ops and a ~30-cycle
+    # barrier latency per kv tile -- `barrier` was 0.51 warps/issue in
+    # the ncu profile. Comptime-drop it; NWG >= 2 keeps FA4's schedule.
+    comptime if NWG > 1:
+        if wg == 0:
+            named_barrier_arrive[Int32(SCHED_BAR_N)](Int32(1))
 
     var wgmma_qk = TensorCoreAsync[
         accum_type,
@@ -658,14 +677,76 @@ def fwd_fa4_kernel[
                 # cross-attention offset shifts the diagonal off the
                 # n == m tile and the band may straddle two tiles.)
                 if mask_diag:
-                    comptime for c in range(c_frag_size_qk):
-                        comptime col_base: Int = (c // 4) * 8 + (c & 1)
-                        comptime row_off: Int = 8 if (c % 4) >= 2 else 0
-                        if (
-                            col_base + mask_col_lo + causal_mask_d
-                            > mask_row_lo + row_off
-                        ):
-                            s_reg.ptr[c] = neg_inf
+                    # 32-BIT THRESHOLDS, hoisted out of the 64-element
+                    # unrolled body. Mojo's Int is 64-bit, so
+                    # `col + mask_col_lo + causal_mask_d > row + off`
+                    # reached SASS as a 64-bit compare -- TWO ISETPs
+                    # (ISETP.GT.U32.AND + ISETP.GT.AND.EX) per element,
+                    # 128 of the masked tile's 192 mask instructions.
+                    # Rearranged, the per-element test is
+                    # `col_base > row + off - mask_col_lo - mask_d`
+                    # whose right-hand side is loop-invariant: two
+                    # Int32 registers and one ISETP per element.
+                    #
+                    # INT32 RANGE ASSUMPTION: mask_row_lo (tile-local,
+                    # < BM <= 192) and mask_col_lo (< 8) are always
+                    # small, but causal_mask_d carries -vl_offs for
+                    # varlen causal -- the cumulative token offset of
+                    # this sequence within its packed batch -- and is
+                    # otherwise O(seqlen) for dense/window causal. The
+                    # Int32() truncation below is exact only while
+                    # |mask_row_lo - mask_col_lo - causal_mask_d| stays
+                    # under INT32_MAX - 8 (~2.1e9): unreachable at any
+                    # physical shape this kernel is built for (it would
+                    # need a multi-billion-token packed varlen batch),
+                    # but it is new exposure vs the old code above,
+                    # which compared in 64-bit `Int` and had no such
+                    # ceiling. Guarded explicitly rather than left
+                    # implicit; off by default like every other
+                    # debug_assert (`-D ASSERT=all` or a debug build
+                    # turns it on).
+                    var mask_thr0_wide: Int = (
+                        mask_row_lo - mask_col_lo - causal_mask_d
+                    )
+                    debug_assert(
+                        mask_thr0_wide <= Int(Int32.MAX_FINITE) - 8
+                        and mask_thr0_wide >= Int(Int32.MIN_FINITE),
+                        (
+                            "fa4 fwd: causal mask threshold overflows"
+                            " int32 (seqlen/vl_offs too large): "
+                        ),
+                        mask_thr0_wide,
+                    )
+                    var mask_thr0: Int32 = Int32(mask_thr0_wide)
+                    var mask_thr1: Int32 = mask_thr0 + 8
+                    # COLUMN-GROUP SKIP: the c-fragment's column
+                    # col_base = (c//4)*8 + (c&1) is monotone in c, so
+                    # the mask is a SUFFIX in c and whole quarters of
+                    # the fragment can be skipped with one compare. The
+                    # causal band is 65 columns wide inside a 128-column
+                    # tile, so on the diagonal tile a bit under half the
+                    # fragment is below the boundary for every thread.
+                    # The test uses mask_thr0 (<= mask_thr1) so it is
+                    # conservative for both rows, and the threads of a
+                    # warp share a row block, so the branch is nearly
+                    # warp-uniform.
+                    comptime GROUPS: Int = 4
+                    comptime GSZ: Int = c_frag_size_qk // GROUPS
+                    comptime for g in range(GROUPS):
+                        comptime col_max: Int32 = Int32(
+                            ((g * GSZ + GSZ - 1) // 4) * 8 + 1
+                        )
+                        if col_max > mask_thr0:
+                            comptime for cc in range(GSZ):
+                                comptime c: Int = g * GSZ + cc
+                                comptime col_base: Int32 = Int32(
+                                    (c // 4) * 8 + (c & 1)
+                                )
+                                comptime hi_row: Bool = (c % 4) >= 2
+                                if col_base > (
+                                    mask_thr1 if hi_row else mask_thr0
+                                ):
+                                    s_reg.ptr[c] = neg_inf
         comptime if window:
             # Leading window edge (prologue tile only): cols before
             # row - left are outside the window.
@@ -684,14 +765,41 @@ def fwd_fa4_kernel[
                     comptime col_base: Int = (c // 4) * 8 + (c & 1)
                     if col_base + mask_col_lo >= vl_kv_tail:
                         s_reg.ptr[c] = neg_inf
+        # TREE-SHAPED row reductions. The natural
+        # `local_max[row] = max(local_max[row], s_reg[c])` sweep is two
+        # 32-deep dependent chains (~4-cycle FMNMX latency each = ~128
+        # cycles of pure latency for 64 issue slots); `wait` was the
+        # top stall in the ncu profile. Four partial accumulators per
+        # row turn it into eight 8-deep chains plus a 2-level combine.
+        # Same instruction count, ~1/3 the exposed latency, and max is
+        # associative/commutative so the result is bit-identical.
+        comptime RED_WAYS: Int = 4
         var local_max = stack_allocation[
             rows_per_thread, Scalar[accum_type]
         ]()
-        comptime for i in range(rows_per_thread):
-            local_max[i] = neg_inf
-        comptime for c in range(c_frag_size_qk):
-            comptime row_idx: Int = 1 if (c % 4) >= 2 else 0
-            local_max[row_idx] = max(local_max[row_idx], s_reg.ptr[c])
+        comptime if TREE_REDUCE:
+            var part_max = stack_allocation[
+                rows_per_thread * RED_WAYS, Scalar[accum_type]
+            ]()
+            comptime for i in range(rows_per_thread * RED_WAYS):
+                part_max[i] = neg_inf
+            comptime for c in range(c_frag_size_qk):
+                comptime row_idx: Int = 1 if (c % 4) >= 2 else 0
+                comptime part: Int = (c // 4) % RED_WAYS
+                part_max[row_idx * RED_WAYS + part] = max(
+                    part_max[row_idx * RED_WAYS + part], s_reg.ptr[c]
+                )
+            comptime for i in range(rows_per_thread):
+                local_max[i] = max(
+                    max(part_max[i * RED_WAYS], part_max[i * RED_WAYS + 1]),
+                    max(part_max[i * RED_WAYS + 2], part_max[i * RED_WAYS + 3]),
+                )
+        else:
+            comptime for i in range(rows_per_thread):
+                local_max[i] = neg_inf
+            comptime for c in range(c_frag_size_qk):
+                comptime row_idx: Int = 1 if (c % 4) >= 2 else 0
+                local_max[row_idx] = max(local_max[row_idx], s_reg.ptr[c])
         comptime for i in range(rows_per_thread):
             local_max[i] = warp.lane_group_max[num_lanes=4](local_max[i])
             var rmax_new: Scalar[accum_type] = max(
@@ -703,15 +811,39 @@ def fwd_fa4_kernel[
         var local_sum = stack_allocation[
             rows_per_thread, Scalar[accum_type]
         ]()
-        comptime for i in range(rows_per_thread):
-            local_sum[i] = Scalar[accum_type](0)
-        comptime for c in range(c_frag_size_qk):
-            comptime row_idx: Int = 1 if (c % 4) >= 2 else 0
-            var p: Scalar[accum_type] = exp2(
-                s_reg.ptr[c].fma(scale_log2, -rowmax[row_idx])
-            )
-            s_reg.ptr[c] = p
-            local_sum[row_idx] += p
+        comptime if TREE_REDUCE:
+            var part_sum = stack_allocation[
+                rows_per_thread * RED_WAYS, Scalar[accum_type]
+            ]()
+            comptime for i in range(rows_per_thread * RED_WAYS):
+                part_sum[i] = Scalar[accum_type](0)
+            comptime for c in range(c_frag_size_qk):
+                comptime row_idx: Int = 1 if (c % 4) >= 2 else 0
+                comptime part: Int = (c // 4) % RED_WAYS
+                var p: Scalar[accum_type] = exp2(
+                    s_reg.ptr[c].fma(scale_log2, -rowmax[row_idx])
+                )
+                s_reg.ptr[c] = p
+                part_sum[row_idx * RED_WAYS + part] += p
+            # Pairwise combine (the ONLY numeric difference vs the
+            # a4e8462 kernel: f32 addition is not associative, so rowsum
+            # can differ in the last ulp -- tree summation of
+            # non-negative exp2 outputs is the better-conditioned order,
+            # and the fp64 reference check bounds it).
+            comptime for i in range(rows_per_thread):
+                local_sum[i] = (
+                    part_sum[i * RED_WAYS] + part_sum[i * RED_WAYS + 1]
+                ) + (part_sum[i * RED_WAYS + 2] + part_sum[i * RED_WAYS + 3])
+        else:
+            comptime for i in range(rows_per_thread):
+                local_sum[i] = Scalar[accum_type](0)
+            comptime for c in range(c_frag_size_qk):
+                comptime row_idx: Int = 1 if (c % 4) >= 2 else 0
+                var p: Scalar[accum_type] = exp2(
+                    s_reg.ptr[c].fma(scale_log2, -rowmax[row_idx])
+                )
+                s_reg.ptr[c] = p
+                local_sum[row_idx] += p
         comptime for i in range(rows_per_thread):
             rowsum[i] = rowsum[i] * scale_old[i] + local_sum[i]
 
@@ -752,13 +884,24 @@ def fwd_fa4_kernel[
         comptime if BM == BN and not varlen:
             prologue_diag = kv_trips == 1
         else:
-            prologue_diag = kv_trips <= 2
             causal_mask_d = -m_block * BM
             comptime if varlen:
                 causal_mask_d -= vl_offs
             comptime if window:
                 # The prologue tile is first_kv, not 0.
                 causal_mask_d += first_kv * BN
+            comptime if varlen or window:
+                prologue_diag = kv_trips <= 2
+            else:
+                # EXACT diagonal test (dense causal): a tile needs the
+                # mask iff its last column can exceed this warpgroup's
+                # first row, n*BN + BN-1 > m*BM + wg*WGMMA_M, i.e.
+                # causal_mask_d + BN-1 > wg*WGMMA_M. The old "last two
+                # tiles of the trip range" rule is a strict superset:
+                # at BM=64/BN=128 the 64-row band's diagonal spans 65
+                # columns and always lands in ONE tile, so it made 42%
+                # of all tiles run the mask arm where 22% need it.
+                prologue_diag = causal_mask_d + (BN - 1) > wg * WGMMA_M
     softmax_block(prologue_diag, True)
     pack_p()  # P(0)
     # The window leading edge can straddle into the FIRST loop tile
@@ -784,7 +927,8 @@ def fwd_fa4_kernel[
     for it in range(kv_trips - 1):
         # Queue QK(n+1) then PV(n) on the tensor core.
         full[k_slot].wait(k_phase)
-        named_barrier[Int32(SCHED_BAR_N)](Int32(1 + wg))
+        comptime if NWG > 1:
+            named_barrier[Int32(SCHED_BAR_N)](Int32(1 + wg))
         warpgroup_fence(s_reg)
         wgmma_qk.arrive()
         wgmma_qk.wgmma[num_warp_groups=NWG, scale_c=0](
@@ -800,7 +944,7 @@ def fwd_fa4_kernel[
         # Arrive at the SUCCESSOR's sync barrier: ring W0->W1->...->W0.
         comptime if NWG == 2:
             named_barrier_arrive[Int32(SCHED_BAR_N)](Int32(2 - wg))
-        else:
+        elif NWG > 2:
             named_barrier_arrive[Int32(SCHED_BAR_N)](
                 Int32(wg + 2 if wg < NWG - 1 else 1)
             )
@@ -819,13 +963,16 @@ def fwd_fa4_kernel[
             comptime if BM == BN and not varlen:
                 loop_diag = it == kv_trips - 2
             else:
-                loop_diag = it >= kv_trips - 3
                 causal_mask_d = (it + 1) * BN - m_block * BM
                 comptime if varlen:
                     causal_mask_d -= vl_offs
                 comptime if window:
                     # Loop trip it processes tile first_kv + it + 1.
                     causal_mask_d += first_kv * BN
+                comptime if varlen or window:
+                    loop_diag = it >= kv_trips - 3
+                else:
+                    loop_diag = causal_mask_d + (BN - 1) > wg * WGMMA_M
         # Window, unaligned left only: the first loop tile can hold
         # leading-edge columns (win_mask_d was advanced after the
         # prologue). Aligned variants pass a comptime False so the
@@ -844,13 +991,13 @@ def fwd_fa4_kernel[
 
         k_slot += 2
         k_wrap += 1
-        if k_wrap == 3:
+        if k_wrap == STAGES // 2:
             k_wrap = 0
             k_slot = 0
             k_phase ^= 1
         v_slot += 2
         v_wrap += 1
-        if v_wrap == 3:
+        if v_wrap == STAGES // 2:
             v_wrap = 0
             v_slot = 1
             v_phase ^= 1

--- a/torch_mojo_backend/eager_flash_attention/fa4_fwd_kernel.mojo
+++ b/torch_mojo_backend/eager_flash_attention/fa4_fwd_kernel.mojo
@@ -103,6 +103,7 @@ def fwd_fa4_kernel[
     window: Bool = False,
     window_unaligned: Bool = False,
     softcap_x1000: Int = 0,
+    bhsd: Bool = False,
 ](
     q_tma: TMATensorTile[dtype, qo_rank, q_tile_shape, q_desc_shape],
     k_tma: TMATensorTile[dtype, 3, kv_tile_shape, kv_desc_shape],
@@ -116,6 +117,16 @@ def fwd_fa4_kernel[
     sched_num_hb_q_arg: Int64,
     sched_residual_arg: Int64,
 ):
+    # BHSD-native mode: Q/K/V/O descriptors address the PUBLIC
+    # contiguous (B, H, S, D) layout viewed as (B*H, S, D) — planes are
+    # the TMA outer dim and S its own dim, so BM=192 tail tiles
+    # zero-fill on load and clamp on store at every plane edge. No BTHD
+    # materialization (FA3's scheme: the head stride is just another
+    # gmem stride). Dense only in v1.
+    comptime if bhsd:
+        comptime assert qo_rank == 3 and not varlen and not window, (
+            "bhsd v1 is the dense (non-varlen, non-window) path"
+        )
     # Int is not device-passable (host/device width mismatch); scalars cross
     # the launch ABI as Int64 and index math stays in Int.
     var seq_len = Int(seq_len_arg)
@@ -329,7 +340,14 @@ def fwd_fa4_kernel[
         warpgroup_reg_dealloc[NUM_PRODUCER_REGS]()
         if thread_idx.x == 0:
             mbar_q[0].expect_bytes(Int32(BM * D * size_of[dtype]()))
-            comptime if qo_rank == 4:
+            comptime if bhsd:
+                # (B*H, S, D) planes; S its own dim -> tail zero-fill.
+                q_tma.async_copy_3d(
+                    q_smem,
+                    mbar_q[0],
+                    (0, m_block * BM, b_idx * nheads + h_idx),
+                )
+            elif qo_rank == 4:
                 # Dense hdim64: S is its own TMA dim (BM=192 does not
                 # divide the seqlen envelope; OOB tail rows zero-fill
                 # here and the store-side clamps).
@@ -360,7 +378,15 @@ def fwd_fa4_kernel[
             var wrap: Int = 0
             var row: Int
             var row_step: Int = BN
-            comptime if window:
+            # BHSD: kv rows are plane-local (the plane is a TMA coord).
+            var kv_plane: Int = 0
+            comptime if bhsd:
+                kv_plane = (
+                    b_idx * (nheads // gqa_ratio) + h_idx // gqa_ratio
+                )
+            comptime if bhsd:
+                row = 0
+            elif window:
                 comptime if varlen:
                     row = vl_k_base + first_kv * BN
                 else:
@@ -383,9 +409,12 @@ def fwd_fa4_kernel[
                     alignment=128,
                 ]((kv_smem_base + slot * kv_slot_size).as_unsafe_any_origin())
                 full[slot].expect_bytes(Int32(BN * D * size_of[dtype]()))
-                k_tma.async_copy_3d(
-                    k_st, full[slot], (0, h_idx // gqa_ratio, row)
-                )
+                comptime if bhsd:
+                    k_tma.async_copy_3d(k_st, full[slot], (0, row, kv_plane))
+                else:
+                    k_tma.async_copy_3d(
+                        k_st, full[slot], (0, h_idx // gqa_ratio, row)
+                    )
 
                 empty[slot + 1].wait(phase)
                 var v_st = LayoutTensor[
@@ -396,9 +425,14 @@ def fwd_fa4_kernel[
                     alignment=128,
                 ]((kv_smem_base + (slot + 1) * kv_slot_size).as_unsafe_any_origin())
                 full[slot + 1].expect_bytes(Int32(BN * D * size_of[dtype]()))
-                v_tma.async_copy_3d(
-                    v_st, full[slot + 1], (0, h_idx // gqa_ratio, row)
-                )
+                comptime if bhsd:
+                    v_tma.async_copy_3d(
+                        v_st, full[slot + 1], (0, row, kv_plane)
+                    )
+                else:
+                    v_tma.async_copy_3d(
+                        v_st, full[slot + 1], (0, h_idx // gqa_ratio, row)
+                    )
 
                 row += row_step
                 slot += 2
@@ -864,8 +898,9 @@ def fwd_fa4_kernel[
     # Dense hdim64 (BM=192): the last m-tile is partial whenever
     # seq_len % BM != 0 — rank-4 TMA clamps the O store, but the LSE
     # writes still need the row predicate (vl_rows doubles as the
-    # valid-row count for both paths).
-    comptime if qo_rank == 4:
+    # valid-row count for both paths). BHSD's rank-3 (planes, S, D)
+    # store clamps at the plane's S edge the same way.
+    comptime if qo_rank == 4 or bhsd:
         vl_rows = seq_len - m_block * BM
 
     var full_tile_store: Bool = True
@@ -970,7 +1005,7 @@ def fwd_fa4_kernel[
             # Varlen: rows past the sequence's end belong to the NEXT
             # sequence's packed LSE rows — predicate them off.
             var lse_ok: Bool = True
-            comptime if varlen or qo_rank == 4:
+            comptime if varlen or qo_rank == 4 or bhsd:
                 lse_ok = r < vl_rows
             if lse_ok:
                 (lse_ptr + lse_row_base + r)[0] = (
@@ -989,7 +1024,13 @@ def fwd_fa4_kernel[
             address_space=AddressSpace.SHARED,
             alignment=128,
         ]((smem_base).as_unsafe_any_origin())
-        comptime if qo_rank == 4:
+        comptime if bhsd:
+            # (B*H, S, D) planes: the partial tail clamps at the
+            # plane's S edge in hardware.
+            o_tma.async_store_3d(
+                o_st, (0, m_block * BM, b_idx * nheads + h_idx)
+            )
+        elif qo_rank == 4:
             # S its own dim: the partial tail tile clamps in hardware.
             o_tma.async_store_4d(
                 o_st, (0, h_idx, m_block * BM, b_idx)

--- a/torch_mojo_backend/eager_flash_attention/fa4_fwd_launch.mojo
+++ b/torch_mojo_backend/eager_flash_attention/fa4_fwd_launch.mojo
@@ -84,17 +84,18 @@ def launch_fwd_fa4[
     v_d_stride: Int = 1,
 ) raises:
     # Strided Q/K/V (zero-copy fused-QKV views) is scoped to the
-    # dense d64 causal path in this port; the caller validates the
-    # layout contract (d_stride==1, b_stride==S*s_stride, 16 B-
-    # aligned strides) before this launcher runs.
+    # dense causal path in this port (d64 or d128); the caller
+    # validates the layout contract (d_stride==1, b_stride==S*s_stride,
+    # 16 B-aligned strides, h_stride==head_dim) before this launcher
+    # runs.
     comptime assert (not strided_qkv) or (
-        head_dim == 64
+        (head_dim == 64 or head_dim == 128)
         and causal
         and not varlen
         and not window
         and gqa_ratio == 1
         and softcap_x1000 == 0
-    ), "strided_qkv supports only dense d64 (no varlen/window/gqa/softcap)"
+    ), "strided_qkv supports only dense d64/d128 (no varlen/window/gqa/softcap)"
     var raw_ctx_ptr = UnsafePointer[_DeviceContextCpp, MutUntrackedOrigin](
         unsafe_from_address=ctx_handle_addr
     )
@@ -138,13 +139,13 @@ def launch_fwd_fa4[
 
     comptime if bhsd_qkv:
         comptime assert (
-            head_dim == 64
+            (head_dim == 64 or head_dim == 128)
             and causal
             and not varlen
             and not window
             and softcap_x1000 == 0
             and not strided_qkv
-        ), "bhsd_qkv v1 supports only the dense causal d64 path"
+        ), "bhsd_qkv v1 supports only the dense causal d64/d128 path"
         # PUBLIC-layout consumption (the fix for the 30-45% gather-copy
         # overhead): Q/K/V/O are the contiguous (B, H, S, D) tensors the
         # ATen op provides, viewed as (B*H, S, D). Planes are the TMA
@@ -399,9 +400,30 @@ def launch_fwd_fa4[
         )
         return
 
-    var q_tma = create_split_tma[
-        q_smem_shape, gmem_shape, swizzle_mode=swizzle
-    ](ctx, q_ptr, rows, nheads_int)
+    # QO_RANK == 3 (head_dim != 64, i.e. the d128 dense/strided path):
+    # BM == BN == 128 here, so the seqlen % 128 == 0 eligibility gate
+    # already makes every m-tile a full tile -- no rank-4 tail
+    # descriptor is needed the way d64's BM=192 requires. Q mirrors
+    # K/V's existing strided-vs-plain choice above; O always stays
+    # the dense contiguous descriptor (strided_qkv only broadens Q/K/V).
+    var q_tma: SplitLastDimTMATensorTile[dtype, q_smem_shape, swizzle]
+    comptime if strided_qkv:
+        q_tma = create_split_tma_3d_strided[
+            q_smem_shape, swizzle_mode=swizzle
+        ](
+            ctx,
+            q_ptr,
+            rows,
+            nheads_int,
+            head_dim,
+            q_s_stride,
+            q_h_stride,
+            q_d_stride,
+        )
+    else:
+        q_tma = create_split_tma[
+            q_smem_shape, gmem_shape, swizzle_mode=swizzle
+        ](ctx, q_ptr, rows, nheads_int)
     var o_tma = create_split_tma[
         q_smem_shape, gmem_shape, swizzle_mode=swizzle
     ](ctx, o_imm_ptr, rows, nheads_int)

--- a/torch_mojo_backend/eager_flash_attention/fa4_fwd_launch.mojo
+++ b/torch_mojo_backend/eager_flash_attention/fa4_fwd_launch.mojo
@@ -54,6 +54,7 @@ def launch_fwd_fa4[
     window_unaligned: Bool = False,
     softcap_x1000: Int = 0,
     strided_qkv: Bool = False,
+    bhsd_qkv: Bool = False,
 ](
     batch_int: Int,
     seqlen_int: Int,
@@ -134,6 +135,104 @@ def launch_fwd_fa4[
         kFa4BlockM(head_dim), 1, head_dim
     )
     comptime kv_smem_shape = IndexList[3](kFa4BlockN, 1, head_dim)
+
+    comptime if bhsd_qkv:
+        comptime assert (
+            head_dim == 64
+            and causal
+            and not varlen
+            and not window
+            and softcap_x1000 == 0
+            and not strided_qkv
+        ), "bhsd_qkv v1 supports only the dense causal d64 path"
+        # PUBLIC-layout consumption (the fix for the 30-45% gather-copy
+        # overhead): Q/K/V/O are the contiguous (B, H, S, D) tensors the
+        # ATen op provides, viewed as (B*H, S, D). Planes are the TMA
+        # outer dim and S its OWN dim, so BM=192 tail tiles zero-fill
+        # on load and clamp on store at every plane's S edge — no BTHD
+        # materialization, no next-plane clobber. This is FA3's scheme
+        # (head stride is just another gmem stride).
+        comptime q_smem_shape_b = IndexList[3](
+            1, kFa4BlockM(head_dim), head_dim
+        )
+        comptime kv_smem_shape_b = IndexList[3](1, kFa4BlockN, head_dim)
+        var planes_q: Int = batch_int * nheads_int
+        var planes_kv: Int = batch_int * (nheads_int // gqa_ratio)
+        var q_tma_b = create_split_tma[
+            q_smem_shape_b, gmem_shape, swizzle_mode=swizzle
+        ](ctx, q_ptr, planes_q, seqlen_int)
+        var k_tma_b = create_split_tma[
+            kv_smem_shape_b, gmem_shape, swizzle_mode=swizzle
+        ](ctx, k_ptr, planes_kv, seqlen_int)
+        var v_tma_b = create_split_tma[
+            kv_smem_shape_b, gmem_shape, swizzle_mode=swizzle
+        ](ctx, v_ptr, planes_kv, seqlen_int)
+        var o_imm_ptr_b = UnsafePointer[Scalar[dtype], ImmutAnyOrigin](
+            unsafe_from_address=o_addr
+        )
+        var o_tma_b = create_split_tma[
+            q_smem_shape_b, gmem_shape, swizzle_mode=swizzle
+        ](ctx, o_imm_ptr_b, planes_q, seqlen_int)
+        comptime kernel_inst_b = fwd_fa4_kernel[
+            dtype,
+            head_dim,
+            3,
+            type_of(q_tma_b).tile_shape,
+            type_of(q_tma_b).desc_shape,
+            type_of(k_tma_b).tile_shape,
+            type_of(k_tma_b).desc_shape,
+            type_of(o_tma_b).tile_shape,
+            type_of(o_tma_b).desc_shape,
+            causal,
+            gqa_ratio,
+            False,
+            False,
+            False,
+            0,
+            bhsd=True,
+        ]
+        # Same LPT scheduler as the dense causal rank-4 path.
+        var num_m_b: Int = ceildiv(
+            seqlen_int, Int(kFa4BlockM(head_dim))
+        )
+        var size_one_kv_head_b: Int = (
+            seqlen_int * 2 * head_dim * size_of[dtype]()
+        )
+        var l2_ratio_b: Int = (50 * 1024 * 1024) // size_one_kv_head_b
+        var sched_swizzle_b: Int = 1
+        while sched_swizzle_b * 2 <= l2_ratio_b:
+            sched_swizzle_b *= 2
+        var num_hb_b: Int = nheads_int * batch_int
+        var sched_num_hb_q_b: Int = num_hb_b // sched_swizzle_b
+        var sched_residual_b: Int = max(num_hb_b % sched_swizzle_b, 1)
+        enqueue_fa4_cached[
+            kernel_inst_b,
+            use_external_stream=use_external_stream,
+            dump_asm=_dump_ptx_path(),
+        ](
+            ctx,
+            ctx_handle_addr,
+            stream_opaque,
+            String(
+                t"fwd_bhsd_{dtype}_d{head_dim}_c{causal}_g{gqa_ratio}"
+            ),
+            (num_m_b * num_hb_b, 1, 1),
+            kFa4NThreads(head_dim),
+            smem_bytes,
+            FuncAttribute.MAX_DYNAMIC_SHARED_SIZE_BYTES(UInt32(smem_bytes)),
+            q_tma_b,
+            k_tma_b,
+            v_tma_b,
+            o_tma_b,
+            lse_ptr,
+            Int64(seqlen_int),
+            softmax_scale,
+            Int64(nheads_int),
+            Int64(sched_swizzle_b),
+            Int64(sched_num_hb_q_b),
+            Int64(sched_residual_b),
+        )
+        return
 
     # Varlen: one flat descriptor over the packed (total_tokens, H, D)
     # arrays; the kernel supplies per-sequence row offsets at copy

--- a/torch_mojo_backend/eager_flash_attention/fa4_fwd_launch.mojo
+++ b/torch_mojo_backend/eager_flash_attention/fa4_fwd_launch.mojo
@@ -10,7 +10,7 @@ function's PTX is written to <path> at first-call JIT time via
 kernel module name.
 """
 
-from max.gpu.host import DeviceContext, FuncAttribute
+from max.gpu.host import DeviceAttribute, DeviceContext, FuncAttribute
 from max.gpu.host.device_context import _DeviceContextPtr, _DeviceContextCpp, _DumpPath
 from max.gpu.host.nvidia.tma import TensorMapSwizzle
 from std.math import ceildiv
@@ -199,10 +199,33 @@ def launch_fwd_fa4[
         var size_one_kv_head_b: Int = (
             seqlen_int * 2 * head_dim * size_of[dtype]()
         )
+        # Work order, wave-dispatched (measured on d64; middle group
+        # sizes lose BOTH ways — see the phase-2 harness NOTES.md):
+        # - MANY waves (>= ~12): swizzle group 1 — each plane's whole
+        #   m-sweep is consecutive, so the CTAs in flight walk a few
+        #   planes' K/V phase-aligned (L2-resident, many readers per
+        #   tile): P1 -8%, P3 -3%. The 50MB-budget order (128 planes
+        #   at the SAME m in flight) shares nothing concurrently:
+        #   L2 hit 50%, 1.7x DRAM re-reads, long_scoreboard top stall.
+        # - FEW waves: keep the global-LPT order (all planes sweep m
+        #   together, heavy tiles first) — the tail is all light
+        #   tiles, which dominates short grids (group 1 here cost P0
+        #   8% in stragglers).
+        var sm_count_b: Int = ctx.get_attribute(
+            DeviceAttribute.MULTIPROCESSOR_COUNT
+        )
+        var ctas_per_sm_b: Int = 2 if head_dim == 64 else 1
+        var waves_b: Int = (num_m_b * nheads_int * batch_int) // (
+            ctas_per_sm_b * sm_count_b
+        )
         var l2_ratio_b: Int = (50 * 1024 * 1024) // size_one_kv_head_b
-        var sched_swizzle_b: Int = 1
-        while sched_swizzle_b * 2 <= l2_ratio_b:
-            sched_swizzle_b *= 2
+        var sched_swizzle_b: Int
+        if waves_b >= 12:
+            sched_swizzle_b = 1
+        else:
+            sched_swizzle_b = 1
+            while sched_swizzle_b * 2 <= l2_ratio_b:
+                sched_swizzle_b *= 2
         var num_hb_b: Int = nheads_int * batch_int
         var sched_num_hb_q_b: Int = num_hb_b // sched_swizzle_b
         var sched_residual_b: Int = max(num_hb_b % sched_swizzle_b, 1)

--- a/torch_mojo_backend/eager_flash_attention/fa4_fwd_selfload_common.mojo
+++ b/torch_mojo_backend/eager_flash_attention/fa4_fwd_selfload_common.mojo
@@ -1,0 +1,69 @@
+# ============================================================================
+# PHASE 2c: self-loading single-warpgroup CTA, d64 dense-causal BHSD ONLY.
+# A NEW module (not a replacement): fa4_fwd_common.mojo (phase 2b) still
+# serves head_dim=128 and, below the wave-gate threshold in fa4_ops.mojo,
+# the few-wave d64 shapes too. See NOTES.md "Phase 2c" (agent A's harness,
+# /scratch/fa4-fwd-harness-2c) for the measurements this module encodes.
+# ============================================================================
+"""Comptime constants for the self-loading FA4 fwd kernel (phase 2c).
+
+The phase-2b profile at P1 (B32 H12 S1024) says the d64 kernel is
+latency-bound, not pipe- or bandwidth-bound (tensor 36%, XU 39%, L2 42%,
+issue 44% of peak) with `wait` at 1.31 warps per issue-active cycle and
+only TWO consumer warps per SMSP (2 CTAs/SM x 1 MMA warpgroup). Phase 2
+measured the same lever from the other side: dropping to 1 CTA/SM costs
+55%. So the target is a THIRD CTA per SM.
+
+At phase 2b's 256-thread CTA (1 MMA warpgroup + 1 producer warpgroup)
+that is impossible: `nvvm.minctasm`=3 gives ptxas a static budget of
+65536/(3*256) = 80 registers per thread and it refuses outright
+("Insufficient registers (80) ... try 90 or higher") -- setmaxnreg
+redistributes registers BETWEEN warps at runtime, it does not lift the
+CTA's static allocation.
+
+This module's kernel therefore drops the producer warpgroup: the CTA is
+ONE warpgroup of 128 threads that issues its own TMA loads (see the
+PREFETCH invariant comment in fa4_fwd_selfload_kernel.mojo for the
+correctness argument this enables). 65536/(3*128) = 170 -> 168 registers
+per thread, comfortably above the ~155 the consumer needs, and 4 ring
+stages keep smem at 8 KiB Q + 4*16 KiB = 72 KiB, so 3*72 = 216 KiB fits
+the 227 KiB opt-in cap.
+
+Swept on H100 PCIe at 1395 MHz (phase 2c, NOTES.md): 3 CTAs/SM with a
+4-slot ring is the optimum measured there. 2 CTAs/SM with a 6-slot ring
+(the phase-2b ring depth, same self-loading body) reads 268 us at P1
+against 230 for the 3-CTA/4-slot config -- the third CTA is the whole
+win, and 4 slots is the deepest ring that still fits three CTAs in
+227 KiB. FITTED ON H100 PCIe (114 SMs, 227 KiB smem opt-in cap, 64 K
+32-bit registers per SM) -- re-derive both constants on any other card
+before trusting them there.
+"""
+
+comptime FA_SELFLOAD_STAGES: Int = 4
+comptime FA_SELFLOAD_CTAS: Int = 3
+
+
+def kFa4BlockM(head_dim: Int) -> Int:
+    return 64 if head_dim == 64 else 128
+
+
+comptime kFa4BlockN: Int = 128
+
+
+def kFa4NMmaWarpgroups(head_dim: Int) -> Int:
+    return 1
+
+
+def kFa4NThreads(head_dim: Int) -> Int:
+    return 128
+
+
+def kFa4CtasPerSm(head_dim: Int) -> Int:
+    return FA_SELFLOAD_CTAS
+
+
+# K/V shared-memory ring: K(n) lives in slot (2n) % kFa4KVStages, V(n) in
+# slot (2n+1) % kFa4KVStages -- same incremental scheme as the phase-2b
+# ring, just 4 slots deep instead of 6 (the deepest ring 3 CTAs/SM fits
+# in the 227 KiB opt-in cap at 128 threads; see the module docstring).
+comptime kFa4KVStages: Int = FA_SELFLOAD_STAGES

--- a/torch_mojo_backend/eager_flash_attention/fa4_fwd_selfload_kernel.mojo
+++ b/torch_mojo_backend/eager_flash_attention/fa4_fwd_selfload_kernel.mojo
@@ -1,0 +1,1257 @@
+# ============================================================================
+# PHASE 2c: self-loading single-warpgroup CTA, d64 dense-causal BHSD ONLY.
+# A NEW module (not a replacement): fa4_fwd_kernel.mojo (phase 2b) still
+# serves head_dim=128 and, below the wave-gate threshold in fa4_ops.mojo,
+# the few-wave d64 shapes too. See NOTES.md "Phase 2c" for the merge
+# options this module deliberately did not take (see item 1 of agent A's
+# handoff there: a shared-body `self_load: Bool` comptime parameter is
+# possible but was not done here, to keep every phase-2b instantiation
+# byte-identical without re-running the full asm-diff obligation that
+# merge would owe).
+# ============================================================================
+"""FA4-target flash-attention forward kernel (sm_90a, Hopper) -- the
+self-loading single-warpgroup CTA (phase 2c).
+
+The CTA is ONE warpgroup of 128 threads that issues its own TMA loads --
+no producer warpgroup. That is what buys a THIRD CTA per SM: at the
+phase-2b kernel's 256 threads, `nvvm.minctasm`=3 hands ptxas a static
+budget of 65536/(3*256) = 80 registers per thread and it refuses to
+compile (setmaxnreg moves registers BETWEEN warps, it does not lift the
+CTA's static allocation); at 128 threads the budget is 65536/(3*128) =
+170 -> 168, and ptxas settles at 154, so registers AND smem (4 ring
+stages: 8 KiB Q + 4*16 KiB = 72 KiB, 3*72 <= 227 KiB) both allow 3.
+
+K/V tiles live in a 4-slot smem ring (slot(K_n) = 2n%4, slot(V_n) =
+(2n+1)%4) guarded by `full` mbarriers only:
+
+    full[i].init(1)     -> flipped by TMA expect_bytes completion
+
+The empty[] barriers are GONE. The warpgroup that reads a slot is the
+one that refills it, so program order plus `wgmma.wait_group` already
+orders the refill after the read: a warp's wait_group returns only once
+the whole warpgroup's group has retired, i.e. after every warp's share
+of that wgmma has finished reading smem. Refills are issued exactly at
+the two points where that proof lands -- after `wait_group[1]` (K of the
+trip just consumed) and after `wait_group[0]` (V) -- so the prefetch
+distance is a constant STAGES/2 = 2 tiles. See the PREFETCH invariant
+comment below, next to its definition, before touching STAGES or the
+refill call sites.
+
+The MMA warpgroup runs FA4's intra-warpgroup overlap schedule (from
+`flash_attn/cute/flash_fwd_sm90.py::mma_one_n_block_intrawg_overlap`):
+
+    wait full K(n+1); commit QK(n+1) -> s_reg        (no wait)
+    wait full V(n);   commit PV(n):  p_reg x V -> o_reg
+    wait_group(1)   # QK(n+1) retired -> refill K's slot (was: arrive empty[K(n+1)])
+    softmax(n+1)    # overlaps PV(n) on the tensor core
+    wait_group(0)   # PV(n) retired   -> refill V's slot (was: arrive empty[V(n)])
+    pack P(n+1) bf16; rescale o_reg
+
+No block-wide barriers in the loop (v3's main stall). Single S / single P
+register buffer keeps the register count near FA4's target; there is no
+producer warpgroup left to deallocate registers for via setmaxnreg.
+
+The exp2 uses the scaled-domain trick: rowmax is kept premultiplied
+by softmax_scale*log2(e) so P = exp2(fma(s, scale_log2, -m)).
+
+Grid: (ceildiv(seqlen, BM), nheads, batch). Block: 128 threads.
+
+P c-frag -> a-frag mapping: with num_m_mmas=1 per warpgroup the QK
+c-fragment element order (16 col-chunks x [top0 top1 bot0 bot1]) is
+identical to the PV a-fragment order (8 k_mmas x 8 halves) — a
+straight indexwise cast is correct. (With >1 m_mma it would not be:
+the RS wgmma walks fragments k-major, `a_frags[m + k*num_m]`.)
+"""
+
+from std.math import exp2, log, tanh
+from std.math.constants import log2e
+from std.sys import size_of
+from std.utils.index import StaticTuple, IndexList
+
+from max.gpu.sync import barrier
+from std.gpu import MAX_THREADS_PER_BLOCK_METADATA, block_idx, lane_id, thread_idx, warp_id
+import std.gpu.primitives.warp as warp
+from max.gpu.host.nvidia.tma import TensorMapSwizzle
+from max.gpu.memory import external_memory, fence_async_view_proxy
+from std.memory import AddressSpace
+from max.gpu.sync import named_barrier, named_barrier_arrive
+from std.memory import bitcast, stack_allocation
+
+from max.gpu.compute.mma import st_matrix
+
+from layout import Layout, LayoutTensor
+from layout.tensor_core_async import (
+    TensorCoreAsync,
+    _wgmma_descriptor,
+    tile_layout_k_major,
+    tile_layout_mn_major,
+    tile_to_descriptor,
+    warpgroup_fence,
+)
+
+from fa4_wgmma_f16 import wgmma_rs_f16_m64n128, wgmma_rs_f16_m64n64
+from layout.tma_async import SharedMemBarrier, TMATensorTile
+
+from fa4_fwd_selfload_common import (
+    kFa4NThreads,
+    kFa4BlockM,
+    kFa4BlockN,
+    kFa4NMmaWarpgroups,
+    kFa4KVStages,
+    kFa4CtasPerSm,
+)
+
+comptime WGMMA_M: Int = 64
+comptime WGMMA_K: Int = 16
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](
+        Int32(kFa4NThreads(head_dim))
+    ),
+    `nvvm.minctasm`=SIMDLength(kFa4CtasPerSm(head_dim)),
+)
+@__llvm_arg_metadata(q_tma, `nvvm.grid_constant`)
+@__llvm_arg_metadata(k_tma, `nvvm.grid_constant`)
+@__llvm_arg_metadata(v_tma, `nvvm.grid_constant`)
+@__llvm_arg_metadata(o_tma, `nvvm.grid_constant`)
+def fwd_fa4_selfload_kernel[
+    dtype: DType,
+    head_dim: Int,
+    qo_rank: Int,
+    q_tile_shape: IndexList[qo_rank],
+    q_desc_shape: IndexList[qo_rank],
+    kv_tile_shape: IndexList[3],
+    kv_desc_shape: IndexList[3],
+    o_tile_shape: IndexList[qo_rank],
+    o_desc_shape: IndexList[qo_rank],
+    causal: Bool = False,
+    gqa_ratio: Int = 1,
+    varlen: Bool = False,
+    window: Bool = False,
+    window_unaligned: Bool = False,
+    softcap_x1000: Int = 0,
+    bhsd: Bool = False,
+](
+    q_tma: TMATensorTile[dtype, qo_rank, q_tile_shape, q_desc_shape],
+    k_tma: TMATensorTile[dtype, 3, kv_tile_shape, kv_desc_shape],
+    v_tma: TMATensorTile[dtype, 3, kv_tile_shape, kv_desc_shape],
+    o_tma: TMATensorTile[dtype, qo_rank, o_tile_shape, o_desc_shape],
+    lse_ptr: UnsafePointer[Float32, MutAnyOrigin],
+    seq_len_arg: Int64,
+    softmax_scale: Float32,
+    nheads_arg: Int64,
+    sched_swizzle_arg: Int64,
+    sched_num_hb_q_arg: Int64,
+    sched_residual_arg: Int64,
+):
+    # BHSD-native mode: Q/K/V/O descriptors address the PUBLIC
+    # contiguous (B, H, S, D) layout viewed as (B*H, S, D) — planes are
+    # the TMA outer dim and S its own dim, so BM=192 tail tiles
+    # zero-fill on load and clamp on store at every plane edge. No BTHD
+    # materialization (FA3's scheme: the head stride is just another
+    # gmem stride). Dense only in v1.
+    comptime if bhsd:
+        comptime assert qo_rank == 3 and not varlen and not window, (
+            "bhsd v1 is the dense (non-varlen, non-window) path"
+        )
+    # Int is not device-passable (host/device width mismatch); scalars cross
+    # the launch ABI as Int64 and index math stays in Int.
+    var seq_len = Int(seq_len_arg)
+    var nheads = Int(nheads_arg)
+    var sched_swizzle = Int(sched_swizzle_arg)
+    var sched_num_hb_q = Int(sched_num_hb_q_arg)
+    var sched_residual = Int(sched_residual_arg)
+    # SCOPE GUARD: this body has no producer warpgroup and assumes one
+    # 128-thread MMA warpgroup per CTA. head_dim=128 needs BM=BN=128 with
+    # TWO warpgroups and 224 KiB of smem (1 CTA/SM) -- it must keep the
+    # phase-2b kernel (fa4_fwd_kernel.mojo); instantiating this one at
+    # d128 would compute only 64 of its 128 rows.
+    comptime assert head_dim == 64, (
+        "self-load geometry is d64-only (d128 keeps the phase-2b kernel)"
+    )
+    comptime BM: Int = kFa4BlockM(head_dim)
+    comptime BN: Int = kFa4BlockN
+    comptime D: Int = head_dim
+    comptime NWG: Int = kFa4NMmaWarpgroups(head_dim)
+    comptime STAGES: Int = kFa4KVStages
+    # PREFETCH INVARIANT -- READ BEFORE CHANGING STAGES OR THE REFILL
+    # CALL SITES. This kernel deleted the empty[] mbarriers that the
+    # phase-2b producer/consumer split used to prove a slot's smem read
+    # had retired before the next TMA refill into that same slot. The
+    # substitute proof is: the warpgroup that CONSUMES a slot (via
+    # wgmma) is the same warpgroup that REFILLS it, so program order
+    # plus `wgmma.wait_group` orders "read done" before "refill issued"
+    # -- wait_group returns only once every warp's share of that wgmma
+    # group has retired, which requires the smem read to be complete.
+    # That proof holds ONLY as long as the refill targets the SAME slot
+    # the just-retired wgmma just read, i.e. PREFETCH (the ring depth in
+    # tile-pairs, STAGES/2) must be >= 1: the tile issued after
+    # wait_group(k) is trip `it + PREFETCH`, whose slot is
+    # `(2*(it+PREFETCH)) % STAGES == (2*it) % STAGES` exactly when
+    # `2*PREFETCH % STAGES == 0`, i.e. PREFETCH == STAGES/2. Widening
+    # STAGES without moving PREFETCH by the same STAGES/2 relationship
+    # (or moving PREFETCH without moving the `issue_k`/`issue_v` call
+    # sites' `it + PREFETCH` / `pf < kv_trips` offsets to match) breaks
+    # the slot arithmetic silently: the refill would target a slot a
+    # DIFFERENT in-flight tile still owns, which is a write-after-read
+    # race with no barrier left to catch it -- Mojo's `wgmma.wait_group`
+    # is not annotated with an LLVM memory clobber, so nothing but this
+    # invariant (and the PTX-ordering regression test that checks it,
+    # tests/test_fa4_selfload_ptx_ordering.py) stops a future toolchain
+    # from reordering a refill's `cp.async.bulk.tensor` ahead of the
+    # `wgmma.wait_group` that proves the slot is free. Failure mode if
+    # violated: silent corruption (wrong output, no error, no crash) --
+    # see tests/test_fa4_selfload_soak.py, ported from the phase-2c
+    # harness's soak_v7.mojo, which stresses exactly this window with
+    # back-to-back launches and no inter-launch sync.
+    #
+    # The "consumer refills its own slot after its own retirement proof"
+    # pattern is the same one warp-specialized GEMM mainloops use for
+    # their smem-read retirement, not something invented for this
+    # kernel: CUTLASS's SM90 TMA+GMMA mainloop retires a pipeline stage
+    # with the consumer's own `wait` before the producer may reuse that
+    # stage's smem (cutlass/gemm/collective/sm90_mma_tma_gmma_ss.hpp,
+    # `PipelineTmaAsync` release/acquire pair around lines 493-497 of
+    # that file); FlashAttention-3's own sm90 warp-specialized mainloop
+    # documents the identical rule at the point it advances its KV
+    # pipeline (mainloop_fwd_sm90_tma_gmma_ws.hpp:1142); and the
+    # modular repo's own SM90 dense GEMM mainloop relies on the same
+    # wgmma-wait-then-release proof to retire a shared-memory read
+    # before the next refill into that stage
+    # (max/kernels/src/linalg/matmul/gpu/sm90/matmul_kernels.mojo,
+    # lines 1554-1577) -- the ISA reference for `wgmma.wait_group.sync`
+    # states only that prior wgmma ops complete; it does not by itself
+    # say anything about a paired smem consumer/producer schedule being
+    # safe, so those three call sites (not the ISA text alone) are what
+    # back the claim that this pattern is correct.
+    comptime PREFETCH: Int = STAGES // 2
+    comptime accum_type: DType = DType.float32
+    comptime swizzle: TensorMapSwizzle = TensorMapSwizzle.SWIZZLE_128B
+    # Tree-shaped row reductions (phase 2b), scoped to the geometry they
+    # were profiled on: the d64 tile (BM=64, ONE MMA warpgroup, 2/3
+    # CTAs/SM), where `wait` (fixed-latency dependency) was the top ncu
+    # stall. On the d128 tile (BM=BN=128, two warpgroups, 1 CTA/SM) they
+    # measured NEUTRAL, so d128 keeps a4e8462's codegen (and its exact
+    # rowsum summation order) rather than taking an unproven change.
+    # Ungating is safe if a later measurement wants one code path.
+    comptime TREE_REDUCE: Bool = kFa4NMmaWarpgroups(head_dim) == 1
+
+    comptime q_smem_layout = tile_layout_k_major[
+        dtype, BM, D, swizzle_mode=swizzle
+    ]()
+    comptime k_smem_layout = tile_layout_k_major[
+        dtype, BN, D, swizzle_mode=swizzle
+    ]()
+    comptime v_smem_layout = tile_layout_mn_major[
+        dtype, D, BN, swizzle_mode=swizzle
+    ]()
+
+    comptime q_smem_size: Int = q_smem_layout.size()
+    comptime kv_slot_size: Int = BN * D
+
+    var smem_base = external_memory[
+        Scalar[dtype],
+        address_space=AddressSpace.SHARED,
+        alignment=128,
+    ]()
+    var q_smem = LayoutTensor[
+        dtype,
+        q_smem_layout,
+        MutAnyOrigin,
+        address_space=AddressSpace.SHARED,
+        alignment=128,
+    ]((smem_base).as_unsafe_any_origin())
+    var kv_smem_base = smem_base + q_smem_size
+
+    var mbar_q = stack_allocation[
+        1, SharedMemBarrier, address_space=AddressSpace.SHARED, alignment=8
+    ]()
+    var full = stack_allocation[
+        STAGES,
+        SharedMemBarrier,
+        address_space=AddressSpace.SHARED,
+        alignment=8,
+    ]()
+    if thread_idx.x == 0:
+        mbar_q[0].init()
+        comptime for s in range(STAGES):
+            full[s].init(1)
+    barrier()
+
+    var m_block: Int
+    var h_idx: Int
+    var b_idx: Int
+    # Varlen per-CTA scalars (0/unused when dense; from the host work
+    # table otherwise).
+    var vl_q_base: Int = 0
+    var vl_k_base: Int = 0
+    var vl_seqlen_q: Int = 0
+    var vl_seqlen_k: Int = 0
+    var vl_win_left: Int = 0
+    comptime if varlen:
+        # Host work-item table, one int32[8] row per CTA: (m_block,
+        # q_row_base, k_row_base, seqlen_q, seqlen_k, _, _, _). Its
+        # address rides the sched_swizzle slot (LPT is dense-causal
+        # only) and seq_len carries total_q (for the packed LSE
+        # layout) — the kernel signature stays identical to dense.
+        # Every per-CTA scalar is warp.broadcast-laundered so ptxas
+        # sees it warp-uniform (same hazard class as the tid-widening
+        # trap; see HANDOFF.md).
+        var tbl = (
+            UnsafePointer[Int32, ImmutAnyOrigin](
+                unsafe_from_address=sched_swizzle
+            )
+            + 8 * Int(block_idx.x)
+        )
+        m_block = Int(warp.broadcast(tbl[0]))
+        vl_q_base = Int(warp.broadcast(tbl[1]))
+        vl_k_base = Int(warp.broadcast(tbl[2]))
+        vl_seqlen_q = Int(warp.broadcast(tbl[3]))
+        vl_seqlen_k = Int(warp.broadcast(tbl[4]))
+        comptime if window:
+            vl_win_left = Int(warp.broadcast(tbl[5]))
+        h_idx = Int(block_idx.y)
+        b_idx = 0
+    else:
+        comptime if causal and not window:
+            # FA4's SingleTileLPTScheduler (static, non-persistent):
+            # flat 1-D grid; heaviest m_blocks launch FIRST (LPT
+            # reversal) and sched_swizzle (head,batch) pairs sweep
+            # each m together so their K/V tiles stay L2-resident.
+            var bx: Int = Int(block_idx.x)
+            var num_m: Int = (seq_len + BM - 1) // BM
+            var l2_major: Int = num_m * sched_swizzle
+            var bidhb: Int = bx // l2_major
+            var l2_mod: Int = bx - bidhb * l2_major
+            var dvsr: Int = (
+                sched_swizzle if bidhb < sched_num_hb_q else sched_residual
+            )
+            var blk: Int = l2_mod // dvsr
+            var res: Int = l2_mod - blk * dvsr
+            var bidhb_act: Int = bidhb * sched_swizzle + res
+            b_idx = bidhb_act // nheads
+            h_idx = bidhb_act - b_idx * nheads
+            m_block = num_m - 1 - blk
+        else:
+            m_block = Int(block_idx.x)
+            h_idx = Int(block_idx.y)
+            b_idx = Int(block_idx.z)
+    # Cross-attention diagonal offset (FA4's bottom-right
+    # alignment): row i attends col j iff j <= i + (slk - slq).
+    # 0 for self-attention; only the causal arms consume it. v1
+    # envelope: slq <= slk per sequence under causal
+    # (host-asserted), so every q row attends >= 1 key.
+    var vl_offs: Int = 0
+    comptime if varlen and causal:
+        vl_offs = vl_seqlen_k - vl_seqlen_q
+    var num_kv_blocks: Int
+    comptime if varlen:
+        num_kv_blocks = (vl_seqlen_k + BN - 1) // BN
+    else:
+        num_kv_blocks = (seq_len + BN - 1) // BN
+    comptime if causal:
+        comptime if varlen:
+            # Cross-attention general form (bottom-right diagonal):
+            # row block m attends kv cols < (m+1)*BM + (slk - slq),
+            # so the band may straddle two tiles even at BM == BN
+            # (offs % BN != 0) — varlen causal always takes the
+            # BAND mask arms below. Self-attn (offs == 0) degrades
+            # to the dense count with one extra no-op masked tile.
+            num_kv_blocks = min(
+                num_kv_blocks,
+                ((m_block + 1) * BM + vl_offs + BN - 1) // BN,
+            )
+        elif BM == BN:
+            # BM == BN: row block m attends KV tiles 0..m inclusive;
+            # tile n == m_block is the (only) masked diagonal tile.
+            num_kv_blocks = min(num_kv_blocks, m_block + 1)
+        else:
+            # BM=192 > BN=128 (hdim64): row block m attends kv cols
+            # < (m+1)*BM, i.e. ceil((m+1)*BM/BN) tiles; the diagonal
+            # BAND spans the last TWO tiles of the trip range.
+            num_kv_blocks = min(
+                num_kv_blocks,
+                ((m_block + 1) * BM + BN - 1) // BN,
+            )
+
+    # Sliding window (causal, any left >= 1): the kv trip range
+    # gains a LOWER bound. The leading edges for an m-tile's rows
+    # span a BM-wide range, which straddles at most TWO kv tiles
+    # (BM == BN): the prologue tile and, when left % BN != 0, the
+    # first loop tile — both get the leading mask; the steady loop
+    # stays mask-free. (Aligned left makes the second tile's mask a
+    # provable no-op.)
+    var win_left: Int = 0
+    var first_kv: Int = 0
+    var kv_trips: Int = num_kv_blocks
+    comptime if window:
+        comptime assert causal, "window v1 requires causal"
+        comptime if varlen:
+            # sched_swizzle carries the work table under varlen;
+            # win_left rides the table's free col 5 instead. The
+            # bottom-right offset shifts the leading edge: attended
+            # j ∈ [i + offs - left, i + offs].
+            win_left = vl_win_left
+        else:
+            win_left = sched_swizzle  # rides the (free) LPT slot
+        first_kv = max(
+            0, (m_block * BM + vl_offs - win_left) // BN
+        )
+        kv_trips = num_kv_blocks - first_kv
+
+    # Varlen ragged kv tail: garbage columns live only in the
+    # sequence's LAST kv tile (kv tiles are seq-local). Non-causal
+    # masks them there; causal needs NO extra mask — bottom-right
+    # alignment means garbage col j >= slk is attended only by rows
+    # i >= j - offs >= slk - (slk - slq) = slq, i.e. never by a
+    # STORED row; and the last kv tile, when processed, is always
+    # within the band-masked trailing trips, whose col + mask_d >
+    # row predicate covers exactly j > i + offs.
+    var vl_kv_tail: Int = 0
+    comptime if varlen and not causal:
+        vl_kv_tail = vl_seqlen_k - (num_kv_blocks - 1) * BN
+
+    # ================= single warpgroup, self-loading =================
+    # No producer warpgroup: this warpgroup issues its own TMA loads
+    # (thread 0) at the points where `wgmma.wait_group` proves the
+    # slot's reader has retired. Program order then replaces the empty[]
+    # barriers entirely (see the PREFETCH invariant comment above).
+    var wg: Int = 0
+
+    # kv row of trip n is row0 + n * row_step (the same trip numbering
+    # the consumer loop uses; window starts at first_kv, varlen
+    # non-causal walks backwards).
+    var kv_row0: Int
+    var kv_row_step: Int = BN
+    var kv_plane: Int = 0
+    comptime if bhsd:
+        kv_plane = b_idx * (nheads // gqa_ratio) + h_idx // gqa_ratio
+        kv_row0 = 0
+    elif window:
+        comptime if varlen:
+            kv_row0 = vl_k_base + first_kv * BN
+        else:
+            kv_row0 = b_idx * seq_len + first_kv * BN
+    elif varlen:
+        comptime if causal:
+            kv_row0 = vl_k_base
+        else:
+            kv_row0 = vl_k_base + (num_kv_blocks - 1) * BN
+            kv_row_step = -BN
+    else:
+        kv_row0 = b_idx * seq_len
+
+    @parameter
+    @always_inline
+    def issue_k(n: Int, slot: Int):
+        """TMA K(n) into `slot` (thread 0 only, caller-guarded)."""
+        var k_st = LayoutTensor[
+            dtype,
+            k_smem_layout,
+            MutAnyOrigin,
+            address_space=AddressSpace.SHARED,
+            alignment=128,
+        ]((kv_smem_base + slot * kv_slot_size).as_unsafe_any_origin())
+        full[slot].expect_bytes(Int32(BN * D * size_of[dtype]()))
+        var row: Int = kv_row0 + n * kv_row_step
+        comptime if bhsd:
+            k_tma.async_copy_3d(k_st, full[slot], (0, row, kv_plane))
+        else:
+            k_tma.async_copy_3d(
+                k_st, full[slot], (0, h_idx // gqa_ratio, row)
+            )
+
+    @parameter
+    @always_inline
+    def issue_v(n: Int, slot: Int):
+        """TMA V(n) into `slot` (thread 0 only, caller-guarded)."""
+        var v_st = LayoutTensor[
+            dtype,
+            v_smem_layout,
+            MutAnyOrigin,
+            address_space=AddressSpace.SHARED,
+            alignment=128,
+        ]((kv_smem_base + slot * kv_slot_size).as_unsafe_any_origin())
+        full[slot].expect_bytes(Int32(BN * D * size_of[dtype]()))
+        var row: Int = kv_row0 + n * kv_row_step
+        comptime if bhsd:
+            v_tma.async_copy_3d(v_st, full[slot], (0, row, kv_plane))
+        else:
+            v_tma.async_copy_3d(
+                v_st, full[slot], (0, h_idx // gqa_ratio, row)
+            )
+
+    # Prologue issues: Q plus PREFETCH whole tile-pairs (the ring holds
+    # exactly PREFETCH pairs).
+    if thread_idx.x == 0:
+        mbar_q[0].expect_bytes(Int32(BM * D * size_of[dtype]()))
+        comptime if bhsd:
+            q_tma.async_copy_3d(
+                q_smem,
+                mbar_q[0],
+                (0, m_block * BM, b_idx * nheads + h_idx),
+            )
+        elif qo_rank == 4:
+            q_tma.async_copy_4d(
+                q_smem, mbar_q[0], (0, h_idx, m_block * BM, b_idx)
+            )
+        elif varlen:
+            q_tma.async_copy_3d(
+                q_smem, mbar_q[0], (0, h_idx, vl_q_base + m_block * BM)
+            )
+        else:
+            q_tma.async_copy_3d(
+                q_smem,
+                mbar_q[0],
+                (0, h_idx, b_idx * seq_len + m_block * BM),
+            )
+        comptime for pf in range(PREFETCH):
+            if pf < kv_trips:
+                issue_k(pf, (2 * pf) % STAGES)
+                issue_v(pf, (2 * pf + 1) % STAGES)
+
+    # Scheduler-pingpong barrier participant count: each barrier id
+    # is waited by ONE warpgroup (128) and armed by its predecessor
+    # (128) — 256 regardless of NWG (== NWG*128 only at NWG == 2).
+    comptime SCHED_BAR_N: Int = 2 * 128
+
+    # Warp-scheduler pingpong (FA4's use_scheduler_barrier): named
+    # barrier 1+wg gates each warpgroup's GEMM-issue phase; a
+    # warpgroup arrives at the *other* one's barrier after committing
+    # its GEMM pair, so issue phases alternate and each warpgroup's
+    # softmax overlaps the other's GEMMs. WG0 self-arms its barrier.
+    # At NWG == 1 the pingpong ring degenerates to a SELF ring: the
+    # warpgroup's wait on barrier 1 is satisfied by its own arrive from
+    # the previous trip, so it orders nothing (the K/V mbarriers carry
+    # every real dependency) while costing two BAR ops and a ~30-cycle
+    # barrier latency per kv tile -- `barrier` was 0.51 warps/issue in
+    # the ncu profile. Comptime-drop it; NWG >= 2 keeps FA4's schedule.
+    comptime if NWG > 1:
+        if wg == 0:
+            named_barrier_arrive[Int32(SCHED_BAR_N)](Int32(1))
+
+    var wgmma_qk = TensorCoreAsync[
+        accum_type,
+        dtype,
+        dtype,
+        IndexList[3](WGMMA_M, BN, WGMMA_K),
+        a_swizzle=swizzle,
+        b_swizzle=swizzle,
+        transpose_b=True,
+    ]()
+    var wgmma_pv = TensorCoreAsync[
+        accum_type,
+        dtype,
+        dtype,
+        IndexList[3](WGMMA_M, D, WGMMA_K),
+        a_swizzle=TensorMapSwizzle.SWIZZLE_NONE,
+        b_swizzle=swizzle,
+        transpose_b=False,
+    ]()
+
+    comptime c_frag_size_qk: Int = WGMMA_M * BN // 128  # 64
+    comptime c_frag_size_pv: Int = WGMMA_M * D // 128  # 64
+    comptime a_frag_size_pv: Int = WGMMA_M * WGMMA_K // 128  # 8
+    comptime num_k_mmas_pv: Int = BN // WGMMA_K  # 8
+
+    var s_reg = LayoutTensor[
+        accum_type,
+        Layout.row_major(1, c_frag_size_qk),
+        MutAnyOrigin,
+        address_space=AddressSpace.LOCAL,
+    ].stack_allocation()
+    var o_reg = LayoutTensor[
+        accum_type,
+        Layout.row_major(1, c_frag_size_pv),
+        MutAnyOrigin,
+        address_space=AddressSpace.LOCAL,
+    ].stack_allocation()
+    _ = o_reg.fill(0)
+    var p_reg = LayoutTensor[
+        dtype,
+        Layout.row_major(num_k_mmas_pv, a_frag_size_pv),
+        MutAnyOrigin,
+        address_space=AddressSpace.LOCAL,
+    ].stack_allocation()
+
+    # Online-softmax state, kept in the scaled (log2) domain:
+    # rowmax_s = max(S) * softmax_scale * log2(e). 2 rows per thread.
+    comptime rows_per_thread: Int = 2
+    var rowmax = stack_allocation[rows_per_thread, Scalar[accum_type]]()
+    var rowsum = stack_allocation[rows_per_thread, Scalar[accum_type]]()
+    var scale_old = stack_allocation[rows_per_thread, Scalar[accum_type]]()
+    var neg_inf: Scalar[accum_type] = Scalar[accum_type](-1.0e30)
+    comptime for i in range(rows_per_thread):
+        rowmax[i] = neg_inf
+        rowsum[i] = Scalar[accum_type](0)
+
+    var scale_log2: Scalar[accum_type] = (
+        softmax_scale * Scalar[DType.float32](log2e)
+    ).cast[accum_type]()
+    # Softcap (Gemma-2): S_capped = cap * tanh(S_raw * scale / cap),
+    # FA4 semantics (scale applied BEFORE the tanh, score_mod
+    # pre-mask). The cap is a COMPTIME constant (one JIT variant per
+    # cap value — it is a model-architecture constant), so it costs
+    # no kernel arg slot and composes with window/GQA/varlen. The
+    # softmax then runs in the capped domain: s_reg holds
+    # t = tanh(s*scale/cap) and scale_log2 is repointed at
+    # cap * log2(e), so the existing max/exp2 sites fold the cap
+    # back in unchanged.
+    comptime softcap_on: Bool = softcap_x1000 != 0
+    var t_scale: Scalar[accum_type] = Scalar[accum_type](0)
+    comptime if softcap_on:
+        comptime cap_f32: Float32 = Float32(softcap_x1000) / 1000
+        t_scale = (softmax_scale / cap_f32).cast[accum_type]()
+        scale_log2 = (
+            cap_f32 * Scalar[DType.float32](log2e)
+        ).cast[accum_type]()
+
+    @parameter
+    @always_inline
+    def k_tile(slot: Int) -> LayoutTensor[
+        dtype,
+        k_smem_layout,
+        MutAnyOrigin,
+        address_space=AddressSpace.SHARED,
+        alignment=128,
+    ]:
+        return {(kv_smem_base + slot * kv_slot_size).as_unsafe_any_origin()}
+
+    @parameter
+    @always_inline
+    def v_tile(slot: Int) -> LayoutTensor[
+        dtype,
+        v_smem_layout,
+        MutAnyOrigin,
+        address_space=AddressSpace.SHARED,
+        alignment=128,
+    ]:
+        return {(kv_smem_base + slot * kv_slot_size).as_unsafe_any_origin()}
+
+    # fp16 RS fork: the stdlib's register-A wgmma overload is
+    # bf16-only (hardcoded .bf16.bf16 asm); the vendored
+    # m64n128k16 f32.f16.f16 emitter (_wgmma_f16.mojo) replicates
+    # the TensorCoreAsync RS k-loop here. bf16 keeps the stdlib
+    # path — byte-identical codegen.
+    comptime v_canonical = tile_to_descriptor[
+        dtype, v_smem_layout, False
+    ]()
+    comptime v_k_stride: Int = (
+        v_canonical[1].stride[1].value() * 2 * size_of[dtype]()
+    )
+
+    @parameter
+    @always_inline
+    def pv_gemm(slot_arg: Int):
+        comptime if dtype == DType.float16:
+            var b_desc = _wgmma_descriptor[v_canonical, False, swizzle](
+                kv_smem_base + slot_arg * kv_slot_size
+            )
+            var o_simd = o_reg.ptr.load[width=c_frag_size_pv]()
+            comptime for k_mma in range(num_k_mmas_pv):
+                comptime if head_dim == 128:
+                    o_simd = rebind[SIMD[accum_type, c_frag_size_pv]](
+                        wgmma_rs_f16_m64n128(
+                            rebind[SIMD[DType.float16, 8]](
+                                (p_reg.ptr + 8 * k_mma).load[width=8]()
+                            ),
+                            (b_desc + k_mma * v_k_stride).desc,
+                            rebind[SIMD[DType.float32, 64]](o_simd),
+                        )
+                    )
+                else:
+                    o_simd = rebind[SIMD[accum_type, c_frag_size_pv]](
+                        wgmma_rs_f16_m64n64(
+                            rebind[SIMD[DType.float16, 8]](
+                                (p_reg.ptr + 8 * k_mma).load[width=8]()
+                            ),
+                            (b_desc + k_mma * v_k_stride).desc,
+                            rebind[SIMD[DType.float32, 32]](o_simd),
+                        )
+                    )
+            o_reg.ptr.store[width=c_frag_size_pv](o_simd)
+        else:
+            wgmma_pv.wgmma(p_reg, v_tile(slot_arg), o_reg)
+
+    # c-frag (row, col) roots for the diagonal mask (within-tile
+    # coordinates; global q = m*BM + row, kv = n*BN + col, and on the
+    # diagonal tile n == m_block the mask is simply col > row).
+    var mask_row_lo: Int = (
+        wg * WGMMA_M + (Int(warp_id()) % 4) * 16 + Int(lane_id()) // 4
+    )
+    var mask_col_lo: Int = 2 * (Int(lane_id()) % 4)
+    # BM != BN causal: per-tile global offset (col_g - row_g = col +
+    # mask_d - row with mask_d = n*BN - m*BM), set before each
+    # masked-tile softmax call. Unused (and DCE'd) when BM == BN.
+    var causal_mask_d: Int = 0
+    # Window leading-edge offset: mask col + win_mask_d < row on the
+    # leading tile(s); per-tile, advanced by BN for the second
+    # masked tile (first loop trip).
+    var win_mask_d: Int = 0
+    comptime if window:
+        win_mask_d = first_kv * BN - m_block * BM + win_left
+        comptime if varlen:
+            # Bottom-right alignment: masked iff j < i + offs - left.
+            win_mask_d -= vl_offs
+
+    @parameter
+    @always_inline
+    def softmax_block(mask_diag: Bool, mask_tail: Bool):
+        """Online softmax over s_reg (S just retired): update
+        rowmax/rowsum/scale_old, write P (f32) back into s_reg.
+        mask_diag (causal only): apply the diagonal-tile mask first.
+        mask_tail (varlen non-causal only): this is the sequence's
+        last kv tile — mask the ragged-tail garbage columns."""
+        comptime if softcap_on:
+            # Cap BEFORE the mask arms (FA4 applies score_mod
+            # pre-mask; masking after keeps -1e30 * cap_log2 = a
+            # true -inf in the exp2). tanh lowers to the sm90 HW
+            # tanh.approx.f32 — FA4's "fastmath" tanh emulates via
+            # ex2 and pays 3.1x kernel time for it.
+            comptime for c in range(c_frag_size_qk):
+                s_reg.ptr[c] = tanh(s_reg.ptr[c] * t_scale)
+        comptime if causal:
+            comptime if BM == BN and not varlen:
+                if mask_diag:
+                    comptime for c in range(c_frag_size_qk):
+                        comptime col_base: Int = (c // 4) * 8 + (c & 1)
+                        comptime row_off: Int = 8 if (c % 4) >= 2 else 0
+                        if col_base + mask_col_lo > mask_row_lo + row_off:
+                            s_reg.ptr[c] = neg_inf
+            else:
+                # Diagonal-band tile: global mask col + mask_d > row.
+                # (Varlen causal always uses this arm — the
+                # cross-attention offset shifts the diagonal off the
+                # n == m tile and the band may straddle two tiles.)
+                if mask_diag:
+                    # 32-BIT THRESHOLDS, hoisted out of the 64-element
+                    # unrolled body. Mojo's Int is 64-bit, so
+                    # `col + mask_col_lo + causal_mask_d > row + off`
+                    # reached SASS as a 64-bit compare -- TWO ISETPs
+                    # (ISETP.GT.U32.AND + ISETP.GT.AND.EX) per element,
+                    # 128 of the masked tile's 192 mask instructions.
+                    # Rearranged, the per-element test is
+                    # `col_base > row + off - mask_col_lo - mask_d`
+                    # whose right-hand side is loop-invariant: two
+                    # Int32 registers and one ISETP per element.
+                    #
+                    # INT32 RANGE ASSUMPTION: mask_row_lo (tile-local,
+                    # < BM <= 192) and mask_col_lo (< 8) are always
+                    # small, but causal_mask_d carries -vl_offs for
+                    # varlen causal -- the cumulative token offset of
+                    # this sequence within its packed batch -- and is
+                    # otherwise O(seqlen) for dense/window causal. The
+                    # Int32() truncation below is exact only while
+                    # |mask_row_lo - mask_col_lo - causal_mask_d| stays
+                    # under INT32_MAX - 8 (~2.1e9): unreachable at any
+                    # physical shape this kernel is built for (it would
+                    # need a multi-billion-token packed varlen batch),
+                    # but it is new exposure vs a 64-bit compare, which
+                    # has no such ceiling. Guarded explicitly rather
+                    # than left implicit; off by default like every
+                    # other debug_assert (`-D ASSERT=all` or a debug
+                    # build turns it on).
+                    var mask_thr0_wide: Int = (
+                        mask_row_lo - mask_col_lo - causal_mask_d
+                    )
+                    debug_assert(
+                        mask_thr0_wide <= Int(Int32.MAX_FINITE) - 8
+                        and mask_thr0_wide >= Int(Int32.MIN_FINITE),
+                        (
+                            "fa4 fwd (self-load): causal mask threshold"
+                            " overflows int32 (seqlen/vl_offs too"
+                            " large): "
+                        ),
+                        mask_thr0_wide,
+                    )
+                    var mask_thr0: Int32 = Int32(mask_thr0_wide)
+                    var mask_thr1: Int32 = mask_thr0 + 8
+                    # COLUMN-GROUP SKIP: the c-fragment's column
+                    # col_base = (c//4)*8 + (c&1) is monotone in c, so
+                    # the mask is a SUFFIX in c and whole quarters of
+                    # the fragment can be skipped with one compare. The
+                    # causal band is 65 columns wide inside a 128-column
+                    # tile, so on the diagonal tile a bit under half the
+                    # fragment is below the boundary for every thread.
+                    # The test uses mask_thr0 (<= mask_thr1) so it is
+                    # conservative for both rows, and the threads of a
+                    # warp share a row block, so the branch is nearly
+                    # warp-uniform.
+                    comptime GROUPS: Int = 4
+                    comptime GSZ: Int = c_frag_size_qk // GROUPS
+                    comptime for g in range(GROUPS):
+                        comptime col_max: Int32 = Int32(
+                            ((g * GSZ + GSZ - 1) // 4) * 8 + 1
+                        )
+                        if col_max > mask_thr0:
+                            comptime for cc in range(GSZ):
+                                comptime c: Int = g * GSZ + cc
+                                comptime col_base: Int32 = Int32(
+                                    (c // 4) * 8 + (c & 1)
+                                )
+                                comptime hi_row: Bool = (c % 4) >= 2
+                                if col_base > (
+                                    mask_thr1 if hi_row else mask_thr0
+                                ):
+                                    s_reg.ptr[c] = neg_inf
+        comptime if window:
+            # Leading window edge (prologue tile only): cols before
+            # row - left are outside the window.
+            if mask_tail:
+                comptime for c in range(c_frag_size_qk):
+                    comptime col_base: Int = (c // 4) * 8 + (c & 1)
+                    comptime row_off: Int = 8 if (c % 4) >= 2 else 0
+                    if (
+                        col_base + mask_col_lo + win_mask_d
+                        < mask_row_lo + row_off
+                    ):
+                        s_reg.ptr[c] = neg_inf
+        comptime if varlen and not causal:
+            if mask_tail and vl_kv_tail < BN:
+                comptime for c in range(c_frag_size_qk):
+                    comptime col_base: Int = (c // 4) * 8 + (c & 1)
+                    if col_base + mask_col_lo >= vl_kv_tail:
+                        s_reg.ptr[c] = neg_inf
+        # TREE-SHAPED row reductions. The natural
+        # `local_max[row] = max(local_max[row], s_reg[c])` sweep is two
+        # 32-deep dependent chains (~4-cycle FMNMX latency each = ~128
+        # cycles of pure latency for 64 issue slots); `wait` was the
+        # top stall in the ncu profile. Four partial accumulators per
+        # row turn it into eight 8-deep chains plus a 2-level combine.
+        # Same instruction count, ~1/3 the exposed latency, and max is
+        # associative/commutative so the result is bit-identical.
+        comptime RED_WAYS: Int = 4
+        var local_max = stack_allocation[
+            rows_per_thread, Scalar[accum_type]
+        ]()
+        comptime if TREE_REDUCE:
+            var part_max = stack_allocation[
+                rows_per_thread * RED_WAYS, Scalar[accum_type]
+            ]()
+            comptime for i in range(rows_per_thread * RED_WAYS):
+                part_max[i] = neg_inf
+            comptime for c in range(c_frag_size_qk):
+                comptime row_idx: Int = 1 if (c % 4) >= 2 else 0
+                comptime part: Int = (c // 4) % RED_WAYS
+                part_max[row_idx * RED_WAYS + part] = max(
+                    part_max[row_idx * RED_WAYS + part], s_reg.ptr[c]
+                )
+            comptime for i in range(rows_per_thread):
+                local_max[i] = max(
+                    max(part_max[i * RED_WAYS], part_max[i * RED_WAYS + 1]),
+                    max(part_max[i * RED_WAYS + 2], part_max[i * RED_WAYS + 3]),
+                )
+        else:
+            comptime for i in range(rows_per_thread):
+                local_max[i] = neg_inf
+            comptime for c in range(c_frag_size_qk):
+                comptime row_idx: Int = 1 if (c % 4) >= 2 else 0
+                local_max[row_idx] = max(local_max[row_idx], s_reg.ptr[c])
+        comptime for i in range(rows_per_thread):
+            local_max[i] = warp.lane_group_max[num_lanes=4](local_max[i])
+            var rmax_new: Scalar[accum_type] = max(
+                local_max[i] * scale_log2, rowmax[i]
+            )
+            scale_old[i] = exp2(rowmax[i] - rmax_new)
+            rowmax[i] = rmax_new
+
+        var local_sum = stack_allocation[
+            rows_per_thread, Scalar[accum_type]
+        ]()
+        comptime if TREE_REDUCE:
+            var part_sum = stack_allocation[
+                rows_per_thread * RED_WAYS, Scalar[accum_type]
+            ]()
+            comptime for i in range(rows_per_thread * RED_WAYS):
+                part_sum[i] = Scalar[accum_type](0)
+            comptime for c in range(c_frag_size_qk):
+                comptime row_idx: Int = 1 if (c % 4) >= 2 else 0
+                comptime part: Int = (c // 4) % RED_WAYS
+                var p: Scalar[accum_type] = exp2(
+                    s_reg.ptr[c].fma(scale_log2, -rowmax[row_idx])
+                )
+                s_reg.ptr[c] = p
+                part_sum[row_idx * RED_WAYS + part] += p
+            # Pairwise combine (the ONLY numeric difference vs the
+            # a4e8462 kernel: f32 addition is not associative, so rowsum
+            # can differ in the last ulp -- tree summation of
+            # non-negative exp2 outputs is the better-conditioned order,
+            # and the fp64 reference check bounds it).
+            comptime for i in range(rows_per_thread):
+                local_sum[i] = (
+                    part_sum[i * RED_WAYS] + part_sum[i * RED_WAYS + 1]
+                ) + (part_sum[i * RED_WAYS + 2] + part_sum[i * RED_WAYS + 3])
+        else:
+            comptime for i in range(rows_per_thread):
+                local_sum[i] = Scalar[accum_type](0)
+            comptime for c in range(c_frag_size_qk):
+                comptime row_idx: Int = 1 if (c % 4) >= 2 else 0
+                var p: Scalar[accum_type] = exp2(
+                    s_reg.ptr[c].fma(scale_log2, -rowmax[row_idx])
+                )
+                s_reg.ptr[c] = p
+                local_sum[row_idx] += p
+        comptime for i in range(rows_per_thread):
+            rowsum[i] = rowsum[i] * scale_old[i] + local_sum[i]
+
+    @parameter
+    @always_inline
+    def pack_p():
+        comptime for c in range(c_frag_size_qk):
+            p_reg.ptr[c] = s_reg.ptr[c].cast[dtype]()
+
+    @parameter
+    @always_inline
+    def rescale_o():
+        comptime for c in range(c_frag_size_pv):
+            comptime row_idx: Int = 1 if (c % 4) >= 2 else 0
+            o_reg.ptr[c] *= scale_old[row_idx]
+
+    # ---- Prologue: S(0) -> P(0).
+    mbar_q[0].wait(UInt32(0))
+    full[0].wait(UInt32(0))
+    warpgroup_fence(s_reg)
+    wgmma_qk.arrive()
+    wgmma_qk.wgmma[num_warp_groups=NWG, scale_c=0](
+        q_smem, k_tile(0), s_reg, wg
+    )
+    wgmma_qk.commit_group()
+    wgmma_qk.wait_group()
+    warpgroup_fence(s_reg)
+    # K(0)'s slot (0) is free: refill it with K(PREFETCH). 2*PREFETCH
+    # == STAGES, so that tile's slot IS slot 0 (see the PREFETCH
+    # invariant comment above).
+    if thread_idx.x == 0:
+        if PREFETCH < kv_trips:
+            issue_k(PREFETCH, 0)
+
+    # rowmax starts at -inf -> scale_old==0, rowsum init. For causal,
+    # m_block 0's single tile IS the diagonal (BM==BN) or may sit in
+    # the 2-tile diagonal band (BM>BN). Varlen non-causal walks kv in
+    # reverse, so the FIRST tile here is the sequence's ragged-tail
+    # (boundary) tile — the only one that needs the column mask; the
+    # steady loop below stays mask-free.
+    var prologue_diag: Bool = False
+    comptime if causal:
+        comptime if BM == BN and not varlen:
+            prologue_diag = kv_trips == 1
+        else:
+            causal_mask_d = -m_block * BM
+            comptime if varlen:
+                causal_mask_d -= vl_offs
+            comptime if window:
+                # The prologue tile is first_kv, not 0.
+                causal_mask_d += first_kv * BN
+            comptime if varlen or window:
+                prologue_diag = kv_trips <= 2
+            else:
+                # EXACT diagonal test (dense causal): a tile needs the
+                # mask iff its last column can exceed this warpgroup's
+                # first row, n*BN + BN-1 > m*BM + wg*WGMMA_M, i.e.
+                # causal_mask_d + BN-1 > wg*WGMMA_M. The old "last two
+                # tiles of the trip range" rule is a strict superset:
+                # at BM=64/BN=128 the 64-row band's diagonal spans 65
+                # columns and always lands in ONE tile, so it made 42%
+                # of all tiles run the mask arm where 22% need it.
+                prologue_diag = causal_mask_d + (BN - 1) > wg * WGMMA_M
+    softmax_block(prologue_diag, True)
+    pack_p()  # P(0)
+    # The window leading edge can straddle into the FIRST loop tile
+    # when left % BN != 0: advance the mask offset ONCE here (the
+    # prologue consumed the first tile's value). COMPTIME-split:
+    # aligned lefts keep the loop's inlined softmax_block free of
+    # the window arm entirely (constant-False flag, DCE'd) — having
+    # the arm merely PRESENT behind a runtime flag cost a
+    # consistent 2-4% at the canonical aligned config.
+    comptime if window_unaligned:
+        win_mask_d += BN
+
+    # ---- Main loop: QK(n+1) + PV(n) per iteration. Ring slots track
+    # incrementally (no div/mod per iter): K(t): slot 2t%STAGES,
+    # V(t): (2t+1)%STAGES, phase flips every STAGES//2 tiles.
+    var k_slot: Int = 2  # K(1)
+    var k_phase: UInt32 = 0
+    var k_wrap: Int = 1
+    var v_slot: Int = 1  # V(0)
+    var v_phase: UInt32 = 0
+    var v_wrap: Int = 0
+
+    for it in range(kv_trips - 1):
+        # Queue QK(n+1) then PV(n) on the tensor core.
+        full[k_slot].wait(k_phase)
+        comptime if NWG > 1:
+            named_barrier[Int32(SCHED_BAR_N)](Int32(1 + wg))
+        warpgroup_fence(s_reg)
+        wgmma_qk.arrive()
+        wgmma_qk.wgmma[num_warp_groups=NWG, scale_c=0](
+            q_smem, k_tile(k_slot), s_reg, wg
+        )
+        wgmma_qk.commit_group()
+
+        full[v_slot].wait(v_phase)
+        warpgroup_fence(o_reg)
+        wgmma_pv.arrive()
+        pv_gemm(v_slot)
+        wgmma_pv.commit_group()
+        # Arrive at the SUCCESSOR's sync barrier: ring W0->W1->...->W0.
+        comptime if NWG == 2:
+            named_barrier_arrive[Int32(SCHED_BAR_N)](Int32(2 - wg))
+        elif NWG > 2:
+            named_barrier_arrive[Int32(SCHED_BAR_N)](
+                Int32(wg + 2 if wg < NWG - 1 else 1)
+            )
+
+        # QK(n+1) retired (PV(n) still running on the tensor core).
+        wgmma_qk.wait_group[1]()
+        warpgroup_fence(s_reg)
+        # QK(it+1) has retired for the whole warpgroup -> K(it+1)'s slot
+        # is free for the tile PREFETCH trips later (same slot; see the
+        # PREFETCH invariant comment above).
+        if thread_idx.x == 0:
+            var k_next: Int = it + 1 + PREFETCH
+            if k_next < kv_trips:
+                issue_k(k_next, k_slot)
+
+        # Softmax of S(n+1) overlaps PV(n). For causal the last
+        # tile (BM==BN: n+1 == num_kv_blocks-1 == m_block is THE
+        # diagonal; BM>BN: the last TWO tiles form the band).
+        # (Varlen's tail mask ran in the prologue — reverse order.)
+        var loop_diag: Bool = False
+        comptime if causal:
+            comptime if BM == BN and not varlen:
+                loop_diag = it == kv_trips - 2
+            else:
+                causal_mask_d = (it + 1) * BN - m_block * BM
+                comptime if varlen:
+                    causal_mask_d -= vl_offs
+                comptime if window:
+                    # Loop trip it processes tile first_kv + it + 1.
+                    causal_mask_d += first_kv * BN
+                comptime if varlen or window:
+                    loop_diag = it >= kv_trips - 3
+                else:
+                    loop_diag = causal_mask_d + (BN - 1) > wg * WGMMA_M
+        # Window, unaligned left only: the first loop tile can hold
+        # leading-edge columns (win_mask_d was advanced after the
+        # prologue). Aligned variants pass a comptime False so the
+        # window arm is DCE'd from the loop's inlined copy.
+        var loop_lead: Bool = False
+        comptime if window_unaligned:
+            loop_lead = it == 0
+        softmax_block(loop_diag, loop_lead)
+
+        # PV(n) retired: p_reg and o_reg are safe to touch.
+        wgmma_pv.wait_group[0]()
+        warpgroup_fence(o_reg)
+        if thread_idx.x == 0:
+            var v_next: Int = it + PREFETCH
+            if v_next < kv_trips:
+                issue_v(v_next, v_slot)
+        pack_p()  # P(n+1)
+        rescale_o()
+
+        k_slot += 2
+        k_wrap += 1
+        if k_wrap == STAGES // 2:
+            k_wrap = 0
+            k_slot = 0
+            k_phase ^= 1
+        v_slot += 2
+        v_wrap += 1
+        if v_wrap == STAGES // 2:
+            v_wrap = 0
+            v_slot = 1
+            v_phase ^= 1
+
+    # ---- Epilogue: PV(N-1) (v_slot/v_phase left at tile N-1).
+    full[v_slot].wait(v_phase)
+    warpgroup_fence(o_reg)
+    wgmma_pv.arrive()
+    pv_gemm(v_slot)
+    wgmma_pv.commit_group()
+    wgmma_pv.wait_group[0]()
+    warpgroup_fence(o_reg)
+
+    # ---- Normalize (reciprocal; one div per row) and store.
+    var inv_rowsum = stack_allocation[rows_per_thread, Scalar[accum_type]]()
+    comptime for i in range(rows_per_thread):
+        rowsum[i] = warp.lane_group_sum[num_lanes=4](rowsum[i])
+        inv_rowsum[i] = Scalar[accum_type](1) / rowsum[i]
+
+    comptime for c in range(c_frag_size_pv):
+        comptime row_idx: Int = 1 if (c % 4) >= 2 else 0
+        o_reg.ptr[c] *= inv_rowsum[row_idx]
+
+    # ---- Store: stmatrix-stage O into the dead Q tile (same SW128
+    # k-major layout it was loaded with — the bwd dK/dV epilogue's
+    # scheme) and issue ONE whole-tile TMA store. 8x stmatrix.x4
+    # (non-trans) per thread; the 128B swizzle XOR is taken from the
+    # ABSOLUTE address and re-applied per call (32-B column steps
+    # live in the swizzled bits 4-6).
+    var lane: Int = Int(lane_id())
+    var warp_in_wg: Int = Int(warp_id()) % 4
+    var lane_group: Int = lane // 4
+    var lane_pair: Int = lane % 4
+    var row_warp_base: Int = wg * WGMMA_M + warp_in_wg * 16
+
+    # Varlen ragged q tail: the sequence's last m-tile may be partial
+    # (vl_rows < BM). A full-tile TMA store would overwrite the NEXT
+    # sequence's rows, so the partial tile bypasses the smem staging
+    # and stores its c-frags straight to gmem, row-predicated (the O
+    # raw pointer rides the sched_num_hb_q slot; boundary-tile-only,
+    # at most one per sequence).
+    var vl_rows: Int = BM
+    comptime if varlen:
+        vl_rows = vl_seqlen_q - m_block * BM
+    # Dense hdim64 (BM=192): the last m-tile is partial whenever
+    # seq_len % BM != 0 — rank-4 TMA clamps the O store, but the LSE
+    # writes still need the row predicate (vl_rows doubles as the
+    # valid-row count for both paths). BHSD's rank-3 (planes, S, D)
+    # store clamps at the plane's S edge the same way.
+    comptime if qo_rank == 4 or bhsd:
+        vl_rows = seq_len - m_block * BM
+
+    var full_tile_store: Bool = True
+    comptime if varlen:
+        if vl_rows < BM:
+            full_tile_store = False
+            var o_gptr = UnsafePointer[Scalar[dtype], MutAnyOrigin](
+                unsafe_from_address=sched_num_hb_q
+            )
+            var o_row0: Int = vl_q_base + m_block * BM
+            comptime for c2 in range(c_frag_size_pv // 2):
+                comptime col_chunk: Int = c2 // 2
+                comptime is_bot: Int = c2 % 2
+                var row: Int = (
+                    row_warp_base + lane_group + (8 if is_bot == 1 else 0)
+                )
+                if row < vl_rows:
+                    var pair = SIMD[dtype, 2](
+                        o_reg.ptr[2 * c2].cast[dtype](),
+                        o_reg.ptr[2 * c2 + 1].cast[dtype](),
+                    )
+                    (
+                        o_gptr
+                        + ((o_row0 + row) * nheads + h_idx) * D
+                        + col_chunk * 8
+                        + 2 * lane_pair
+                    ).store[width=2, alignment=4](pair)
+
+    if full_tile_store:
+        comptime if D == 64:
+            # D=64: stage via plain paired stores at the canonical
+            # SW128 k-major addresses (64-elem rows = one 128-B
+            # swizzle period; XOR re-applied per 16-B store). The
+            # stmatrix scheme below encodes D=128 geometry —
+            # revisit only if the parity bench demands it.
+            comptime for c2 in range(c_frag_size_pv // 2):
+                comptime col_chunk: Int = c2 // 2
+                comptime is_bot: Int = c2 % 2
+                var row: Int = (
+                    row_warp_base + lane_group + (8 if is_bot == 1 else 0)
+                )
+                var col: Int = col_chunk * 8 + 2 * lane_pair
+                var pair = SIMD[dtype, 2](
+                    o_reg.ptr[2 * c2].cast[dtype](),
+                    o_reg.ptr[2 * c2 + 1].cast[dtype](),
+                )
+                var b_addr: Int = (
+                    Int(smem_base)
+                    + (row >> 3) * 1024
+                    + (row & 7) * 128
+                    + 2 * col
+                )
+                var b_sw: Int = b_addr ^ ((b_addr >> 3) & 112)
+                (
+                    smem_base + ((b_sw >> 1) - (Int(smem_base) >> 1))
+                ).store[width=2, alignment=4](pair)
+        else:
+            var st_row: Int = (
+                row_warp_base + ((lane // 8) % 2) * 8 + (lane % 8)
+            )
+            var st_off_raw: Int = st_row * 64 + (lane // 16) * 8
+            var o_raw: Int = Int(smem_base) + 2 * st_off_raw
+            comptime for i in range(c_frag_size_pv // 8):
+                var packed = SIMD[DType.float32, 4](0)
+                comptime for jm in range(4):
+                    comptime p: Int = 4 * i + jm
+                    packed[jm] = bitcast[DType.float32, 1](
+                        SIMD[accum_type, 2](
+                            o_reg.ptr[2 * p], o_reg.ptr[2 * p + 1]
+                        ).cast[dtype]()
+                    )
+                var raw_i: Int = (
+                    o_raw + (i % 4) * 32 + (i // 4) * (BM * 128)
+                )
+                var sw_i: Int = raw_i ^ ((raw_i >> 3) & 112)
+                # .bitcast[BFloat16]: the stdlib st_matrix comptime-
+                # asserts bf16/f32, but stmatrix.b16 is dtype-agnostic
+                # (raw 16-bit stores; the payload is already bit-packed)
+                # — the cast unblocks fp16 and is a no-op for bf16.
+                st_matrix[simd_width=4](
+                    (
+                        smem_base
+                        + ((sw_i >> 1) - (Int(smem_base) >> 1))
+                    ).bitcast[BFloat16](),
+                    packed,
+                )
+
+    # ---- LSE (natural log), one f32 per row: rowmax is kept in the
+    # scaled log2 domain (max*scale*log2e) and rowsum is already
+    # row-reduced, so lse = rowmax*ln2 + ln(rowsum). lane_pair 0
+    # writes its thread's two rows; (B, H, S) f32, grid.y == nheads.
+    if lane_pair == 0:
+        var lse_row_base: Int
+        comptime if varlen:
+            # Packed (H, total_q) layout; seq_len carries total_q.
+            lse_row_base = h_idx * seq_len + vl_q_base + m_block * BM
+        else:
+            lse_row_base = (b_idx * nheads + h_idx) * seq_len + m_block * BM
+        comptime LN2: Scalar[accum_type] = 0.6931471805599453
+        comptime for i in range(rows_per_thread):
+            var r: Int = row_warp_base + lane_group + 8 * i
+            # Varlen: rows past the sequence's end belong to the NEXT
+            # sequence's packed LSE rows — predicate them off.
+            var lse_ok: Bool = True
+            comptime if varlen or qo_rank == 4 or bhsd:
+                lse_ok = r < vl_rows
+            if lse_ok:
+                (lse_ptr + lse_row_base + r)[0] = (
+                    rowmax[i] * LN2 + log(rowsum[i])
+                ).cast[DType.float32]()
+
+    fence_async_view_proxy()
+    # No producer warpgroup exists in this kernel -> a plain
+    # whole-CTA barrier (id NWG+1: ids 1..NWG are the scheduler
+    # pingpong barriers) suffices before the O store reads smem.
+    named_barrier[Int32(NWG * 128)](Int32(NWG + 1))
+    if full_tile_store and thread_idx.x == 0:
+        var o_st = LayoutTensor[
+            dtype,
+            q_smem_layout,
+            MutAnyOrigin,
+            address_space=AddressSpace.SHARED,
+            alignment=128,
+        ]((smem_base).as_unsafe_any_origin())
+        comptime if bhsd:
+            # (B*H, S, D) planes: the partial tail clamps at the
+            # plane's S edge in hardware.
+            o_tma.async_store_3d(
+                o_st, (0, m_block * BM, b_idx * nheads + h_idx)
+            )
+        elif qo_rank == 4:
+            # S its own dim: the partial tail tile clamps in hardware.
+            o_tma.async_store_4d(
+                o_st, (0, h_idx, m_block * BM, b_idx)
+            )
+        elif varlen:
+            o_tma.async_store_3d(
+                o_st, (0, h_idx, vl_q_base + m_block * BM)
+            )
+        else:
+            o_tma.async_store_3d(
+                o_st, (0, h_idx, b_idx * seq_len + m_block * BM)
+            )
+        o_tma.commit_group()
+        o_tma.wait_group()

--- a/torch_mojo_backend/eager_flash_attention/fa4_fwd_selfload_launch.mojo
+++ b/torch_mojo_backend/eager_flash_attention/fa4_fwd_selfload_launch.mojo
@@ -1,0 +1,223 @@
+# ============================================================================
+# PHASE 2c: self-loading single-warpgroup CTA, d64 dense-causal BHSD ONLY.
+# A NEW module (not a replacement): fa4_fwd_launch.mojo (phase 2b) still
+# owns every other route -- dense, strided-QKV (zero-copy BTHD), varlen,
+# window, and d128 in general. Per NOTES.md "Phase 2c" handoff item 2,
+# the self-loading structure was benchmarked and edge-case-tested ONLY
+# on dense-causal BHSD at d64, so this launcher deliberately implements
+# nothing else: varlen/window/strided_qkv/dense-r4 stay on
+# ``launch_fwd_fa4`` (fa4_fwd_launch.mojo), unmodified and untouched by
+# this change, rather than sharing a comptime-gated body with routes
+# this structure was never measured or raced on.
+# ============================================================================
+"""Launch helper for the self-loading FA4 fwd kernel (dense causal BHSD,
+d64 only).
+
+The runtime choice between this launcher and the phase-2b
+``launch_fwd_fa4`` bhsd path lives in ``fa4_ops.mojo`` (the wave-count
+gate: 3 CTAs/SM buys nothing below roughly 2 waves and costs 5-9% there,
+NOTES.md "Phase 2c" section 5) -- this module only implements the
+self-loading geometry itself, unconditionally, for whichever caller
+already decided to use it.
+
+PTX dump: when the build defines `MOJO_DUMP_PTX=<path>` (wired from the
+same-named environment variable by `_jit.py`), the device function's PTX
+is written to <path> at first-call JIT time via
+`compile_function(dump_asm=...)`. A `%` in the path expands to the
+kernel module name.
+"""
+
+from max.gpu.host import DeviceAttribute, DeviceContext, FuncAttribute
+from max.gpu.host.device_context import _DeviceContextPtr, _DeviceContextCpp, _DumpPath
+from max.gpu.host.nvidia.tma import TensorMapSwizzle
+from std.math import ceildiv
+from std.memory import OpaquePointer
+from std.sys import get_defined_string, size_of
+from std.utils.index import IndexList
+
+from layout import UNKNOWN_VALUE
+from layout.tma_async import create_split_tma
+
+from fa4_fwd_selfload_kernel import fwd_fa4_selfload_kernel
+from fa4_fwd_selfload_common import (
+    kFa4NThreads,
+    kFa4BlockM,
+    kFa4BlockN,
+    kFa4KVStages,
+    kFa4CtasPerSm,
+)
+from fa4_launch_cache import enqueue_fa4_cached
+
+comptime MOJO_DUMP_PTX: StaticString = get_defined_string[
+    "MOJO_DUMP_PTX", ""
+]()
+
+
+def _dump_ptx_path() -> _DumpPath:
+    comptime if MOJO_DUMP_PTX == StaticString(""):
+        return _DumpPath(False)
+    else:
+        return _DumpPath(MOJO_DUMP_PTX)
+
+
+def launch_fwd_fa4_selfload[
+    dtype: DType,
+    head_dim: Int,
+    use_external_stream: Bool,
+    causal: Bool = False,
+    gqa_ratio: Int = 1,
+    softcap_x1000: Int = 0,
+](
+    batch_int: Int,
+    seqlen_int: Int,
+    nheads_int: Int,
+    softmax_scale: Float32,
+    q_addr: Int,
+    k_addr: Int,
+    v_addr: Int,
+    o_addr: Int,
+    lse_addr: Int,
+    stream_handle_addr: Int,
+    ctx_handle_addr: Int,
+) raises:
+    # Dense causal d64 BHSD-native only: the comptime assert in
+    # fwd_fa4_selfload_kernel.mojo backstops head_dim == 64 at kernel
+    # instantiation; this one gives a clearer message for the rest of
+    # the (today, unreachable) envelope this launcher's signature could
+    # otherwise be asked to serve.
+    comptime assert (
+        (head_dim == 64) and causal and softcap_x1000 == 0
+    ), "self-load geometry is d64-only, dense-causal-bhsd only (d128/non-causal keep the phase-2b launcher)"
+    var raw_ctx_ptr = UnsafePointer[_DeviceContextCpp, MutUntrackedOrigin](
+        unsafe_from_address=ctx_handle_addr
+    )
+    var ctx = DeviceContext(_DeviceContextPtr[mut=True](raw_ctx_ptr))
+    var stream_opaque = OpaquePointer[MutAnyOrigin](
+        unsafe_from_address=stream_handle_addr
+    )
+
+    comptime swizzle: TensorMapSwizzle = TensorMapSwizzle.SWIZZLE_128B
+
+    # Smem: Q (BM x D) + kFa4KVStages ring slots (BN x D) bf16/f16 +
+    # mbarriers. d64: 8 KiB Q + 4*16 KiB ring = 72 KiB/CTA, so 3 CTAs/SM
+    # fit the 227 KiB opt-in cap (see fa4_fwd_selfload_common.mojo).
+    comptime q_bytes: Int = (
+        kFa4BlockM(head_dim) * head_dim * size_of[dtype]()
+    )
+    comptime kv_slot_bytes: Int = kFa4BlockN * head_dim * size_of[dtype]()
+    comptime mbar_bytes: Int = 128
+    comptime smem_bytes: Int = (
+        q_bytes + kFa4KVStages * kv_slot_bytes + mbar_bytes
+    )
+
+    var q_ptr = UnsafePointer[Scalar[dtype], ImmutAnyOrigin](
+        unsafe_from_address=q_addr
+    )
+    var k_ptr = UnsafePointer[Scalar[dtype], ImmutAnyOrigin](
+        unsafe_from_address=k_addr
+    )
+    var v_ptr = UnsafePointer[Scalar[dtype], ImmutAnyOrigin](
+        unsafe_from_address=v_addr
+    )
+    var lse_ptr = UnsafePointer[Float32, MutAnyOrigin](
+        unsafe_from_address=lse_addr
+    )
+    # PUBLIC-layout consumption (the fix the phase-2 bhsd descriptors
+    # bought): Q/K/V/O are the contiguous (B, H, S, D) tensors the ATen
+    # op provides, viewed as (B*H, S, D). Planes are the TMA outer dim
+    # and S its OWN dim, so BM tail tiles zero-fill on load and clamp on
+    # store at every plane's S edge -- no BTHD materialization.
+    comptime gmem_shape = IndexList[3](UNKNOWN_VALUE, UNKNOWN_VALUE, head_dim)
+    comptime q_smem_shape = IndexList[3](1, kFa4BlockM(head_dim), head_dim)
+    comptime kv_smem_shape = IndexList[3](1, kFa4BlockN, head_dim)
+
+    var planes_q: Int = batch_int * nheads_int
+    var planes_kv: Int = batch_int * (nheads_int // gqa_ratio)
+    var q_tma = create_split_tma[
+        q_smem_shape, gmem_shape, swizzle_mode=swizzle
+    ](ctx, q_ptr, planes_q, seqlen_int)
+    var k_tma = create_split_tma[
+        kv_smem_shape, gmem_shape, swizzle_mode=swizzle
+    ](ctx, k_ptr, planes_kv, seqlen_int)
+    var v_tma = create_split_tma[
+        kv_smem_shape, gmem_shape, swizzle_mode=swizzle
+    ](ctx, v_ptr, planes_kv, seqlen_int)
+    var o_imm_ptr = UnsafePointer[Scalar[dtype], ImmutAnyOrigin](
+        unsafe_from_address=o_addr
+    )
+    var o_tma = create_split_tma[
+        q_smem_shape, gmem_shape, swizzle_mode=swizzle
+    ](ctx, o_imm_ptr, planes_q, seqlen_int)
+    comptime kernel_inst = fwd_fa4_selfload_kernel[
+        dtype,
+        head_dim,
+        3,
+        type_of(q_tma).tile_shape,
+        type_of(q_tma).desc_shape,
+        type_of(k_tma).tile_shape,
+        type_of(k_tma).desc_shape,
+        type_of(o_tma).tile_shape,
+        type_of(o_tma).desc_shape,
+        causal,
+        gqa_ratio,
+        False,
+        False,
+        False,
+        softcap_x1000,
+        bhsd=True,
+    ]
+    # Same LPT scheduler as the phase-2b bhsd path. This launcher's own
+    # wave count (kFa4CtasPerSm(head_dim) == 3 here) picks its L2-swizzle
+    # group -- NOT the same computation ``launch_fwd_fa4`` makes with its
+    # own ctas_per_sm (2 at d64): that keeps the phase-2b >= 12-wave
+    # threshold undisturbed for shapes still dispatched there (see the
+    # gate in fa4_ops.mojo and NOTES.md "Phase 2c" handoff item 4).
+    var num_m: Int = ceildiv(seqlen_int, Int(kFa4BlockM(head_dim)))
+    var size_one_kv_head: Int = (
+        seqlen_int * 2 * head_dim * size_of[dtype]()
+    )
+    var sm_count: Int = ctx.get_attribute(
+        DeviceAttribute.MULTIPROCESSOR_COUNT
+    )
+    var ctas_per_sm: Int = kFa4CtasPerSm(head_dim)
+    var waves: Int = (num_m * nheads_int * batch_int) // (
+        ctas_per_sm * sm_count
+    )
+    var l2_ratio: Int = (50 * 1024 * 1024) // size_one_kv_head
+    var sched_swizzle: Int
+    if waves >= 12:
+        sched_swizzle = 1
+    else:
+        sched_swizzle = 1
+        while sched_swizzle * 2 <= l2_ratio:
+            sched_swizzle *= 2
+    var num_hb: Int = nheads_int * batch_int
+    var sched_num_hb_q: Int = num_hb // sched_swizzle
+    var sched_residual: Int = max(num_hb % sched_swizzle, 1)
+    enqueue_fa4_cached[
+        kernel_inst,
+        use_external_stream=use_external_stream,
+        dump_asm=_dump_ptx_path(),
+    ](
+        ctx,
+        ctx_handle_addr,
+        stream_opaque,
+        String(
+            t"fwd_selfload_bhsd_{dtype}_d{head_dim}_c{causal}_g{gqa_ratio}"
+        ),
+        (num_m * num_hb, 1, 1),
+        kFa4NThreads(head_dim),
+        smem_bytes,
+        FuncAttribute.MAX_DYNAMIC_SHARED_SIZE_BYTES(UInt32(smem_bytes)),
+        q_tma,
+        k_tma,
+        v_tma,
+        o_tma,
+        lse_ptr,
+        Int64(seqlen_int),
+        softmax_scale,
+        Int64(nheads_int),
+        Int64(sched_swizzle),
+        Int64(sched_num_hb_q),
+        Int64(sched_residual),
+    )

--- a/torch_mojo_backend/eager_flash_attention/fa4_ops.mojo
+++ b/torch_mojo_backend/eager_flash_attention/fa4_ops.mojo
@@ -5,16 +5,57 @@ asynchronous; synchronization belongs at explicit consumer/benchmark
 boundaries, never between forward or backward component kernels.
 """
 
+from std.math import ceildiv
 from std.os import abort
 from std.python import PythonObject
 from std.python.bindings import PythonModuleBuilder
 
+from max.gpu.host import DeviceAttribute, DeviceContext
+from max.gpu.host.device_context import _DeviceContextPtr, _DeviceContextCpp
+
 from fa4_fwd_launch import launch_fwd_fa4
+from fa4_fwd_selfload_launch import launch_fwd_fa4_selfload
+from fa4_fwd_selfload_common import kFa4BlockM as kFa4SelfloadBlockM
+from fa4_fwd_selfload_common import kFa4CtasPerSm as kFa4SelfloadCtasPerSm
 from fa4_bwd_launch import (
     launch_bwd_preprocess,
     launch_bwd_main,
     launch_bwd_convert,
 )
+
+# PHASE 2c wave-gate threshold (NOTES.md, /scratch/fa4-fwd-harness-2c,
+# "Phase 2c" section 5): the self-loading (3 CTAs/SM) bhsd route beats
+# the phase-2b (2 CTAs/SM) geometry once there is enough parallel work
+# to fill a third CTA everywhere; below it, the shallower 4-stage ring
+# and the missing dedicated producer warpgroup are pure cost with
+# nothing to hide behind. Measured waves at this divisor: P0/P1/P2/P3 at
+# 4.5/17/3.0/23 all clear the bar; P4/P5 at 0.8/0.2 both regress (5-9%)
+# but stay under 1.10x cuDNN either way, so the gate is not delicate.
+# FITTED ON H100 PCIe (114 SMs) -- re-derive on other cards; nothing
+# here is architecture-specific in principle, but the threshold was
+# never measured off Hopper.
+comptime _FA4_SELFLOAD_MIN_WAVES: Int = 2
+
+
+def _fa4_bhsd_selfload_waves(
+    batch: Int, seqlen: Int, nheads: Int, ctx_handle_addr: Int
+) raises -> Int:
+    """Runtime wave count for the self-loading (3 CTAs/SM) bhsd route.
+
+    Deliberately its OWN computation, not shared with
+    ``launch_fwd_fa4``'s internal L2-swizzle wave count (which keeps
+    dividing by ITS OWN 2-CTAs/SM occupancy): conflating the two would
+    move the phase-2b ">= 12 waves" swizzle-group threshold for shapes
+    that stay on the phase-2b geometry, an unmeasured combination this
+    gate must not create (NOTES.md "Phase 2c" handoff item 4).
+    """
+    var raw_ctx_ptr = UnsafePointer[_DeviceContextCpp, MutUntrackedOrigin](
+        unsafe_from_address=ctx_handle_addr
+    )
+    var ctx = DeviceContext(_DeviceContextPtr[mut=True](raw_ctx_ptr))
+    var sm_count = ctx.get_attribute(DeviceAttribute.MULTIPROCESSOR_COUNT)
+    var num_m = ceildiv(seqlen, kFa4SelfloadBlockM(64))
+    return (num_m * nheads * batch) // (kFa4SelfloadCtasPerSm(64) * sm_count)
 
 
 def flash_attention_fwd_bf16_d64_causal(
@@ -630,7 +671,14 @@ def flash_attention_fwd_bf16_d64_causal_bhsd(
     the PUBLIC contiguous (B, H, S, D) layout directly (viewed as
     (B*H, S, D) planes), skipping the BTHD materialization the dense
     entry point above requires. See fa4_fwd_kernel.mojo/fa4_fwd_launch.mojo
-    ``bhsd``/``bhsd_qkv`` comptime params."""
+    ``bhsd``/``bhsd_qkv`` comptime params.
+
+    Runtime-gated (phase 2c, ``_fa4_bhsd_selfload_waves``) between two
+    d64 geometries: the self-loading single-warpgroup, 3-CTAs/SM kernel
+    (``fa4_fwd_selfload_launch.mojo``) once there is enough parallel work
+    to fill a third CTA everywhere, else the phase-2b 2-CTAs/SM producer/
+    consumer kernel this bridge always used before. See
+    ``_FA4_SELFLOAD_MIN_WAVES`` above for the threshold and its source."""
     var q_addr = Int(py=args[0])
     var k_addr = Int(py=args[1])
     var v_addr = Int(py=args[2])
@@ -644,30 +692,55 @@ def flash_attention_fwd_bf16_d64_causal_bhsd(
 
     _check_bhsd_args(batch, seqlen, nheads, q_addr, k_addr, v_addr, out_addr)
 
-    launch_fwd_fa4[
-        DType.bfloat16,
-        64,
-        False,
-        True,
-        1,
-        False,
-        False,
-        False,
-        0,
-        bhsd_qkv=True,
-    ](
-        batch,
-        seqlen,
-        nheads,
-        softmax_scale,
-        q_addr,
-        k_addr,
-        v_addr,
-        out_addr,
-        lse_addr,
-        0,
-        ctx_addr,
-    )
+    if (
+        _fa4_bhsd_selfload_waves(batch, seqlen, nheads, ctx_addr)
+        >= _FA4_SELFLOAD_MIN_WAVES
+    ):
+        launch_fwd_fa4_selfload[
+            DType.bfloat16,
+            64,
+            False,
+            True,
+            1,
+            0,
+        ](
+            batch,
+            seqlen,
+            nheads,
+            softmax_scale,
+            q_addr,
+            k_addr,
+            v_addr,
+            out_addr,
+            lse_addr,
+            0,
+            ctx_addr,
+        )
+    else:
+        launch_fwd_fa4[
+            DType.bfloat16,
+            64,
+            False,
+            True,
+            1,
+            False,
+            False,
+            False,
+            0,
+            bhsd_qkv=True,
+        ](
+            batch,
+            seqlen,
+            nheads,
+            softmax_scale,
+            q_addr,
+            k_addr,
+            v_addr,
+            out_addr,
+            lse_addr,
+            0,
+            ctx_addr,
+        )
     return PythonObject(None)
 
 
@@ -676,7 +749,8 @@ def flash_attention_fwd_f16_d64_causal_bhsd(
     mut args: PythonObject,
 ) raises -> PythonObject:
     """Same BHSD-native dense causal d64 fwd as the bf16 entry point
-    above, only the comptime ``dtype`` differs."""
+    above, only the comptime ``dtype`` differs (including the phase-2c
+    self-load/phase-2b wave gate)."""
     var q_addr = Int(py=args[0])
     var k_addr = Int(py=args[1])
     var v_addr = Int(py=args[2])
@@ -690,30 +764,55 @@ def flash_attention_fwd_f16_d64_causal_bhsd(
 
     _check_bhsd_args(batch, seqlen, nheads, q_addr, k_addr, v_addr, out_addr)
 
-    launch_fwd_fa4[
-        DType.float16,
-        64,
-        False,
-        True,
-        1,
-        False,
-        False,
-        False,
-        0,
-        bhsd_qkv=True,
-    ](
-        batch,
-        seqlen,
-        nheads,
-        softmax_scale,
-        q_addr,
-        k_addr,
-        v_addr,
-        out_addr,
-        lse_addr,
-        0,
-        ctx_addr,
-    )
+    if (
+        _fa4_bhsd_selfload_waves(batch, seqlen, nheads, ctx_addr)
+        >= _FA4_SELFLOAD_MIN_WAVES
+    ):
+        launch_fwd_fa4_selfload[
+            DType.float16,
+            64,
+            False,
+            True,
+            1,
+            0,
+        ](
+            batch,
+            seqlen,
+            nheads,
+            softmax_scale,
+            q_addr,
+            k_addr,
+            v_addr,
+            out_addr,
+            lse_addr,
+            0,
+            ctx_addr,
+        )
+    else:
+        launch_fwd_fa4[
+            DType.float16,
+            64,
+            False,
+            True,
+            1,
+            False,
+            False,
+            False,
+            0,
+            bhsd_qkv=True,
+        ](
+            batch,
+            seqlen,
+            nheads,
+            softmax_scale,
+            q_addr,
+            k_addr,
+            v_addr,
+            out_addr,
+            lse_addr,
+            0,
+            ctx_addr,
+        )
     return PythonObject(None)
 
 

--- a/torch_mojo_backend/eager_flash_attention/fa4_ops.mojo
+++ b/torch_mojo_backend/eager_flash_attention/fa4_ops.mojo
@@ -566,6 +566,142 @@ def flash_attention_fwd_f16_d64_causal_strided_qkv(
     return PythonObject(None)
 
 
+def _check_bhsd_args(
+    batch: Int,
+    seqlen: Int,
+    nheads: Int,
+    q_addr: Int,
+    k_addr: Int,
+    v_addr: Int,
+    out_addr: Int,
+) raises:
+    """Defensive validation for the BHSD-native forward entry points.
+
+    The Python bridge (``_fa4_bhsd_layout`` in ``aten_fast.py``) has
+    already gated on public (B, H, S, D) contiguity and 16-byte
+    base-pointer alignment before selecting this path -- TMA descriptor
+    creation over the plane-viewed (B*H, S, D) layout requires exactly
+    that. Re-check here (same spirit as ``_check_strided_qkv_layout``
+    for the strided ABI) so a caller that bypasses the Python gate
+    cannot slip an unaligned or degenerate view past descriptor
+    creation.
+    """
+    if batch <= 0 or seqlen <= 0 or nheads <= 0:
+        raise Error(
+            "fa4 bhsd: batch, seqlen and nheads must be positive, got (",
+            batch,
+            ", ",
+            seqlen,
+            ", ",
+            nheads,
+            ")",
+        )
+    if (
+        q_addr % 16 != 0
+        or k_addr % 16 != 0
+        or v_addr % 16 != 0
+        or out_addr % 16 != 0
+    ):
+        raise Error(
+            "fa4 bhsd: q/k/v/out base addresses must be 16-byte aligned"
+        )
+
+
+def flash_attention_fwd_bf16_d64_causal_bhsd(
+    mut py_self: PythonObject,
+    mut args: PythonObject,
+) raises -> PythonObject:
+    """Dense causal d64 fwd, BHSD-native: Q/K/V/O TMA descriptors address
+    the PUBLIC contiguous (B, H, S, D) layout directly (viewed as
+    (B*H, S, D) planes), skipping the BTHD materialization the dense
+    entry point above requires. See fa4_fwd_kernel.mojo/fa4_fwd_launch.mojo
+    ``bhsd``/``bhsd_qkv`` comptime params."""
+    var q_addr = Int(py=args[0])
+    var k_addr = Int(py=args[1])
+    var v_addr = Int(py=args[2])
+    var out_addr = Int(py=args[3])
+    var lse_addr = Int(py=args[4])
+    var batch = Int(py=args[5])
+    var seqlen = Int(py=args[6])
+    var nheads = Int(py=args[7])
+    var softmax_scale = Float32(py=args[8])
+    var ctx_addr = Int(py=args[9])
+
+    _check_bhsd_args(batch, seqlen, nheads, q_addr, k_addr, v_addr, out_addr)
+
+    launch_fwd_fa4[
+        DType.bfloat16,
+        64,
+        False,
+        True,
+        1,
+        False,
+        False,
+        False,
+        0,
+        bhsd_qkv=True,
+    ](
+        batch,
+        seqlen,
+        nheads,
+        softmax_scale,
+        q_addr,
+        k_addr,
+        v_addr,
+        out_addr,
+        lse_addr,
+        0,
+        ctx_addr,
+    )
+    return PythonObject(None)
+
+
+def flash_attention_fwd_f16_d64_causal_bhsd(
+    mut py_self: PythonObject,
+    mut args: PythonObject,
+) raises -> PythonObject:
+    """Same BHSD-native dense causal d64 fwd as the bf16 entry point
+    above, only the comptime ``dtype`` differs."""
+    var q_addr = Int(py=args[0])
+    var k_addr = Int(py=args[1])
+    var v_addr = Int(py=args[2])
+    var out_addr = Int(py=args[3])
+    var lse_addr = Int(py=args[4])
+    var batch = Int(py=args[5])
+    var seqlen = Int(py=args[6])
+    var nheads = Int(py=args[7])
+    var softmax_scale = Float32(py=args[8])
+    var ctx_addr = Int(py=args[9])
+
+    _check_bhsd_args(batch, seqlen, nheads, q_addr, k_addr, v_addr, out_addr)
+
+    launch_fwd_fa4[
+        DType.float16,
+        64,
+        False,
+        True,
+        1,
+        False,
+        False,
+        False,
+        0,
+        bhsd_qkv=True,
+    ](
+        batch,
+        seqlen,
+        nheads,
+        softmax_scale,
+        q_addr,
+        k_addr,
+        v_addr,
+        out_addr,
+        lse_addr,
+        0,
+        ctx_addr,
+    )
+    return PythonObject(None)
+
+
 def flash_attention_bwd_bf16_d64_causal_strided_qkv(
     mut py_self: PythonObject,
     mut args: PythonObject,
@@ -866,6 +1002,12 @@ def PyInit_fa4_ops() abi("C") -> PythonObject:
         )
         module.def_py_function[flash_attention_fwd_f16_d64_causal_strided_qkv](
             "flash_attention_fwd_f16_d64_causal_strided_qkv"
+        )
+        module.def_py_function[flash_attention_fwd_bf16_d64_causal_bhsd](
+            "flash_attention_fwd_bf16_d64_causal_bhsd"
+        )
+        module.def_py_function[flash_attention_fwd_f16_d64_causal_bhsd](
+            "flash_attention_fwd_f16_d64_causal_bhsd"
         )
         module.def_py_function[flash_attention_bwd_bf16_d64_causal_strided_qkv](
             "flash_attention_bwd_bf16_d64_causal_strided_qkv"

--- a/torch_mojo_backend/eager_flash_attention/fa4_ops.mojo
+++ b/torch_mojo_backend/eager_flash_attention/fa4_ops.mojo
@@ -274,6 +274,7 @@ def _check_strided_qkv_layout(
     d_stride: Int,
     seqlen: Int,
     nheads: Int,
+    head_dim: Int,
 ) raises:
     """Reject any Q/K/V layout outside the strict zero-copy regime.
 
@@ -281,6 +282,9 @@ def _check_strided_qkv_layout(
     violation never partially launches. Strides are in Q/K/V dtype
     ELEMENTS (bf16 or f16 -- shared by both entry-point families since
     both are 2-byte types with identical 16-byte-multiple math).
+    ``head_dim`` is a runtime value here even though every caller
+    passes a literal (64 or 128, matching its own comptime instance)
+    -- this check has no comptime context of its own.
     """
     if b_stride <= 0 or s_stride <= 0 or h_stride <= 0 or d_stride <= 0:
         raise Error(
@@ -300,18 +304,23 @@ def _check_strided_qkv_layout(
         raise Error(
             "fa4 strided qkv: ", name, " d_stride must be 1, got ", d_stride
         )
-    if h_stride != 64:
+    if h_stride != head_dim:
         raise Error(
-            "fa4 strided qkv: ", name, " h_stride must be 64, got ", h_stride
+            "fa4 strided qkv: ",
+            name,
+            " h_stride must be ",
+            head_dim,
+            ", got ",
+            h_stride,
         )
-    if s_stride < nheads * 64:
+    if s_stride < nheads * head_dim:
         raise Error(
             "fa4 strided qkv: ",
             name,
             " s_stride ",
             s_stride,
-            " must be >= nheads * 64 = ",
-            nheads * 64,
+            " must be >= nheads * head_dim = ",
+            nheads * head_dim,
         )
     if b_stride != seqlen * s_stride:
         raise Error(
@@ -408,6 +417,7 @@ def flash_attention_fwd_bf16_d64_causal_strided_qkv(
         q_d_stride,
         seqlen,
         nheads,
+        64,
     )
     _check_strided_qkv_layout(
         "k",
@@ -418,6 +428,7 @@ def flash_attention_fwd_bf16_d64_causal_strided_qkv(
         k_d_stride,
         seqlen,
         nheads,
+        64,
     )
     _check_strided_qkv_layout(
         "v",
@@ -428,6 +439,7 @@ def flash_attention_fwd_bf16_d64_causal_strided_qkv(
         v_d_stride,
         seqlen,
         nheads,
+        64,
     )
 
     launch_fwd_fa4[
@@ -507,6 +519,7 @@ def flash_attention_fwd_f16_d64_causal_strided_qkv(
         q_d_stride,
         seqlen,
         nheads,
+        64,
     )
     _check_strided_qkv_layout(
         "k",
@@ -517,6 +530,7 @@ def flash_attention_fwd_f16_d64_causal_strided_qkv(
         k_d_stride,
         seqlen,
         nheads,
+        64,
     )
     _check_strided_qkv_layout(
         "v",
@@ -527,6 +541,7 @@ def flash_attention_fwd_f16_d64_causal_strided_qkv(
         v_d_stride,
         seqlen,
         nheads,
+        64,
     )
 
     launch_fwd_fa4[
@@ -752,6 +767,7 @@ def flash_attention_bwd_bf16_d64_causal_strided_qkv(
         q_d_stride,
         seqlen,
         nheads,
+        64,
     )
     _check_strided_qkv_layout(
         "k",
@@ -762,6 +778,7 @@ def flash_attention_bwd_bf16_d64_causal_strided_qkv(
         k_d_stride,
         seqlen,
         nheads,
+        64,
     )
     _check_strided_qkv_layout(
         "v",
@@ -772,6 +789,7 @@ def flash_attention_bwd_bf16_d64_causal_strided_qkv(
         v_d_stride,
         seqlen,
         nheads,
+        64,
     )
 
     launch_bwd_preprocess[
@@ -891,6 +909,7 @@ def flash_attention_bwd_f16_d64_causal_strided_qkv(
         q_d_stride,
         seqlen,
         nheads,
+        64,
     )
     _check_strided_qkv_layout(
         "k",
@@ -901,6 +920,7 @@ def flash_attention_bwd_f16_d64_causal_strided_qkv(
         k_d_stride,
         seqlen,
         nheads,
+        64,
     )
     _check_strided_qkv_layout(
         "v",
@@ -911,6 +931,7 @@ def flash_attention_bwd_f16_d64_causal_strided_qkv(
         v_d_stride,
         seqlen,
         nheads,
+        64,
     )
 
     launch_bwd_preprocess[
@@ -981,6 +1002,850 @@ def flash_attention_bwd_f16_d64_causal_strided_qkv(
     return PythonObject(None)
 
 
+# ---------------------------------------------------------------------------
+# head_dim=128 forward/backward entry points. Structurally identical to the
+# d64 family above (dense, strided_qkv zero-copy BTHD, bhsd-native) --
+# fa4_fwd_common.mojo / fa4_bwd_common.mojo already carry BM, warpgroup
+# count, register budgets and the bwd causal tile_m as head_dim-parametric
+# constants mirroring FA4's own sm90 configs (BM=128 not 192, 2 MMA
+# warpgroups not 3, bwd causal tile_m=64 not 128), so only the comptime
+# head_dim argument to launch_fwd_fa4/launch_bwd_* differs from the d64
+# twins below.
+# ---------------------------------------------------------------------------
+
+
+def flash_attention_fwd_bf16_d128_causal(
+    mut py_self: PythonObject,
+    mut args: PythonObject,
+) raises -> PythonObject:
+    var q_addr = Int(py=args[0])
+    var k_addr = Int(py=args[1])
+    var v_addr = Int(py=args[2])
+    var out_addr = Int(py=args[3])
+    var lse_addr = Int(py=args[4])
+    var batch = Int(py=args[5])
+    var seqlen = Int(py=args[6])
+    var nheads = Int(py=args[7])
+    var softmax_scale = Float32(py=args[8])
+    var ctx_addr = Int(py=args[9])
+
+    if batch <= 0 or seqlen <= 0 or nheads <= 0:
+        return PythonObject(None)
+
+    launch_fwd_fa4[
+        DType.bfloat16,
+        128,
+        False,
+        True,
+        1,
+        False,
+        False,
+        False,
+        0,
+    ](
+        batch,
+        seqlen,
+        nheads,
+        softmax_scale,
+        q_addr,
+        k_addr,
+        v_addr,
+        out_addr,
+        lse_addr,
+        0,
+        ctx_addr,
+    )
+    return PythonObject(None)
+
+
+def flash_attention_fwd_f16_d128_causal(
+    mut py_self: PythonObject,
+    mut args: PythonObject,
+) raises -> PythonObject:
+    """Same dense d128 causal forward as the bf16 entry point above, only the
+    comptime ``dtype`` differs. The f16 RS (register-A) wgmma emitters live
+    in ``fa4_wgmma_f16.mojo`` and are selected inside the shared kernel by
+    ``comptime if dtype == DType.float16`` -- bf16 keeps the stdlib path
+    byte-identical."""
+    var q_addr = Int(py=args[0])
+    var k_addr = Int(py=args[1])
+    var v_addr = Int(py=args[2])
+    var out_addr = Int(py=args[3])
+    var lse_addr = Int(py=args[4])
+    var batch = Int(py=args[5])
+    var seqlen = Int(py=args[6])
+    var nheads = Int(py=args[7])
+    var softmax_scale = Float32(py=args[8])
+    var ctx_addr = Int(py=args[9])
+
+    if batch <= 0 or seqlen <= 0 or nheads <= 0:
+        return PythonObject(None)
+
+    launch_fwd_fa4[
+        DType.float16,
+        128,
+        False,
+        True,
+        1,
+        False,
+        False,
+        False,
+        0,
+    ](
+        batch,
+        seqlen,
+        nheads,
+        softmax_scale,
+        q_addr,
+        k_addr,
+        v_addr,
+        out_addr,
+        lse_addr,
+        0,
+        ctx_addr,
+    )
+    return PythonObject(None)
+
+
+def flash_attention_bwd_bf16_d128_causal(
+    mut py_self: PythonObject,
+    mut args: PythonObject,
+) raises -> PythonObject:
+    var q_addr = Int(py=args[0])
+    var k_addr = Int(py=args[1])
+    var v_addr = Int(py=args[2])
+    var out_addr = Int(py=args[3])
+    var dout_addr = Int(py=args[4])
+    var lse_addr = Int(py=args[5])
+    var dq_addr = Int(py=args[6])
+    var dk_addr = Int(py=args[7])
+    var dv_addr = Int(py=args[8])
+    var dpsum_addr = Int(py=args[9])
+    var lse_log2_addr = Int(py=args[10])
+    var dq_accum_addr = Int(py=args[11])
+    var batch = Int(py=args[12])
+    var seqlen = Int(py=args[13])
+    var nheads = Int(py=args[14])
+    var softmax_scale = Float32(py=args[15])
+    var ctx_addr = Int(py=args[16])
+
+    if batch <= 0 or seqlen <= 0 or nheads <= 0:
+        return PythonObject(None)
+
+    launch_bwd_preprocess[
+        DType.bfloat16, 128, False, True, 1, False
+    ](
+        batch,
+        seqlen,
+        nheads,
+        out_addr,
+        dout_addr,
+        lse_addr,
+        dpsum_addr,
+        lse_log2_addr,
+        dq_accum_addr,
+        0,
+        0,
+        0,
+        ctx_addr,
+    )
+    launch_bwd_main[
+        DType.bfloat16, 128, False, True, 1, False, False, 0
+    ](
+        batch,
+        seqlen,
+        nheads,
+        softmax_scale,
+        q_addr,
+        k_addr,
+        v_addr,
+        dout_addr,
+        dk_addr,
+        dv_addr,
+        lse_log2_addr,
+        dpsum_addr,
+        dq_accum_addr,
+        0,
+        ctx_addr,
+    )
+    launch_bwd_convert[
+        DType.bfloat16, 128, False, True, 1, False
+    ](
+        batch,
+        seqlen,
+        nheads,
+        softmax_scale,
+        dq_accum_addr,
+        dq_addr,
+        0,
+        ctx_addr,
+    )
+    return PythonObject(None)
+
+
+def flash_attention_bwd_f16_d128_causal(
+    mut py_self: PythonObject,
+    mut args: PythonObject,
+) raises -> PythonObject:
+    """Same dense d128 causal backward as the bf16 entry point above, only
+    the comptime ``dtype`` differs (see ``flash_attention_fwd_f16_d128_causal``
+    for the f16 RS wgmma note)."""
+    var q_addr = Int(py=args[0])
+    var k_addr = Int(py=args[1])
+    var v_addr = Int(py=args[2])
+    var out_addr = Int(py=args[3])
+    var dout_addr = Int(py=args[4])
+    var lse_addr = Int(py=args[5])
+    var dq_addr = Int(py=args[6])
+    var dk_addr = Int(py=args[7])
+    var dv_addr = Int(py=args[8])
+    var dpsum_addr = Int(py=args[9])
+    var lse_log2_addr = Int(py=args[10])
+    var dq_accum_addr = Int(py=args[11])
+    var batch = Int(py=args[12])
+    var seqlen = Int(py=args[13])
+    var nheads = Int(py=args[14])
+    var softmax_scale = Float32(py=args[15])
+    var ctx_addr = Int(py=args[16])
+
+    if batch <= 0 or seqlen <= 0 or nheads <= 0:
+        return PythonObject(None)
+
+    launch_bwd_preprocess[
+        DType.float16, 128, False, True, 1, False
+    ](
+        batch,
+        seqlen,
+        nheads,
+        out_addr,
+        dout_addr,
+        lse_addr,
+        dpsum_addr,
+        lse_log2_addr,
+        dq_accum_addr,
+        0,
+        0,
+        0,
+        ctx_addr,
+    )
+    launch_bwd_main[
+        DType.float16, 128, False, True, 1, False, False, 0
+    ](
+        batch,
+        seqlen,
+        nheads,
+        softmax_scale,
+        q_addr,
+        k_addr,
+        v_addr,
+        dout_addr,
+        dk_addr,
+        dv_addr,
+        lse_log2_addr,
+        dpsum_addr,
+        dq_accum_addr,
+        0,
+        ctx_addr,
+    )
+    launch_bwd_convert[
+        DType.float16, 128, False, True, 1, False
+    ](
+        batch,
+        seqlen,
+        nheads,
+        softmax_scale,
+        dq_accum_addr,
+        dq_addr,
+        0,
+        ctx_addr,
+    )
+    return PythonObject(None)
+
+
+def flash_attention_fwd_bf16_d128_causal_strided_qkv(
+    mut py_self: PythonObject,
+    mut args: PythonObject,
+) raises -> PythonObject:
+    """Zero-copy fwd: Q/K/V are strided (B, S, H, 128) views described
+    by per-tensor runtime element strides (b, s, h, d); out/lse keep
+    the contiguous layouts of the dense entry point."""
+    var q_addr = Int(py=args[0])
+    var q_b_stride = Int(py=args[1])
+    var q_s_stride = Int(py=args[2])
+    var q_h_stride = Int(py=args[3])
+    var q_d_stride = Int(py=args[4])
+    var k_addr = Int(py=args[5])
+    var k_b_stride = Int(py=args[6])
+    var k_s_stride = Int(py=args[7])
+    var k_h_stride = Int(py=args[8])
+    var k_d_stride = Int(py=args[9])
+    var v_addr = Int(py=args[10])
+    var v_b_stride = Int(py=args[11])
+    var v_s_stride = Int(py=args[12])
+    var v_h_stride = Int(py=args[13])
+    var v_d_stride = Int(py=args[14])
+    var out_addr = Int(py=args[15])
+    var lse_addr = Int(py=args[16])
+    var batch = Int(py=args[17])
+    var seqlen = Int(py=args[18])
+    var nheads = Int(py=args[19])
+    var softmax_scale = Float32(py=args[20])
+    var ctx_addr = Int(py=args[21])
+
+    _check_strided_qkv_args(batch, seqlen, nheads)
+    _check_strided_qkv_layout(
+        "q",
+        q_addr,
+        q_b_stride,
+        q_s_stride,
+        q_h_stride,
+        q_d_stride,
+        seqlen,
+        nheads,
+        128,
+    )
+    _check_strided_qkv_layout(
+        "k",
+        k_addr,
+        k_b_stride,
+        k_s_stride,
+        k_h_stride,
+        k_d_stride,
+        seqlen,
+        nheads,
+        128,
+    )
+    _check_strided_qkv_layout(
+        "v",
+        v_addr,
+        v_b_stride,
+        v_s_stride,
+        v_h_stride,
+        v_d_stride,
+        seqlen,
+        nheads,
+        128,
+    )
+
+    launch_fwd_fa4[
+        DType.bfloat16,
+        128,
+        False,
+        True,
+        1,
+        False,
+        False,
+        False,
+        0,
+        strided_qkv=True,
+    ](
+        batch,
+        seqlen,
+        nheads,
+        softmax_scale,
+        q_addr,
+        k_addr,
+        v_addr,
+        out_addr,
+        lse_addr,
+        0,
+        ctx_addr,
+        q_b_stride=q_b_stride,
+        q_s_stride=q_s_stride,
+        q_h_stride=q_h_stride,
+        q_d_stride=q_d_stride,
+        k_s_stride=k_s_stride,
+        k_h_stride=k_h_stride,
+        k_d_stride=k_d_stride,
+        v_s_stride=v_s_stride,
+        v_h_stride=v_h_stride,
+        v_d_stride=v_d_stride,
+    )
+    return PythonObject(None)
+
+
+def flash_attention_fwd_f16_d128_causal_strided_qkv(
+    mut py_self: PythonObject,
+    mut args: PythonObject,
+) raises -> PythonObject:
+    """Same zero-copy strided fwd as the bf16 entry point above (see its
+    docstring for the layout contract), only the comptime ``dtype`` differs.
+    """
+    var q_addr = Int(py=args[0])
+    var q_b_stride = Int(py=args[1])
+    var q_s_stride = Int(py=args[2])
+    var q_h_stride = Int(py=args[3])
+    var q_d_stride = Int(py=args[4])
+    var k_addr = Int(py=args[5])
+    var k_b_stride = Int(py=args[6])
+    var k_s_stride = Int(py=args[7])
+    var k_h_stride = Int(py=args[8])
+    var k_d_stride = Int(py=args[9])
+    var v_addr = Int(py=args[10])
+    var v_b_stride = Int(py=args[11])
+    var v_s_stride = Int(py=args[12])
+    var v_h_stride = Int(py=args[13])
+    var v_d_stride = Int(py=args[14])
+    var out_addr = Int(py=args[15])
+    var lse_addr = Int(py=args[16])
+    var batch = Int(py=args[17])
+    var seqlen = Int(py=args[18])
+    var nheads = Int(py=args[19])
+    var softmax_scale = Float32(py=args[20])
+    var ctx_addr = Int(py=args[21])
+
+    _check_strided_qkv_args(batch, seqlen, nheads)
+    _check_strided_qkv_layout(
+        "q",
+        q_addr,
+        q_b_stride,
+        q_s_stride,
+        q_h_stride,
+        q_d_stride,
+        seqlen,
+        nheads,
+        128,
+    )
+    _check_strided_qkv_layout(
+        "k",
+        k_addr,
+        k_b_stride,
+        k_s_stride,
+        k_h_stride,
+        k_d_stride,
+        seqlen,
+        nheads,
+        128,
+    )
+    _check_strided_qkv_layout(
+        "v",
+        v_addr,
+        v_b_stride,
+        v_s_stride,
+        v_h_stride,
+        v_d_stride,
+        seqlen,
+        nheads,
+        128,
+    )
+
+    launch_fwd_fa4[
+        DType.float16,
+        128,
+        False,
+        True,
+        1,
+        False,
+        False,
+        False,
+        0,
+        strided_qkv=True,
+    ](
+        batch,
+        seqlen,
+        nheads,
+        softmax_scale,
+        q_addr,
+        k_addr,
+        v_addr,
+        out_addr,
+        lse_addr,
+        0,
+        ctx_addr,
+        q_b_stride=q_b_stride,
+        q_s_stride=q_s_stride,
+        q_h_stride=q_h_stride,
+        q_d_stride=q_d_stride,
+        k_s_stride=k_s_stride,
+        k_h_stride=k_h_stride,
+        k_d_stride=k_d_stride,
+        v_s_stride=v_s_stride,
+        v_h_stride=v_h_stride,
+        v_d_stride=v_d_stride,
+    )
+    return PythonObject(None)
+
+
+def flash_attention_fwd_bf16_d128_causal_bhsd(
+    mut py_self: PythonObject,
+    mut args: PythonObject,
+) raises -> PythonObject:
+    """Dense causal d128 fwd, BHSD-native: Q/K/V/O TMA descriptors address
+    the PUBLIC contiguous (B, H, S, D) layout directly (viewed as
+    (B*H, S, D) planes), skipping the BTHD materialization the dense
+    entry point above requires. See fa4_fwd_kernel.mojo/fa4_fwd_launch.mojo
+    ``bhsd``/``bhsd_qkv`` comptime params."""
+    var q_addr = Int(py=args[0])
+    var k_addr = Int(py=args[1])
+    var v_addr = Int(py=args[2])
+    var out_addr = Int(py=args[3])
+    var lse_addr = Int(py=args[4])
+    var batch = Int(py=args[5])
+    var seqlen = Int(py=args[6])
+    var nheads = Int(py=args[7])
+    var softmax_scale = Float32(py=args[8])
+    var ctx_addr = Int(py=args[9])
+
+    _check_bhsd_args(batch, seqlen, nheads, q_addr, k_addr, v_addr, out_addr)
+
+    launch_fwd_fa4[
+        DType.bfloat16,
+        128,
+        False,
+        True,
+        1,
+        False,
+        False,
+        False,
+        0,
+        bhsd_qkv=True,
+    ](
+        batch,
+        seqlen,
+        nheads,
+        softmax_scale,
+        q_addr,
+        k_addr,
+        v_addr,
+        out_addr,
+        lse_addr,
+        0,
+        ctx_addr,
+    )
+    return PythonObject(None)
+
+
+def flash_attention_fwd_f16_d128_causal_bhsd(
+    mut py_self: PythonObject,
+    mut args: PythonObject,
+) raises -> PythonObject:
+    """Same BHSD-native dense causal d128 fwd as the bf16 entry point
+    above, only the comptime ``dtype`` differs."""
+    var q_addr = Int(py=args[0])
+    var k_addr = Int(py=args[1])
+    var v_addr = Int(py=args[2])
+    var out_addr = Int(py=args[3])
+    var lse_addr = Int(py=args[4])
+    var batch = Int(py=args[5])
+    var seqlen = Int(py=args[6])
+    var nheads = Int(py=args[7])
+    var softmax_scale = Float32(py=args[8])
+    var ctx_addr = Int(py=args[9])
+
+    _check_bhsd_args(batch, seqlen, nheads, q_addr, k_addr, v_addr, out_addr)
+
+    launch_fwd_fa4[
+        DType.float16,
+        128,
+        False,
+        True,
+        1,
+        False,
+        False,
+        False,
+        0,
+        bhsd_qkv=True,
+    ](
+        batch,
+        seqlen,
+        nheads,
+        softmax_scale,
+        q_addr,
+        k_addr,
+        v_addr,
+        out_addr,
+        lse_addr,
+        0,
+        ctx_addr,
+    )
+    return PythonObject(None)
+
+
+def flash_attention_bwd_bf16_d128_causal_strided_qkv(
+    mut py_self: PythonObject,
+    mut args: PythonObject,
+) raises -> PythonObject:
+    """Zero-copy bwd: Q/K/V are strided (B, S, H, 128) views described
+    by per-tensor runtime element strides (b, s, h, d); out/dout/lse,
+    the dq/dk/dv outputs and all scratch keep the contiguous layouts
+    of the dense entry point."""
+    var q_addr = Int(py=args[0])
+    var q_b_stride = Int(py=args[1])
+    var q_s_stride = Int(py=args[2])
+    var q_h_stride = Int(py=args[3])
+    var q_d_stride = Int(py=args[4])
+    var k_addr = Int(py=args[5])
+    var k_b_stride = Int(py=args[6])
+    var k_s_stride = Int(py=args[7])
+    var k_h_stride = Int(py=args[8])
+    var k_d_stride = Int(py=args[9])
+    var v_addr = Int(py=args[10])
+    var v_b_stride = Int(py=args[11])
+    var v_s_stride = Int(py=args[12])
+    var v_h_stride = Int(py=args[13])
+    var v_d_stride = Int(py=args[14])
+    var out_addr = Int(py=args[15])
+    var dout_addr = Int(py=args[16])
+    var lse_addr = Int(py=args[17])
+    var dq_addr = Int(py=args[18])
+    var dk_addr = Int(py=args[19])
+    var dv_addr = Int(py=args[20])
+    var dpsum_addr = Int(py=args[21])
+    var lse_log2_addr = Int(py=args[22])
+    var dq_accum_addr = Int(py=args[23])
+    var batch = Int(py=args[24])
+    var seqlen = Int(py=args[25])
+    var nheads = Int(py=args[26])
+    var softmax_scale = Float32(py=args[27])
+    var ctx_addr = Int(py=args[28])
+
+    # The whole layout contract is validated up front so preprocess
+    # never launches for an unsupported layout.
+    _check_strided_qkv_args(batch, seqlen, nheads)
+    _check_strided_qkv_layout(
+        "q",
+        q_addr,
+        q_b_stride,
+        q_s_stride,
+        q_h_stride,
+        q_d_stride,
+        seqlen,
+        nheads,
+        128,
+    )
+    _check_strided_qkv_layout(
+        "k",
+        k_addr,
+        k_b_stride,
+        k_s_stride,
+        k_h_stride,
+        k_d_stride,
+        seqlen,
+        nheads,
+        128,
+    )
+    _check_strided_qkv_layout(
+        "v",
+        v_addr,
+        v_b_stride,
+        v_s_stride,
+        v_h_stride,
+        v_d_stride,
+        seqlen,
+        nheads,
+        128,
+    )
+
+    launch_bwd_preprocess[
+        DType.bfloat16, 128, False, True, 1, False
+    ](
+        batch,
+        seqlen,
+        nheads,
+        out_addr,
+        dout_addr,
+        lse_addr,
+        dpsum_addr,
+        lse_log2_addr,
+        dq_accum_addr,
+        0,
+        0,
+        0,
+        ctx_addr,
+    )
+    launch_bwd_main[
+        DType.bfloat16,
+        128,
+        False,
+        True,
+        1,
+        False,
+        False,
+        0,
+        strided_qkv=True,
+    ](
+        batch,
+        seqlen,
+        nheads,
+        softmax_scale,
+        q_addr,
+        k_addr,
+        v_addr,
+        dout_addr,
+        dk_addr,
+        dv_addr,
+        lse_log2_addr,
+        dpsum_addr,
+        dq_accum_addr,
+        0,
+        ctx_addr,
+        q_s_stride=q_s_stride,
+        q_h_stride=q_h_stride,
+        q_d_stride=q_d_stride,
+        k_s_stride=k_s_stride,
+        k_h_stride=k_h_stride,
+        k_d_stride=k_d_stride,
+        v_s_stride=v_s_stride,
+        v_h_stride=v_h_stride,
+        v_d_stride=v_d_stride,
+    )
+    launch_bwd_convert[
+        DType.bfloat16, 128, False, True, 1, False
+    ](
+        batch,
+        seqlen,
+        nheads,
+        softmax_scale,
+        dq_accum_addr,
+        dq_addr,
+        0,
+        ctx_addr,
+    )
+    return PythonObject(None)
+
+
+def flash_attention_bwd_f16_d128_causal_strided_qkv(
+    mut py_self: PythonObject,
+    mut args: PythonObject,
+) raises -> PythonObject:
+    """Same zero-copy strided bwd as the bf16 entry point above (see its
+    docstring for the layout contract), only the comptime ``dtype`` differs.
+    """
+    var q_addr = Int(py=args[0])
+    var q_b_stride = Int(py=args[1])
+    var q_s_stride = Int(py=args[2])
+    var q_h_stride = Int(py=args[3])
+    var q_d_stride = Int(py=args[4])
+    var k_addr = Int(py=args[5])
+    var k_b_stride = Int(py=args[6])
+    var k_s_stride = Int(py=args[7])
+    var k_h_stride = Int(py=args[8])
+    var k_d_stride = Int(py=args[9])
+    var v_addr = Int(py=args[10])
+    var v_b_stride = Int(py=args[11])
+    var v_s_stride = Int(py=args[12])
+    var v_h_stride = Int(py=args[13])
+    var v_d_stride = Int(py=args[14])
+    var out_addr = Int(py=args[15])
+    var dout_addr = Int(py=args[16])
+    var lse_addr = Int(py=args[17])
+    var dq_addr = Int(py=args[18])
+    var dk_addr = Int(py=args[19])
+    var dv_addr = Int(py=args[20])
+    var dpsum_addr = Int(py=args[21])
+    var lse_log2_addr = Int(py=args[22])
+    var dq_accum_addr = Int(py=args[23])
+    var batch = Int(py=args[24])
+    var seqlen = Int(py=args[25])
+    var nheads = Int(py=args[26])
+    var softmax_scale = Float32(py=args[27])
+    var ctx_addr = Int(py=args[28])
+
+    # The whole layout contract is validated up front so preprocess
+    # never launches for an unsupported layout.
+    _check_strided_qkv_args(batch, seqlen, nheads)
+    _check_strided_qkv_layout(
+        "q",
+        q_addr,
+        q_b_stride,
+        q_s_stride,
+        q_h_stride,
+        q_d_stride,
+        seqlen,
+        nheads,
+        128,
+    )
+    _check_strided_qkv_layout(
+        "k",
+        k_addr,
+        k_b_stride,
+        k_s_stride,
+        k_h_stride,
+        k_d_stride,
+        seqlen,
+        nheads,
+        128,
+    )
+    _check_strided_qkv_layout(
+        "v",
+        v_addr,
+        v_b_stride,
+        v_s_stride,
+        v_h_stride,
+        v_d_stride,
+        seqlen,
+        nheads,
+        128,
+    )
+
+    launch_bwd_preprocess[
+        DType.float16, 128, False, True, 1, False
+    ](
+        batch,
+        seqlen,
+        nheads,
+        out_addr,
+        dout_addr,
+        lse_addr,
+        dpsum_addr,
+        lse_log2_addr,
+        dq_accum_addr,
+        0,
+        0,
+        0,
+        ctx_addr,
+    )
+    launch_bwd_main[
+        DType.float16,
+        128,
+        False,
+        True,
+        1,
+        False,
+        False,
+        0,
+        strided_qkv=True,
+    ](
+        batch,
+        seqlen,
+        nheads,
+        softmax_scale,
+        q_addr,
+        k_addr,
+        v_addr,
+        dout_addr,
+        dk_addr,
+        dv_addr,
+        lse_log2_addr,
+        dpsum_addr,
+        dq_accum_addr,
+        0,
+        ctx_addr,
+        q_s_stride=q_s_stride,
+        q_h_stride=q_h_stride,
+        q_d_stride=q_d_stride,
+        k_s_stride=k_s_stride,
+        k_h_stride=k_h_stride,
+        k_d_stride=k_d_stride,
+        v_s_stride=v_s_stride,
+        v_h_stride=v_h_stride,
+        v_d_stride=v_d_stride,
+    )
+    launch_bwd_convert[
+        DType.float16, 128, False, True, 1, False
+    ](
+        batch,
+        seqlen,
+        nheads,
+        softmax_scale,
+        dq_accum_addr,
+        dq_addr,
+        0,
+        ctx_addr,
+    )
+    return PythonObject(None)
+
+
 @export
 def PyInit_fa4_ops() abi("C") -> PythonObject:
     try:
@@ -1014,6 +1879,36 @@ def PyInit_fa4_ops() abi("C") -> PythonObject:
         )
         module.def_py_function[flash_attention_bwd_f16_d64_causal_strided_qkv](
             "flash_attention_bwd_f16_d64_causal_strided_qkv"
+        )
+        module.def_py_function[flash_attention_fwd_bf16_d128_causal](
+            "flash_attention_fwd_bf16_d128_causal"
+        )
+        module.def_py_function[flash_attention_fwd_f16_d128_causal](
+            "flash_attention_fwd_f16_d128_causal"
+        )
+        module.def_py_function[flash_attention_bwd_bf16_d128_causal](
+            "flash_attention_bwd_bf16_d128_causal"
+        )
+        module.def_py_function[flash_attention_bwd_f16_d128_causal](
+            "flash_attention_bwd_f16_d128_causal"
+        )
+        module.def_py_function[flash_attention_fwd_bf16_d128_causal_strided_qkv](
+            "flash_attention_fwd_bf16_d128_causal_strided_qkv"
+        )
+        module.def_py_function[flash_attention_fwd_f16_d128_causal_strided_qkv](
+            "flash_attention_fwd_f16_d128_causal_strided_qkv"
+        )
+        module.def_py_function[flash_attention_fwd_bf16_d128_causal_bhsd](
+            "flash_attention_fwd_bf16_d128_causal_bhsd"
+        )
+        module.def_py_function[flash_attention_fwd_f16_d128_causal_bhsd](
+            "flash_attention_fwd_f16_d128_causal_bhsd"
+        )
+        module.def_py_function[flash_attention_bwd_bf16_d128_causal_strided_qkv](
+            "flash_attention_bwd_bf16_d128_causal_strided_qkv"
+        )
+        module.def_py_function[flash_attention_bwd_f16_d128_causal_strided_qkv](
+            "flash_attention_bwd_f16_d128_causal_strided_qkv"
         )
         return module.finalize()
     except error:

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -6497,7 +6497,11 @@ def _fa4_16bit_d64_causal_inputs(
     gate and the launch cache below; f16 only needs its own RS wgmma
     emitter because the stdlib's register-operand overload is hardcoded
     bf16 (see ``fa4_wgmma_f16.mojo``). Q/K/V must all share one dtype from
-    this set -- no bf16/f16 mixing.
+    this set -- no bf16/f16 mixing. ``head_dim`` is a compile-time regime,
+    not a free runtime dimension (AGENTS.md rule 4): only 64 (GPT-2-class)
+    and 128 (Llama-class) have an instantiated kernel + exported Mojo
+    symbol (``fa4_ops.mojo``); any other head_dim declines here and falls
+    to the math decomposition.
     """
     q = _t(query)
     k = _t(key)
@@ -6525,7 +6529,13 @@ def _fa4_16bit_d64_causal_inputs(
     ):
         return None
     batch, heads, seqlen, head_dim = q._shape
-    if batch <= 0 or heads <= 0 or seqlen <= 0 or seqlen % 128 != 0 or head_dim != 64:
+    if (
+        batch <= 0
+        or heads <= 0
+        or seqlen <= 0
+        or seqlen % 128 != 0
+        or head_dim not in (64, 128)
+    ):
         return None
     if scale is not None and (
         not isinstance(scale, int | float)
@@ -6561,11 +6571,11 @@ def _fa4_strided_bthd_layout(tensor) -> bool:
         or seqlen <= 0
         or heads <= 0
         or seqlen % 128 != 0
-        or head_dim != 64
+        or head_dim not in (64, 128)
         or min(b_stride, s_stride, h_stride, d_stride) <= 0
         or d_stride != 1
-        or h_stride != 64
-        or s_stride < heads * 64
+        or h_stride != head_dim
+        or s_stride < heads * head_dim
         or b_stride != seqlen * s_stride
         or tensor._ptr % 16 != 0
     ):
@@ -6621,6 +6631,26 @@ def _fa4_prepare_qkv_bridge(q_native, k_native, v_native):
     return qkv, False
 
 
+def _fa4_symbol(
+    fa4_ops: object, direction: str, dtype: DType, head_dim: int, variant: str = ""
+) -> object:
+    """Resolve one FA4 Mojo-exported entry point by name.
+
+    Mirrors the ``flash_attention_{direction}_{bf16,f16}_d{64,128}_causal{variant}``
+    naming convention ``PyInit_fa4_ops`` registers (``fa4_ops.mojo``) --
+    allocation and symbol selection are both derived from ``head_dim`` at
+    the call site rather than hardcoded, so d64 and d128 share every
+    dispatcher below (``variant`` is ``""`` for the dense entry point,
+    ``"_strided_qkv"`` or ``"_bhsd"`` for the zero-copy ones). ``fa4_ops``
+    is typed ``object`` rather than ``ModuleType``: host-only tests pass a
+    ``SimpleNamespace`` double here instead of the real compiled extension
+    module.
+    """
+    dtype_suffix = "bf16" if dtype == DType.bfloat16 else "f16"
+    name = f"flash_attention_{direction}_{dtype_suffix}_d{head_dim}_causal{variant}"
+    return getattr(fa4_ops, name)
+
+
 def fast_fa4_16bit_d64_causal_forward(
     query,
     key,
@@ -6631,8 +6661,8 @@ def fast_fa4_16bit_d64_causal_forward(
     scale=None,
     enable_gqa=False,
 ):
-    """Run vendored FA4 (bf16 or f16) and return output/LSE plus saved
-    physical inputs.
+    """Run vendored FA4 (bf16 or f16, head_dim 64 or 128) and return
+    output/LSE plus saved physical inputs.
 
     Loading the bridge happens before materialization or allocation, so a
     packaging/compiler error cannot leave unnecessary device work queued.
@@ -6663,11 +6693,7 @@ def fast_fa4_16bit_d64_causal_forward(
         out_native = _alloc((batch, heads, seqlen, head_dim), qkv_dtype, q._device)
         logsumexp = _alloc((batch, heads, seqlen), DType.float32, q._device)
         scale_value = float(scale) if scale is not None else 1.0 / math.sqrt(head_dim)
-        forward_fn = (
-            fa4_ops.flash_attention_fwd_bf16_d64_causal_bhsd
-            if qkv_dtype == DType.bfloat16
-            else fa4_ops.flash_attention_fwd_f16_d64_causal_bhsd
-        )
+        forward_fn = _fa4_symbol(fa4_ops, "fwd", qkv_dtype, head_dim, "_bhsd")
         _device_call(
             forward_fn,
             q._ptr,
@@ -6699,11 +6725,7 @@ def fast_fa4_16bit_d64_causal_forward(
     logsumexp = _alloc((batch, heads, seqlen), DType.float32, q._device)
     scale_value = float(scale) if scale is not None else 1.0 / math.sqrt(head_dim)
     if use_strided_qkv:
-        forward_fn = (
-            fa4_ops.flash_attention_fwd_bf16_d64_causal_strided_qkv
-            if qkv_dtype == DType.bfloat16
-            else fa4_ops.flash_attention_fwd_f16_d64_causal_strided_qkv
-        )
+        forward_fn = _fa4_symbol(fa4_ops, "fwd", qkv_dtype, head_dim, "_strided_qkv")
         _device_call(
             forward_fn,
             q_native._ptr,
@@ -6722,11 +6744,7 @@ def fast_fa4_16bit_d64_causal_forward(
             keepalive=(q_native, k_native, v_native, out_native, logsumexp),
         )
     else:
-        forward_fn = (
-            fa4_ops.flash_attention_fwd_bf16_d64_causal
-            if qkv_dtype == DType.bfloat16
-            else fa4_ops.flash_attention_fwd_f16_d64_causal
-        )
+        forward_fn = _fa4_symbol(fa4_ops, "fwd", qkv_dtype, head_dim)
         _device_call(
             forward_fn,
             q_native._ptr,
@@ -6785,11 +6803,7 @@ def fast_fa4_16bit_d64_causal_backward(
         (batch * heads * seqlen_padded * head_dim,), DType.float32, q_native._device
     )
     if use_strided_qkv:
-        backward_fn = (
-            fa4_ops.flash_attention_bwd_bf16_d64_causal_strided_qkv
-            if qkv_dtype == DType.bfloat16
-            else fa4_ops.flash_attention_bwd_f16_d64_causal_strided_qkv
-        )
+        backward_fn = _fa4_symbol(fa4_ops, "bwd", qkv_dtype, head_dim, "_strided_qkv")
         _device_call(
             backward_fn,
             q_native._ptr,
@@ -6828,11 +6842,7 @@ def fast_fa4_16bit_d64_causal_backward(
             ),
         )
     else:
-        backward_fn = (
-            fa4_ops.flash_attention_bwd_bf16_d64_causal
-            if qkv_dtype == DType.bfloat16
-            else fa4_ops.flash_attention_bwd_f16_d64_causal
-        )
+        backward_fn = _fa4_symbol(fa4_ops, "bwd", qkv_dtype, head_dim)
         _device_call(
             backward_fn,
             q_native._ptr,

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -6575,6 +6575,27 @@ def _fa4_strided_bthd_layout(tensor) -> bool:
     )
 
 
+def _fa4_bhsd_layout(tensor) -> bool:
+    """Whether the PUBLIC (B, H, S, D) tensor is eligible for the
+    BHSD-native TMA path -- no BTHD materialization needed at all.
+
+    TMA descriptor creation over the (B*H, S, D) plane view requires the
+    exact row-major (B, H, S, D) contiguity the aten op naturally
+    produces, plus a 16-byte-aligned base pointer. A sliced/offset view
+    can be fully contiguous yet still violate the latter, so both are
+    checked here -- mirroring the alignment requirement
+    ``_fa4_strided_bthd_layout`` enforces for the strided BTHD ABI.
+    """
+    return (
+        tensor is not None
+        and tensor._dtype in (DType.bfloat16, DType.float16)
+        and tensor._itemsize == tensor._dtype.size_in_bytes
+        and len(tensor._shape) == 4
+        and tensor._is_contiguous
+        and tensor._ptr % 16 == 0
+    )
+
+
 def _fa4_native_bthd(tensor):
     """Expose public BHTD storage as FA4-native BTHD, copying if required."""
     physical = fast_aten_transpose(tensor, 1, 2)
@@ -6627,6 +6648,42 @@ def fast_fa4_16bit_d64_causal_forward(
     fa4_ops = load_fa4_ops()
     q, k, v = inputs
     qkv_dtype = q._dtype
+    batch, heads, seqlen, head_dim = q._shape
+    if _fa4_bhsd_layout(q) and _fa4_bhsd_layout(k) and _fa4_bhsd_layout(v):
+        # PUBLIC contiguous (B, H, S, D), 16-byte-aligned base pointers:
+        # TMA descriptors address this layout directly (viewed as
+        # (B*H, S, D) planes), so no BTHD materialization
+        # (fast_aten_transpose + copy, ~3 gather copies removed) is
+        # needed for Q/K/V, and the output is allocated in this same
+        # contiguous layout and returned as-is (no transpose-back
+        # either). "q_native"/"k_native"/"v_native" below is just
+        # ``q``/``k``/``v`` themselves -- they are what the kernel
+        # actually consumed, matching what the strided/dense branches
+        # return for their own materialized forms.
+        out_native = _alloc((batch, heads, seqlen, head_dim), qkv_dtype, q._device)
+        logsumexp = _alloc((batch, heads, seqlen), DType.float32, q._device)
+        scale_value = float(scale) if scale is not None else 1.0 / math.sqrt(head_dim)
+        forward_fn = (
+            fa4_ops.flash_attention_fwd_bf16_d64_causal_bhsd
+            if qkv_dtype == DType.bfloat16
+            else fa4_ops.flash_attention_fwd_f16_d64_causal_bhsd
+        )
+        _device_call(
+            forward_fn,
+            q._ptr,
+            k._ptr,
+            v._ptr,
+            out_native._ptr,
+            logsumexp._ptr,
+            batch,
+            seqlen,
+            heads,
+            scale_value,
+            _ctx_ptr(q._device),
+            keepalive=(q, k, v, out_native, logsumexp),
+        )
+        return out_native, logsumexp, q, k, v
+
     q_native = _fa4_native_bthd(q)
     k_native = _fa4_native_bthd(k)
     v_native = _fa4_native_bthd(v)
@@ -6637,7 +6694,6 @@ def fast_fa4_16bit_d64_causal_forward(
         return NOT_HANDLED
     (q_native, k_native, v_native), use_strided_qkv = prepared
 
-    batch, heads, seqlen, head_dim = q._shape
     physical_shape = (batch, seqlen, heads, head_dim)
     out_native = _alloc(physical_shape, qkv_dtype, q._device)
     logsumexp = _alloc((batch, heads, seqlen), DType.float32, q._device)
@@ -7218,15 +7274,20 @@ def fast_aten__scaled_dot_product_flash_attention_backward(
         )
         if recomputed is NOT_HANDLED:
             return NOT_HANDLED
-        recomputed_output, recomputed_lse, q_native, k_native, v_native = recomputed
+        recomputed_output, recomputed_lse, _, _, _ = recomputed
         output = recomputed_output
         lse = recomputed_lse
-    else:
-        q_native = _fa4_native_bthd(q)
-        k_native = _fa4_native_bthd(k)
-        v_native = _fa4_native_bthd(v)
-        if q_native is None or k_native is None or v_native is None:
-            return NOT_HANDLED
+    # Always re-materialize Q/K/V natives from the public tensors rather than
+    # trusting forward's returned "natives": the BHSD-eligible fast path
+    # above returns the PUBLIC q/k/v untouched (that's the whole point --
+    # no BTHD copy), which is the wrong shape/layout for the bwd kernels'
+    # BTHD-only ABI, so backward must derive its own regardless of which
+    # forward path (if any) ran above.
+    q_native = _fa4_native_bthd(q)
+    k_native = _fa4_native_bthd(k)
+    v_native = _fa4_native_bthd(v)
+    if q_native is None or k_native is None or v_native is None:
+        return NOT_HANDLED
     # The lower ATen backward accepts arbitrary shape-compatible views, while
     # FA4 consumes LSE as contiguous (B, H, S).  Keep the generated/high-level
     # path zero-copy and materialize only a genuinely strided direct caller.

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -6488,6 +6488,8 @@ def _fa4_16bit_d64_causal_inputs(
     is_causal=False,
     scale=None,
     enable_gqa=False,
+    *,
+    allow_any_seqlen: bool = False,
 ):
     """Return eligible public BHTD inputs (bf16 or f16) without doing any
     device work.
@@ -6502,6 +6504,17 @@ def _fa4_16bit_d64_causal_inputs(
     and 128 (Llama-class) have an instantiated kernel + exported Mojo
     symbol (``fa4_ops.mojo``); any other head_dim declines here and falls
     to the math decomposition.
+
+    ``allow_any_seqlen`` lifts the ``seqlen % 128 == 0`` restriction down
+    to ``seqlen > 0``. Default ``False`` keeps every existing caller's
+    contract byte-identical -- in particular the two backward-adjacent call
+    sites (the autograd wrapper's ``needs_backward`` dispatch decision and
+    the flash backward op's own eligibility check), where the bwd tile
+    machinery has never been proven to handle a partial last tile and a
+    wrong answer there would be a silently wrong gradient. Only
+    ``fast_fa4_16bit_d64_causal_forward`` passes ``True``, and only for
+    inputs it goes on to route through the BHSD-native path -- see the
+    per-route check there.
     """
     q = _t(query)
     k = _t(key)
@@ -6529,13 +6542,8 @@ def _fa4_16bit_d64_causal_inputs(
     ):
         return None
     batch, heads, seqlen, head_dim = q._shape
-    if (
-        batch <= 0
-        or heads <= 0
-        or seqlen <= 0
-        or seqlen % 128 != 0
-        or head_dim not in (64, 128)
-    ):
+    seqlen_ok = seqlen > 0 and (allow_any_seqlen or seqlen % 128 == 0)
+    if batch <= 0 or heads <= 0 or not seqlen_ok or head_dim not in (64, 128):
         return None
     if scale is not None and (
         not isinstance(scale, int | float)
@@ -6666,9 +6674,25 @@ def fast_fa4_16bit_d64_causal_forward(
 
     Loading the bridge happens before materialization or allocation, so a
     packaging/compiler error cannot leave unnecessary device work queued.
+
+    Seqlen eligibility is per-route (PR #391 review thread): the BHSD-native
+    descriptor path zero-fills/clamps a partial last tile at both d64 and
+    d128 (proven by ``test_fa4_bhsd_d64_direct_partial_tail_block`` and the
+    d128 sibling), so it accepts any ``seqlen >= 1``. The legacy strided-BTHD
+    and dense-copy routes below predate that tail machinery and may assume
+    full BM/BN tiles, so they still require ``seqlen % 128 == 0`` until
+    someone proves otherwise for them specifically.
     """
     inputs = _fa4_16bit_d64_causal_inputs(
-        query, key, value, attn_mask, dropout_p, is_causal, scale, enable_gqa
+        query,
+        key,
+        value,
+        attn_mask,
+        dropout_p,
+        is_causal,
+        scale,
+        enable_gqa,
+        allow_any_seqlen=True,
     )
     if inputs is None:
         return NOT_HANDLED
@@ -6679,7 +6703,14 @@ def fast_fa4_16bit_d64_causal_forward(
     q, k, v = inputs
     qkv_dtype = q._dtype
     batch, heads, seqlen, head_dim = q._shape
-    if _fa4_bhsd_layout(q) and _fa4_bhsd_layout(k) and _fa4_bhsd_layout(v):
+    bhsd_eligible = _fa4_bhsd_layout(q) and _fa4_bhsd_layout(k) and _fa4_bhsd_layout(v)
+    if seqlen % 128 != 0 and not bhsd_eligible:
+        # Partial tiles are unproven outside the BHSD-native path (see the
+        # docstring above) -- decline rather than risk the untested legacy
+        # tail behavior. A caller that needs this seqlen on a non-BHSD
+        # layout falls back to the math decomposition.
+        return NOT_HANDLED
+    if bhsd_eligible:
         # PUBLIC contiguous (B, H, S, D), 16-byte-aligned base pointers:
         # TMA descriptors address this layout directly (viewed as
         # (B*H, S, D) planes), so no BTHD materialization
@@ -7232,7 +7263,16 @@ def fast_aten__scaled_dot_product_flash_attention_backward(
     *,
     scale=None,
 ):
-    """Dense lower-op autograd bridge for the vendored bf16/f16 FA4 kernel."""
+    """Dense lower-op autograd bridge for the vendored bf16/f16 FA4 kernel.
+
+    Deliberately omits ``allow_any_seqlen=True``: this is the actual bwd
+    tile machinery, unproven on a partial last tile, so it declines an odd
+    seqlen here regardless of how forward was reached (a direct call to the
+    lower ``aten::_scaled_dot_product_flash_attention`` op with grad-needing
+    inputs and an odd seqlen makes it this far -- forward tolerates it via
+    BHSD, but backward must not, so this raises NotImplementedError rather
+    than silently mishandling the tail).
+    """
     inputs = _fa4_16bit_d64_causal_inputs(
         query, key, value, None, dropout_p, is_causal, scale, False
     )

--- a/torch_mojo_backend/mojo_device/mojo_device_autograd.py
+++ b/torch_mojo_backend/mojo_device/mojo_device_autograd.py
@@ -581,6 +581,13 @@ def _scaled_dot_product_attention_autograd(
     # and backward pair. Dispatch through it so generated autograd owns the
     # saves, version checks, and backward call; retain the custom Function only
     # for the generic math/dropout fallback, which has no native backward op.
+    #
+    # This call intentionally omits allow_any_seqlen=True: the bwd tile
+    # machinery has never been proven to handle a partial last tile (only
+    # the BHSD-native forward has), so when a backward pass is coming this
+    # gate must still require seqlen % 128 == 0. An odd seqlen with grad
+    # needed simply falls through to the math-decomposition Function below
+    # instead of the native flash op pair.
     if (
         needs_backward
         and aten_fast._fa4_16bit_d64_causal_inputs(


### PR DESCRIPTION
## Diagnosis

FA4 forward on H100 was 1.36-1.48x slower than stock PyTorch flash attention,
even though the FA4 kernel itself already matched or beat stock
kernel-vs-kernel on every measured shape. The gap was three
`data_movement_ops__run_gather_k` copies per call: `_fa4_native_bthd` in
`aten_fast.py` materializes Q/K/V from the public contiguous `(B, H, S, D)`
layout into `(B, S, H, D)` because the TMA descriptor path only accepted
`h_stride==64` layouts. Stock flash (FA2/FA3) consumes strided BHSD
directly — copies are 30-45% of the op, running at ~1.67 TB/s (already near
DRAM speed, not optimizable, only removable).

## The fix: a BHSD-native TMA descriptor variant

Added a `bhsd` comptime kernel param (`fa4_fwd_kernel.mojo`) and a matching
`bhsd_qkv` launch param (`fa4_fwd_launch.mojo`): Q/K/V/O TMA descriptors
address the **public** contiguous `(B, H, S, D)` tensor directly, viewed as
`(B*H, S, D)` planes — planes are the TMA outer dim and `S` is its own dim,
so the existing `BM=192` tail-tile zero-fill-on-load / clamp-on-store logic
handles every plane edge correctly with no BTHD materialization. This is
**FlashAttention-3's structure** (head stride is just another gmem stride);
none of FA3's scheduling machinery was needed since the existing FA4
pingpong/warp-specialized schedule already runs at stock parity. Both
params are additive with `False` defaults — every pre-existing instantiation
takes the exact same code path as before. Both bf16 and f16 are
instantiated (`flash_attention_fwd_{bf16,f16}_d64_causal_bhsd` in
`fa4_ops.mojo`), matching the existing bf16/f16 export-pair convention from
#386.

`fast_fa4_16bit_d64_causal_forward` in `aten_fast.py` now takes this path
whenever Q/K/V are all eligible (`_fa4_bhsd_layout`, see next section),
allocating the output directly in the same contiguous `(B, H, S, D)` layout
and returning it as-is — no transpose-back either. Ineligible views
(non-contiguous, or contiguous-but-misaligned) fall through to the existing
copy/strided paths unchanged.

## The alignment gate (review MUST-FIX)

Agent A2's review flagged that the Python-side eligibility gate must check
16-byte base-pointer alignment in addition to contiguity, since TMA
descriptor creation requires it and a sliced/offset bf16/f16 view can be
fully contiguous yet still violate it. `_fa4_bhsd_layout` in `aten_fast.py`
checks both, mirroring the existing `_fa4_strided_bthd_layout` precedent
for the strided BTHD ABI:

```python
return (
    tensor is not None
    and tensor._dtype in (DType.bfloat16, DType.float16)
    and tensor._itemsize == tensor._dtype.size_in_bytes
    and len(tensor._shape) == 4
    and tensor._is_contiguous
    and tensor._ptr % 16 == 0
)
```

Covered by three tests, one against a real device tensor:
- `tests/test_fa4_host_wiring.py::test_fa4_bhsd_layout_requires_contiguity_and_16_byte_alignment`
- `tests/test_fa4_host_wiring.py::test_fa4_offset_view_public_layout_copies_and_uses_contiguous_fallback` (mocked, repurposed from the pre-existing "unsupported public layout" test, which is what a plain 16-byte-aligned contiguous tensor now *is* eligible for)
- `tests/test_eager_kernels.py::test_fa4_bhsd_gate_rejects_misaligned_offset_view` (real H100 tensor: `storage[1:].view(...)`, spies confirm the dense bridge runs and the bhsd bridge never does, output still matches the CPU reference)

## Backward: no interaction

No backward kernel/launch changes. Verified by reading
`fast_aten__scaled_dot_product_flash_attention_backward`: PyTorch's
generated autograd formula for `_scaled_dot_product_flash_attention` saves
the **public** `query/key/value/output/logsumexp` tensors (not whatever
forward's `q_native/k_native/v_native` return values were), and backward
always re-derives its own BTHD natives from those public tensors via
`_fa4_native_bthd`. I also simplified backward's rare
SavedVariable-recompute fallback branch (triggered when PyTorch's autograd
returns `output`/`logsumexp` as bare tensors without the payload) to always
re-derive natives independently rather than trusting forward's returned
tuple — the new BHSD fast path returns the public q/k/v *unchanged* (that's
the entire point, no BTHD copy), which is the wrong shape for the
backward-only BTHD ABI, so this path can no longer assume forward already
built usable natives.

One real, documented nuance: backward's `_fa4_native_bthd(out)` used to get
a free transposed view of the physical BTHD `out` (double-transpose
cancels); now that `out` from the BHSD fast path is already public-shaped
and contiguous, backward pays one `O` copy (~15us on P0) where forward
used to pay 3 copies (~45us) — net win in training too. `bf16` backward's
recorded baseline (0.716) didn't move outside the 8% dead band in this
PR's measurement, confirming zero backward regression.

## Per-node before/after (H100 PCIe, pinned 1395MHz, device time, B8H12S1024D64)

| aten op (dtype) | before (recorded baseline) | after (this PR) |
|---|---|---|
| `_scaled_dot_product_flash_attention` (bf16) | 1.365 | **0.888** |
| `_scaled_dot_product_flash_attention` (f16) | *(not previously recorded)* | **0.883** |
| `_scaled_dot_product_efficient_attention` (bf16) | 0.724 | **0.477** |
| `_scaled_dot_product_efficient_attention` (f16) | 3.461 | **0.478** |
| `scaled_dot_product_attention` (composite, bf16) | 2.255 | **1.468** |
| `scaled_dot_product_attention` (composite, f16) | 11.073 | **1.464** |
| `_scaled_dot_product_flash_attention_backward` (bf16) | 0.716 | not flagged as changed (within the +/-8% dead band; passed both runs, no update written) |
| `_scaled_dot_product_flash_attention_backward` (f16) | *(not previously recorded)* | **0.764** |

`_scaled_dot_product_flash_attention` and `_scaled_dot_product_efficient_attention`
both clear the 10% bar. All numbers recorded via
`uv run pytest benchmarks/test_attention.py --update-baselines`;
`benchmarks/baselines.html` is included in this PR, touching only these 7
entries (`git diff --stat`: 23 insertions, 5 deletions).

Cross-checked against the harness's pure-Mojo numbers in
`/scratch/fa4-fwd-harness/NOTES.md` (P0 shape, streamed device time,
checks on): base(BTHD kernel) 98.0us, candidate(BHSD) 96.1us, stock
109.8us, cand/stock 0.875 — this PR's end-to-end op-level 0.888 (bf16)
matches that kernel-level number closely once ~9us of Python/launch
overhead on a 97us op is folded back in.

## Phase-2 gap (documented, not fixed here)

The composite `scaled_dot_product_attention` node improves a lot (bf16:
2.255 -> 1.468; f16: 11.073 -> 1.464) but stays above the 1.10 bar: stock's
leg there is cuDNN's fused attention kernel, not `flash_fwd_kernel`, and
closing that gap is unrelated to FA4's own efficiency (FA4 itself is
already within 10% of stock's `_scaled_dot_product_flash_attention` path).
Out of scope for this PR.

## Blast radius (`scripts/compare_kernel_asm.py`)

- **sm_90a**: `fa4_ops` module goes from 10 to 12 kernels. All 6 backward
  kernels (preprocess/main/convert x2 dtypes) are byte-identical (exact
  mangled-hash match, not just masked-hash). All 4 pre-existing forward
  kernels (dense/strided x2 dtypes) each differ by exactly one cosmetic
  token — an LLVM module-scope `extern_ptr_syml_N` symbol ordinal that
  shifted by +2 because the new bhsd launch call site sits earlier in
  `fa4_fwd_launch.mojo` — confirmed by masking the mangling hash and diffing
  each pair: 12 lines differ, all on that one token, zero instruction
  changes (verified for all 4 pairs, matched by exact line count and
  content). The remaining 2 kernels are the new bf16/f16 bhsd
  instantiations. **Zero functional movement on any pre-existing sm_90a
  kernel.**
- **gfx942**: `fa4_ops` fails to build identically on both pristine
  `upstream/main` and this branch (`error: failed to run the pass manager
  for offload functions`) — FA4 uses Hopper TMA/wgmma intrinsics
  (`max.gpu.host.nvidia.tma`) and has never targeted AMD. **Zero gfx942
  footprint, before and after, identical failure signature.**

## Tests

- `tests/test_fa4_host_wiring.py`: 15 tests, including the new
  `_fa4_bhsd_layout` unit test, the repurposed offset-view fallback test,
  and a new positive-path test proving the bhsd bridge is reached (and the
  old materialize/copy path is *not*) for aligned contiguous public Q/K/V.
- `tests/test_eager_kernels.py`: ported agent A's 7 pure-Mojo edge shapes
  (every `S % BM=192` tail-residue class reachable under the
  `seqlen % 128 == 0` gate) into a real forward+backward SDPA test against
  a CPU fp32 reference, `x2` dtypes = 14 cases, plus the real-GPU
  misaligned-offset-view fallback test.
- Full FA4/SDPA-relevant selection across
  `test_eager_kernels.py`/`test_fa4_host_wiring.py`/`test_aten_functions.py`/
  `test_high_level_ops.py`/`test_mojo_autocast.py`/`test_compiler.py`/
  `test_call_queue.py`/`test_tensor_spec_oom.py`: **113 passed, 8 skipped
  (unrelated pre-existing skips), 0 failed.**
- `benchmarks/test_coverage.py`: 2 passed (op-registration and
  baseline-addressability reconciliation, both GPU-free).
- `uvx pre-commit run --all-files`: clean.

## Credit

The bhsd descriptor structure follows FlashAttention-3's approach of
treating head stride as just another gmem stride rather than a distinct TMA
dimension, applied here to FA4's existing warp-specialized pingpong
schedule with no scheduling changes.

---

## head_dim=128 (Llama-class) follow-up

### Gap

`B1H16S4096D128` (head_dim=128) was declining FA4's `head_dim == 64` gate
for both dtypes and falling all the way to the bmm+softmax decomposition:
composite/efficient SDPA measured **~10.6x / ~3.1x** slower than stock
there — this is exactly [A2 in `docs/optimization_backlog.md`](docs/optimization_backlog.md).

### What changed

The FA4 kernel family turned out to already be comptime-parametric over
`head_dim` in the places that matter: `fa4_fwd_common.mojo` /
`fa4_bwd_common.mojo` already carried BM, MMA-warpgroup count, register
budgets and the backward causal tile_m as `head_dim`-parametric constants
mirroring Tri Dao FA4's own sm90 configs (BM=128 not 192, 2 MMA
warpgroups not 3, bwd causal tile_m=64 not 128) — this was written when
FA4 was first vendored but never exported past `head_dim == 64` while this
PR's own scope stayed narrow. The gap was pure wiring, not a missing
kernel:

- **`fa4_ops.mojo`**: exported the same three forward entry points (dense,
  `_strided_qkv` zero-copy BTHD, `_bhsd` native) and two backward entry
  points (dense, `_strided_qkv`) for `d128`, mirroring the `d64` family
  1:1 for both bf16 and f16 — 10 new `flash_attention_{fwd,bwd}_*_d128_*`
  Python-callable symbols. `_check_strided_qkv_layout` now takes `head_dim`
  as a parameter instead of hardcoding 64 in its `h_stride`/`s_stride`
  checks.
- **`fa4_fwd_launch.mojo`**: widened the `strided_qkv`/`bhsd_qkv` comptime
  asserts from `head_dim == 64` to `(head_dim == 64 or head_dim == 128)`.
  The strided-Q TMA descriptor branch existed only inside the `QO_RANK ==
  4` path (d64's BM=192 rank-4 tail-tile fix); d128 uses `QO_RANK == 3`
  (BM=128 always divides evenly under the `seqlen % 128 == 0` gate, so it
  never needed that fix) and was building a plain, non-strided Q
  descriptor unconditionally — added the missing `comptime if
  strided_qkv:` branch there too, mirroring the pattern K/V already used.
- **`fa4_bwd_launch.mojo`**: widened the matching backward assert; Q/K/V
  descriptor construction in `launch_bwd_main` was already
  `head_dim`-generic (no `QO_RANK`-style branch to extend).
- **`aten_fast.py`**: `_fa4_16bit_d64_causal_inputs` and
  `_fa4_strided_bthd_layout` now accept `head_dim in (64, 128)` (the
  latter's `h_stride`/`s_stride` checks scale with `head_dim` instead of
  a hardcoded 64). `_fa4_bhsd_layout` needed no change — it was already
  `head_dim`-generic. A new `_fa4_symbol()` helper derives the
  `bf16/f16 x d64/d128 x dense/strided/bhsd` Mojo symbol name from
  `head_dim` at each of the 5 call sites that used to hardcode a
  `d64`-suffixed ternary on dtype alone.

Backward is included (not scoped out): `fa4_bwd_common.mojo`'s own
docstring already documented the d128 causal tile_m (64) alongside d64's
(128), so the backward kernel bodies were exported and tested exactly like
forward — no backward-specific tile work was needed.

### Tests

Parametrized the existing FA4 GPU test suite over `head_dim in {64, 128}
x {bf16, f16}` (40 cases total, `tests/test_eager_kernels.py`):

- `test_fa4_causal_gapped_qkv_forward_backward` — nanoGPT-style gapped
  fused-QKV views, strided zero-copy forward+backward.
- `test_fa4_direct_flash_aten_returns_real_logsumexp` — low-level flash op
  LSE/gradient correctness.
- `test_fa4_bhsd_native_forward_backward_matches_reference` — the 7
  BM-tail-residue edge shapes (single m-block, exact multiples, odd
  plane counts, LPT-swizzle-triggering sizes) x head_dim x dtype. At
  d128, BM==128 always divides the `seqlen % 128 == 0` gate evenly (no
  partial m-tile is reachable there, unlike d64's BM=192), so this
  doubles as a multi-plane/LPT-scheduling stress set at the second tile
  config rather than a literal tail-residue test.
- `test_fa4_bhsd_gate_rejects_misaligned_offset_view` — the 16-byte
  alignment fallback (dense/copy path), at both head_dims.

All 40 pass. The broader FA4/SDPA-relevant regression sweep across
`test_eager_kernels.py`, `test_fa4_host_wiring.py`, `test_aten_functions.py`,
`test_high_level_ops.py`, `test_mojo_autocast.py`: **141 passed, 8 skipped
(pre-existing, unrelated), 0 failed.** `test_fa4_host_wiring.py`'s 16
host-only tests (no GPU) also pass unchanged — `_fa4_symbol`'s type hint
had to move from the (more precise but too strict) `ModuleType` to
`object` so it still accepts the `SimpleNamespace` doubles those tests
mock `load_fa4_ops()` with.

### Before/after (H100 PCIe, pinned clock, device time, `B1H16S4096D128`)

| aten op (dtype) | before | after |
|---|---|---|
| `_scaled_dot_product_flash_attention` (bf16) | *(skip — declined FA4's gate)* | **0.413** (new entry) |
| `_scaled_dot_product_flash_attention` (f16) | *(skip)* | **0.417** (new entry) |
| `_scaled_dot_product_flash_attention_backward` (bf16) | *(skip)* | **0.592** (new entry) |
| `_scaled_dot_product_flash_attention_backward` (f16) | *(skip)* | **0.593** (new entry) |
| `_scaled_dot_product_efficient_attention` (bf16) | 3.147 | **0.249** |
| `_scaled_dot_product_efficient_attention` (f16) | 3.137 | **0.251** |
| `scaled_dot_product_attention` (composite, bf16) | 10.750 | **0.832** |
| `scaled_dot_product_attention` (composite, f16) | 10.649 | **0.835** |

Every node clears the 1.10 bar comfortably — most of them are now
*faster* than stock PyTorch at this shape, not just within 10% of it
(e.g. flash forward: 180us ours vs 436us stock). `B8H12S1024D64` (the
canary) was re-verified read-only (no `--update-baselines`): all 10 nodes
pass unchanged, confirmed by diffing `baselines.html` — the touched JSON
keys are exclusively under `B1H16S4096D128` (28 lines changed total: 4
value updates + 4 new entries, times two ops each for fwd/bwd... see the
commit for the exact diff). Recorded via
`uv run pytest benchmarks/test_attention.py -k B1H16S4096D128
--update-baselines`; `benchmarks/test_coverage.py` (op-registration +
baseline-addressability reconciliation) passes.

### Blast radius (`scripts/compare_kernel_asm.py`)

- **sm_90a**: `fa4_ops` goes from 12 to 22 kernels (+10, 0 removed): 4 new
  forward bodies + 6 new backward bodies (preprocess/main/convert x2
  dtypes), all exclusively reachable through the new d128 entry points.
  The 10 pre-existing d64 kernels each differ by exactly one cosmetic
  token — the same `extern_ptr_syml_N` LLVM module-scope symbol-ordinal
  shift documented in this PR's own earlier blast-radius section above,
  recurring because the new d128 call sites sit earlier in
  `fa4_ops.mojo`/`fa4_fwd_launch.mojo`. Full `--show-diff` confirms zero
  instruction-level changes on every pre-existing kernel. **Zero
  functional movement on any pre-existing sm_90a kernel.**
- **gfx942**: fails identically before and after
  (`error: failed to run the pass manager for offload functions` — same
  Hopper-only TMA/wgmma dependency as before). **Zero gfx942 footprint,
  identical failure signature.**
- `uvx pre-commit run --all-files`: clean.

---

## Forward schedule (phase 2b)

Follow-up to the head_dim=128 section above: closes the gap between FA4
fwd (post-bhsd, `a4e8462`) and **cuDNN attention**
(`sdpa_kernel(CUDNN_ATTENTION)`), the backend stock PyTorch actually picks
on H100 — 1.6x faster than the FLASH backend this PR's earlier sections
benchmarked against. Integrates agent A's phase-2/2b forward-schedule
harness (`/scratch/fa4-fwd-harness`, `NOTES.md`).

### Root cause and fix

`BM=192 > BN=128` makes the causal diagonal band span two 128-column
tiles per 192 rows: at `S=1024` the kernel computed **1.500x** the causal
triangle vs **1.125x** at `BM=64` (cuDNN's own tile is 64x128). d64 moves
tile `192x128` (3 MMA warpgroups, 512 threads, 1 CTA/SM) to `64x128` (1
MMA warpgroup, 256 threads, **2 CTAs/SM** via `nvvm.minctasm=2` — the
second CTA replaces the third warpgroup's latency hiding). On top of the
geometry, an instruction diet on the causal mask and row reductions (see
the kernel-level commit for the full list): 32-bit mask thresholds,
exact per-warpgroup diagonal predicate, column-group skip, tree-shaped
rowmax/rowsum, and dropping the now-self-ring pingpong barrier at
`NWG==1`. `head_dim=128` keeps `a4e8462`'s tile/regs/codegen throughout
(every new axis is comptime-gated off there).

### Per-shape harness table (streamed device time, us, pinned 1395MHz, single-shape processes)

| shape | v1 = a4e8462 | v2 (phase 2, geometry only) | v2b (phase 2b, + diet) | cuDNN | v2b/cuDNN | bar 1.10 |
|-------|--------------|------------------------------|-------------------------|-------|-----------|----------|
| P0 B8 H12 S1024  | 94.5-97.5   | 73.2-75.1   | 70.0-71.1   | 66.0  | 1.06-1.08 | PASS |
| P1 B32 H12 S1024 | 348.7-350.3 | 284.1-284.6 | 261.9-262.9 | 227.1 | **1.15-1.16** | **FAIL (known residual, see below)** |
| P2 B1 H16 S4096  | 127.7-130.1 | 131.3-133.7 | 127.6-129.3 | 151.4 | 0.84-0.85 | PASS |
| P3 B16 H16 S2048 | 613-622     | 587-596     | 555.6-569.3 | 508.0 | 1.09-1.12 | PASS (at the bar) |
| P4 B3 H5 S1152   | 24.5-25.1   | 17.6-17.9   | 16.7-16.9   | 21.6  | 0.77-0.78 | PASS |
| P5 B1 H8 S512    | 15.0-15.5   | 9.25-9.69   | 8.47-8.75   | 9.8   | 0.86-0.89 | PASS |

vs the branch starting point (v1): P0 -27%, P1 -25%, P3 -9%, P4 -33%,
P5 -44%. d128 guard (`B8H12S1024D128` / `B32H12S1024D128`, ncu A/A
controlled): many-wave shape 9% faster (the phase-2 wave-dispatched
swizzle applying to d128 for the first time), low-wave shape neutral
(apparent 3% is inside the harness's own 3.8% A/A leg-asymmetry bound);
bitwise-identical outputs both shapes.

### Benchmark-node before/after (`benchmarks/test_attention.py`, H100 PCIe, pinned 1395MHz, device time)

**D64 (B8H12S1024D64) — moves, mirrors the harness's v1->v2b deltas:**

| aten op (dtype) | before (branch head) | after (this change) |
|---|---|---|
| `scaled_dot_product_attention` (bf16) | 1.468 | **1.066** |
| `scaled_dot_product_attention` (f16) | 1.464 | **1.061** |
| `_scaled_dot_product_flash_attention` (bf16) | 0.888 | **0.643** |
| `_scaled_dot_product_flash_attention` (f16) | 0.883 | **0.635** |
| `_scaled_dot_product_efficient_attention` (bf16) | 0.477 | **0.354** |
| `_scaled_dot_product_efficient_attention` (f16) | 0.478 | **0.355** |
| `_scaled_dot_product_flash_attention_backward` (bf16) | 0.716 | unchanged (within +/-8% dead band; own constants, untouched file) |

The composite `scaled_dot_product_attention` node (stock leg = cuDNN)
crosses the 1.10 bar for the first time on this shape: 1.066/1.061,
matching the harness's P0 v2b/cuDNN of 1.06-1.08 once Python/launch
overhead on a ~70us op is folded back in.

**D128 (B1H16S4096D128) — stable, as expected (this diff's new axes are
comptime-gated off at d128; only `.minnctapersm 1` is emitted there, see
blast radius):**

| aten op (dtype) | before | after |
|---|---|---|
| `_scaled_dot_product_flash_attention` (bf16/f16) | 0.413 / 0.417 | unchanged |
| `_scaled_dot_product_efficient_attention` (bf16/f16) | 0.249 / 0.251 | unchanged |
| `scaled_dot_product_attention` (bf16/f16) | 0.832 / 0.835 | unchanged |
| `_scaled_dot_product_flash_attention_backward` (bf16/f16) | 0.592 / 0.593 | unchanged |

All 20 `test_attention.py` cases pass; `benchmarks/baselines.html` is
included, touching exactly the 6 D64 entries above (`git diff --stat`:
6 value updates, nothing else).

### Known residual: P1 (B32 H12 S1024) at 1.15-1.16

Per-unit accounting (ncu, 27 waves, 2 CTAs/SM): after the diet, the
kernel executes ~610 warp-instructions per 64x128 unit against cuDNN's
~621 (instruction parity) but issues 265k inst/us against their 304k
(-13%) — the gap is issue efficiency / latency hiding with only 2
consumer warps per SMSP and `wait` (fixed-latency dependency) as the top
stall, not either compute pipe (tensor 36%, XU/exp2 39% of peak). P1's
100 MB K/V working set is also the one L2-nonresident shape here (L2 hit
71.5%, vs P0's 25 MB fitting easily) — cuDNN's persistent grid with a
dynamic atomic-counter scheduler is the plausible reason they gain more
per plane going P0->P1 (15%) than this kernel does (6.6%). **Phase 2c resolved this residual — see the
"Forward schedule (phase 2c: self-loading warpgroup)" section below; P1
now measures 1.02-1.05 in the harness and the composite benchmark node
sits at 0.912.**

### Dead ends (measured, so the next agent does not re-explore them)

- **BM=192 + per-warpgroup causal trip counts** (the natural first idea:
  keep 3 warpgroups, let each stop at its own causal boundary) —
  work-per-CTA fell 23% but wall time only -8%: a BM=192 CTA is bound by
  its K/V tile *stream*, not by warpgroup math, and the savings land on
  the tail m-block, which still streams every K/V tile for the CTA's
  other (still-active) warpgroups.
- **BM=128 / 2 warpgroups / 384 threads** — worse per-unit than 3
  warpgroups on long-seq shapes: each warpgroup's ~850-cycle softmax
  overruns its 512-cycle tensor slot at NWG=2, where NWG=3 had 2x512
  cycles of slack to hide it in.
- **8 K/V ring stages vs 6** — no measurable help at BM=128; reverted
  before BM=64 was tried (6 is what fits 2 CTAs/SM's smem budget there
  anyway).
- **L2-swizzle group size fitted to `2*sm_count/num_m_tiles`** — loses
  both ways vs either extreme (worse than group=1 AND worse than the
  production 50MB-budget formula); the shipped rule is a coarse
  wave-count dispatch (>=12 waves -> group 1, else the existing formula)
  instead.
- **Static persistent grid scheduler** (3 variants: single-buffered Q,
  double-buffered Q at 4 stages) — delivered its memory promise (DRAM
  reads 246->162 MB, L2 hit 50->75% at P1) and still lost ~3% wall time
  everywhere: round-robin static assignment forfeits the hardware
  scheduler's dynamic CTA placement (no work-stealing at the tail), and
  the loop-carried scheduler state spills registers the one-shot kernel
  never did. A *dynamic* (atomic-counter) persistent scheduler a la FA3
  might flip the sign but was not built.
- **Rowsum FADD removal via an MMA identity trick** and **packed-half
  softmax** — both measured negative (tensor is the tighter pipe already;
  packing added conversion overhead without freeing a bottlenecked unit).

### Blast radius (`scripts/compare_kernel_asm.py`)

- **sm_90a** vs `a4e8462`: `fa4_ops` still 22 kernels. The 6 d64 forward
  bodies (dense/strided_qkv/bhsd x bf16/f16) get new mangled names
  entirely (BM/thread-count/register-budget template arguments changed,
  not just their content) — 6 old symbols gone, 6 new symbols appear, as
  expected; this *is* the change. The 4 d128 forward bodies each gain
  exactly one line, `.minnctapersm 1` (from the new, now-unconditional
  `nvvm.minctasm` metadata — `2 if NWG==1 else 1` evaluates to `1` at
  d128's NWG=2, which is a no-op vs the previous absence of that
  attribute), zero other bytes differ; the harness's own A/A control
  bounds this line's effect at <=1% (noise), and the benchmark table
  above confirms d128 nodes did not move. All 12 backward kernels
  (`fa4_bwd_kernel.mojo`, its own constants, file untouched by this
  change) are byte-identical.
- **gfx942**: fails to build identically before and after (`error: failed
  to run the pass manager for offload functions` — the same Hopper-only
  TMA/wgmma dependency as every other FA4 change on this PR). Zero gfx942
  footprint.

### Tests

- Full FA4/SDPA selection (`tests/test_eager_kernels.py -k "fa4 or flash
  or sdpa"`, both dtypes, both head_dims): **93 passed, 4 skipped**
  (pre-existing, platform-gated).
- `tests/test_fa4_host_wiring.py`: **16 passed** (host-only, no GPU).
- New: `test_fa4_bhsd_d64_direct_partial_tail_block` (`S in {65, 127,
  193}`, both dtypes, 6 cases) — the permanent-suite home for the
  harness's genuine BM=64 partial-tail shapes. The production
  `seqlen % 128 == 0` eligibility gate would route every one of these
  away from FA4 (128 is now a multiple of BM=64, so the pre-existing
  `_FA4_BHSD_TAIL_SHAPES` set no longer reaches a partial last m-block at
  all under that gate — comments there updated to say so), so this test
  calls the compiled bhsd bridge directly, the same way
  `fast_fa4_16bit_d64_causal_forward` does internally, past the gate.
- `benchmarks/test_coverage.py`: 2 passed (GPU-free).
- `uvx pre-commit run` on the touched files: clean.


## Forward schedule (phase 2c: self-loading warpgroup)

The final forward commit replaces, for dense-causal BHSD d64 at >=2 waves,
the producer/consumer pair with a **single self-loading 128-thread
warpgroup** (each warpgroup refills the ring slot it just consumed, so the
`empty[]` barriers are deleted outright — `wgmma.wait_group` orders the
refill, the same release pattern CUTLASS `sm90_mma_tma_gmma_ss.hpp`, FA3's
mainloop, and MAX's own Hopper GEMM rely on) at **3 CTAs/SM** (154 regs,
4-stage 72 KiB ring). Below 2 waves the launcher keeps the phase-2b kernel
(wave count derived from the runtime SM count), which also preserves the
small-shape wins.

Phase 2c also **falsified the obvious idea first**: 2-CTA clusters with TMA
multicast were fully implemented, delivered the promised -33% L2 read
sectors, and ran +9% *slower* — the kernel is latency-bound, not L2-bound
(nothing was saturated: tensor 36%, XU 39%, L2 42%, issue 44% of peak). The
win is occupancy: warps active +21%, issue rate +14%, time -13.6% (ncu).

Harness numbers (streamed device time vs cuDNN attention, single-shape
processes, pinned 1395 MHz):

| shape | phase 2b | selfload | vs cuDNN |
|---|---|---|---|
| B8 H12 S1024 | 70.9-71.2 µs | 60.8-61.5 µs | **0.91** |
| B32 H12 S1024 | 264.9-269.9 | 229.8-236.0 | **1.02-1.05** |
| B1 H16 S4096 | 129.6-130.7 | 120.8-121.6 | **0.80** |
| B16 H16 S2048 | 570-575 | 520.6-525.7 | **1.03-1.04** |
| B3 H5 S1152 | 16.6-16.9 | 18.2-18.6 (v2b kernel via wave gate) | 0.78-0.87 |
| B1 H8 S512 | 8.5-8.9 | 9.0-9.3 (v2b kernel via wave gate) | 0.86-0.93 |

Recorded benchmark nodes after this commit (bf16/f16): composite
`scaled_dot_product_attention` D64 **0.912/0.907**, flash direct
**0.558/0.552**, efficient **0.308/0.310**; D128 and all backward nodes
unchanged within the dead band.

Correctness carried the heaviest review of the series: the barrier-deletion
argument was adversarially reviewed (verdict: sound, with the
prefetch-distance invariant now documented in the kernel next to the
CUTLASS/FA3/MAX precedent citations), a PTX-ordering regression test guards
against toolchain drift (Mojo's `wait_group` carries no memory clobber), a
2048-launch soak at three clock regimes ran bit-clean, and a CI-sized soak
plus selfload-reaching partial-tail tests are in the permanent suite.

## Seqlen gate relaxation (review thread follow-up)

The review thread asked to relax the `seqlen % 128 == 0` eligibility gate
(`_fa4_16bit_d64_causal_inputs`), a leftover from the pre-phase-2b `BM=192`
era. Landed for the bhsd forward route only, per-route policy:

| route | grad needed | seqlen requirement |
|---|---|---|
| BHSD-native forward (`fast_fa4_16bit_d64_causal_forward`, d64 and d128) | no | any `seqlen >= 1` |
| Legacy strided-BTHD / dense-copy forward | either | `seqlen % 128 == 0` (unproven tail machinery) |
| Any route, backward | yes | `seqlen % 128 == 0` (unproven tail machinery) |

The BHSD-native path's zero-fill/clamp tail machinery was already proven
correct at both d64 and d128 by the existing direct-bridge tests; this
change only widens what the *public* eligibility gate lets reach it.
`_fa4_16bit_d64_causal_inputs` grows an `allow_any_seqlen` kwarg (default
`False`, so every pre-existing call site — including both backward-adjacent
gates — keeps its exact old contract byte-for-byte); only
`fast_fa4_16bit_d64_causal_forward` passes `True`, and it still declines a
non-multiple-of-128 seqlen when the BHSD layout doesn't apply, so the
legacy routes stay exactly as conservative as before.

Backward was investigated and left untouched on purpose. The bwd kernels
address Q/K/V/dQ/dK/dV through one TMA descriptor per tensor spanning the
whole flattened `(B*S, H, D)` range (`fa4_bwd_launch.mojo`'s
`create_split_tma(ctx, ptr, rows=batch*seqlen, nheads)`), not one descriptor
per batch. A batch's partial last KV tile computes an all-zero
gradient contribution for its padding rows (causal masking already excludes
them; verified by reading `fa4_bwd_kernel.mojo`), but the TMA *store* of
that all-zero tile is not clipped at the batch boundary the way it is at
the very end of the tensor — for `batch > 1` it lands on the valid opening
rows of the *next* batch's `dK`/`dV`, racing that batch's own correct CTA
store. That is a real silent-wrong-gradient risk, not a hypothetical one,
so backward keeps requiring `seqlen % 128 == 0` everywhere, and a
training-shaped call (grad enabled, `requires_grad` Q/K/V) at an odd seqlen
falls through — via the autograd wrapper's unchanged `needs_backward` gate
— to the existing math-decomposition `_ScaledDotProductAttentionAutograd`
Function instead of the native flash forward/backward pair. Covered by
`test_fa4_sdpa_odd_seqlen_requires_grad_uses_decomposition`, which spies on
every FA4 forward/backward symbol and asserts none of them ran, and checks
the decomposition's gradients against a CPU fp64→fp32 reference.

New aten-level tests (`tests/test_eager_kernels.py`, through
`torch.nn.functional.scaled_dot_product_attention` and the direct
`aten::_scaled_dot_product_flash_attention` op — not the compiled bridge):
odd seqlens `{65, 127, 193, 1023, 4095} x {bf16, f16} x {d64, d128}` against
a CPU fp32 reference, each asserting (via a monkeypatch spy on the bhsd
symbol) that FA4 actually ran rather than merely producing matching numbers
through some other path.

**A/B spot-check** (not a recorded `benchmarks/` node — odd seqlens aren't
in its shape tables): kineto device time, B8H12 D64 causal, H100 PCIe
pinned at 1395 MHz, via `bench_lib.measure` (the same ABBA interleaved
methodology the recorded baselines use):

| dtype | mojo S1023 / mojo S1024 (tail-cliff check) | ours/stock @ S1023 | ours/stock @ S1024 |
|---|---|---|---|
| bf16 | **1.002** ± 0.4% (59.9us / 59.7us) | 0.891 ± 0.1% | 0.924 ± 0.4% |
| f16 | **0.999** ± 0.3% (60.3us / 60.4us) | 0.898 ± 0.0% | 0.922 ± 0.1% |

The odd seqlen lands within noise of the even one — one partial tile out of
16 costs nothing measurable, not a cliff — and both stay ~8-11% faster than
stock PyTorch, consistent with the recorded S1024 baseline.

**Cross-compilation**: `scripts/compare_kernel_asm.py --before <pre-change
worktree> --after . --accelerator sm_90a --kernel-dir
torch_mojo_backend/eager_flash_attention --modules fa4_ops` reports **0 of
24 kernels differ** — expected, since this change touches no `.mojo` source
at all (Python gate only).

`uvx pre-commit run --all-files`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TFYWf7vJNAv5VadqSz3bRu