### PR TITLE
Route aten::cumsum through fast block.prefix_sum kernels

### DIFF
--- a/benchmarks/baselines.html
+++ b/benchmarks/baselines.html
@@ -6446,11 +6446,30 @@ document.addEventListener("DOMContentLoaded", boot);
         },
         "cumsum": {
           "dtypes": {
-            "f32": {
+            "bf16": {
               "shapes": {
+                "S_4096x4096_d0": {
+                  "layouts": {
+                    "contig": 0.985
+                  }
+                },
                 "S_4096x4096_d1": {
                   "layouts": {
-                    "contig": 7.081
+                    "contig": 0.375
+                  }
+                }
+              }
+            },
+            "f32": {
+              "shapes": {
+                "S_4096x4096_d0": {
+                  "layouts": {
+                    "contig": 1.011
+                  }
+                },
+                "S_4096x4096_d1": {
+                  "layouts": {
+                    "contig": 0.466
                   }
                 }
               }

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -1413,6 +1413,228 @@ def test_fast_var_strided_axis_skips_materialization(mojo_gpu, monkeypatch):
     assert native_calls[target][0][0][1] == (0,)
 
 
+# ---------------------------------------------------------------------------
+# cumsum: INNER (trailing/stride-1 dim, block.prefix_sum-cooperating blocks,
+# with a 3-pass workspace scan once there are too few independent lines to
+# fill the device) and OUTER (dim=0 on a contiguous rank-2 tensor, one
+# thread per independent column, no cooperation needed) -- see
+# torch_mojo_backend/eager_kernels/nn_ops/cumsum_kernels.mojo for the
+# kernels and nn_ops.mojo's `_cumsum_spec_into_go` for the dispatch. Both
+# families are CUDA-only (gated by `_device.api == "cuda"` in
+# `fast_aten_cumsum`): non-CUDA devices, including the `mojo:cpu` test
+# device, keep exactly the int64/int32/float32-trailing-dim-only surface
+# `main` had before this file, through a portable (but unoptimized)
+# `_parallel_for`-based kernel -- see `test_fast_cumsum_...non_cuda...`
+# below.
+#
+# Shapes are chosen to land deliberately on both sides of the regime split
+# (INNER "many independent lines" vs. the long-line workspace path, which
+# is picked below `sm_count * FILL_WAVES` independent lines -- read at
+# runtime, so a handful of rows lands in the workspace regime on any real
+# datacenter GPU without hardcoding a specific SM count).
+# ---------------------------------------------------------------------------
+
+# (shape, dim) -- covers INNER many-lines, INNER workspace (few long lines),
+# OUTER many-lines and OUTER narrow, plus edge cases (single element/line/
+# column, an exact multiple of a tile size vs. one off it, and the awkward
+# 357x789 shape AGENTS.md's benchmark-harness notes ask every kernel to
+# include).
+_CUMSUM_SHAPES = [
+    ((4096, 4096), 1),  # INNER, many lines
+    ((4096, 4096), 0),  # OUTER, many lines
+    ((357, 789), 1),  # INNER, awkward extents
+    ((357, 789), 0),  # OUTER, awkward extents
+    ((1, 200_000), 1),  # INNER, workspace (one very long line)
+    ((8, 100_003), 1),  # INNER, workspace (few long lines, off-by-one)
+    ((4, 1024 * 5), 1),  # INNER, workspace, exact tile multiple
+    ((200_003, 4), 0),  # OUTER, narrow (few columns, many rows)
+    ((1, 4096), 1),  # single line
+    ((500, 1), 1),  # single column, INNER framing
+    ((1, 4096), 0),  # single row, OUTER framing
+    ((4096, 1), 0),  # single column, OUTER framing
+    ((1, 1), 1),  # single element
+    ((500, 256), 1),  # exact tile multiple (256 threads)
+    ((500, 257), 1),  # one past a tile multiple
+]
+
+
+@pytest.mark.parametrize("shape,dim", _CUMSUM_SHAPES)
+def test_fast_cumsum_shapes_match_cpu(mojo_gpu, shape, dim):
+    # Compared against a float64 reference computed from the SAME float32
+    # input, not CPU's own float32 cumsum: two float32 accumulations done in
+    # a different order (ours: one thread per line/column, strictly
+    # sequential; CPU's: whatever order aten's own reduction takes) round
+    # differently at every step and can legitimately disagree, without
+    # either being wrong -- this tolerance measures the fast kernel's OWN
+    # float32 accumulation error, the same idiom
+    # test_fast_var_split_regimes_match_cpu above uses. A random walk this
+    # long (up to 200,003 steps for the narrow-outer shape) crosses near
+    # zero somewhere, where a purely RELATIVE tolerance is meaningless (a
+    # ~1e-3 absolute difference against an expected value of 6e-4 is a
+    # "250000%" relative error despite being an entirely unremarkable fp32
+    # accumulation error at that depth) -- atol carries the bound there;
+    # rtol matters for the large-magnitude tail. Seeded for reproducibility
+    # (swept seeds 0-7 across every shape here to size this bound with
+    # margin, not picked to make one run pass).
+    torch.manual_seed(0)
+    x = torch.randn(shape)
+    result = torch.cumsum(x.to(mojo_gpu), dim=dim).cpu().double()
+    expected = torch.cumsum(x.double(), dim=dim)
+    torch.testing.assert_close(result, expected, rtol=2e-3, atol=2e-2)
+
+
+# Measured worst relative error (against an fp64 reference, moderate
+# accumulation depths up to 4096 elements -- see the PR description for the
+# full sweep): bf16 up to ~0.39%, float16 up to ~0.90% (float16's narrower
+# mantissa loses more on the OUTER kernel's longer per-thread serial
+# accumulation). 3% is roughly a 3-4x margin over that measured worst case
+# -- tightened from an ungrounded 6% bound used during kernel development
+# (the fast kernels accumulate bf16/f16 in float32 internally, matching
+# stock torch's own cumsum accumulation, so the error floor here is the
+# INPUT's bf16/f16 quantization compounding over the scan, not anything the
+# kernel design adds).
+_CUMSUM_LOWP_RTOL = 3e-2
+_CUMSUM_LOWP_ATOL = 3e-2
+
+
+@pytest.mark.parametrize(
+    "dtype", [torch.bfloat16, torch.float16, torch.int32, torch.int64]
+)
+@pytest.mark.parametrize("shape,dim", [((4096, 4096), 1), ((4096, 4096), 0)])
+def test_fast_cumsum_dtypes_match_cpu(mojo_gpu, shape, dim, dtype):
+    """Dtype sweep on the INNER 'many lines' and OUTER regimes."""
+    torch.manual_seed(0)
+    if dtype.is_floating_point:
+        x = torch.randn(shape).to(dtype)
+    else:
+        x = torch.randint(-100, 100, shape, dtype=dtype)
+    result = torch.cumsum(x.to(mojo_gpu), dim=dim)
+    expected = torch.cumsum(x, dim=dim)
+    assert result.dtype == expected.dtype
+    if dtype.is_floating_point:
+        torch.testing.assert_close(
+            result.cpu(), expected, rtol=_CUMSUM_LOWP_RTOL, atol=_CUMSUM_LOWP_ATOL
+        )
+    else:
+        torch.testing.assert_close(result.cpu(), expected, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize(
+    "dtype", [torch.bfloat16, torch.float16, torch.int32, torch.int64]
+)
+@pytest.mark.parametrize("shape,dim", [((4, 5120), 1), ((8, 100_003), 1)])
+def test_fast_cumsum_workspace_dtypes_match_cpu(mojo_gpu, shape, dim, dtype):
+    """A2 follow-up: the long-line 3-pass workspace path was only ever
+    correctness-tested in float32 before integration -- this covers
+    bf16/f16/i32/i64 through the SAME regime (few rows, so `enqueue_
+    cumsum_rows_workspace` is what actually runs, not the many-lines
+    kernel)."""
+    torch.manual_seed(0)
+    if dtype.is_floating_point:
+        x = torch.randn(shape).to(dtype)
+    else:
+        x = torch.randint(-100, 100, shape, dtype=dtype)
+    result = torch.cumsum(x.to(mojo_gpu), dim=dim)
+    expected = torch.cumsum(x, dim=dim)
+    assert result.dtype == expected.dtype
+    if dtype.is_floating_point:
+        torch.testing.assert_close(
+            result.cpu(), expected, rtol=_CUMSUM_LOWP_RTOL, atol=_CUMSUM_LOWP_ATOL
+        )
+    else:
+        torch.testing.assert_close(result.cpu(), expected, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("dim", [-1, -2])
+def test_fast_cumsum_negative_dim(mojo_gpu, dim):
+    torch.manual_seed(0)
+    x = torch.randn(64, 4096)
+    result = torch.cumsum(x.to(mojo_gpu), dim=dim).cpu().double()
+    expected = torch.cumsum(x.double(), dim=dim)
+    torch.testing.assert_close(result, expected, rtol=2e-3, atol=2e-2)
+
+
+def test_fast_cumsum_dtype_kwarg_casts_before_accumulating(mojo_gpu):
+    """torch casts the input to `dtype` first, then accumulates in it --
+    verified against stock torch directly (not just a claim): an int64
+    input with dtype=torch.float32 upcasts before scanning, and a float32
+    input with dtype=torch.int32 TRUNCATES before scanning (not the other
+    way around, i.e. not sum-then-cast)."""
+    x = torch.arange(1, 9, dtype=torch.int64).reshape(2, 4)
+    result = torch.cumsum(x.to(mojo_gpu), dim=1, dtype=torch.float32)
+    expected = torch.cumsum(x, dim=1, dtype=torch.float32)
+    assert result.dtype == torch.float32
+    torch.testing.assert_close(result.cpu(), expected)
+
+    y = torch.tensor([[1.7, 2.7, 3.7, 0.2]])
+    result = torch.cumsum(y.to(mojo_gpu), dim=1, dtype=torch.int32)
+    expected = torch.cumsum(y, dim=1, dtype=torch.int32)
+    assert result.dtype == torch.int32
+    torch.testing.assert_close(result.cpu(), expected)
+
+
+@pytest.mark.parametrize("dtype", [torch.int32, torch.uint8, torch.bool])
+def test_fast_cumsum_integer_promotes_to_int64(mojo_gpu, dtype):
+    """No dtype= kwarg: torch promotes every integer/bool cumsum to int64
+    (same rule fast_aten_sum already applies) -- verified directly against
+    stock torch, not assumed. int8/int16 are NOT covered here: promoting
+    them needs a cast through `_CAST_DTYPES`, which does not include those
+    two dtypes -- a pre-existing gap `fast_aten_sum` has for the same
+    reason (verified: `torch.sum` on an int8 mojo tensor also declines),
+    not something specific to or fixed by this file."""
+    if dtype == torch.bool:
+        x = torch.randint(0, 2, (8, 16), dtype=torch.bool)
+    else:
+        x = torch.randint(0, 20, (8, 16), dtype=dtype)
+    result = torch.cumsum(x.to(mojo_gpu), dim=1)
+    expected = torch.cumsum(x, dim=1)
+    assert result.dtype == torch.int64 == expected.dtype
+    torch.testing.assert_close(result.cpu(), expected)
+
+
+def test_fast_cumsum_noncontiguous_input_materializes_correctly(mojo_gpu):
+    """A non-contiguous operand is NOT declined here: `fast_aten_cumsum`
+    materializes it (`a._contig()`) before the boundary call, same as
+    `_try_spec_unary` already did for this op pre-integration -- so the
+    result must be numerically correct, not just non-crashing."""
+    torch.manual_seed(0)
+    x = torch.randn(64, 128).t()  # transpose of a contiguous tensor
+    assert not x.is_contiguous()
+    result = torch.cumsum(x.to(mojo_gpu), dim=1).cpu().double()
+    expected = torch.cumsum(x.double(), dim=1)
+    torch.testing.assert_close(result, expected, rtol=2e-3, atol=1e-2)
+
+
+def test_fast_cumsum_declines_middle_dim_on_rank3(mojo_gpu):
+    """rank>=3 non-trailing dims are out of this kernel family's scope and
+    must raise (eager has no graph fallback), not silently compute the
+    wrong axis."""
+    x = torch.randn(4, 5, 6).to(mojo_gpu)
+    with pytest.raises(NotImplementedError):
+        torch.cumsum(x, dim=1)
+
+
+def test_fast_cumsum_new_dtype_and_dim_decline_on_non_cuda_device():
+    """dim=0 and bf16/f16 route through the new, CUDA-only fast kernels
+    (`is_cuda` gate in `fast_aten_cumsum`) -- on a non-CUDA device, the
+    `mojo:cpu` test device used here (no real GPU required, unlike AMD/Apple
+    which this repo has no way to exercise in CI), these must decline
+    exactly as they did on `main` before this file existed, not silently run
+    an unmeasured kernel. int64/int32/float32 on the trailing dim is
+    unaffected -- same portable `_parallel_for` kernel as always.
+    """
+    mojo_cpu = f"mojo:{len(get_accelerators()) - 1}"
+    x32 = torch.randn(8, 16)
+    with pytest.raises(NotImplementedError):
+        torch.cumsum(x32.to(mojo_cpu), dim=0)
+    xbf16 = torch.randn(8, 16).to(torch.bfloat16)
+    with pytest.raises(NotImplementedError):
+        torch.cumsum(xbf16.to(mojo_cpu), dim=1)
+    # The pre-existing surface still works on that same device.
+    result = torch.cumsum(x32.to(mojo_cpu), dim=1)
+    torch.testing.assert_close(result.cpu(), torch.cumsum(x32, dim=1))
+
+
 def test_fast_native_layer_norm_bf16_gpu_preserves_generic_path(mojo_gpu):
     input = torch.randn(3, 65).bfloat16()
     weight = torch.randn(65).bfloat16()

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -1261,6 +1261,45 @@ class _CastSpecExtension(
         return (_spec_of(tensor), dtype.value, _spec_of(out))
 
 
+class _CumsumSpecExtension(
+    eager_kernels.MojoExtension[_TensorOutputSpec, TorchMojoTensor]
+):
+    """cumsum's dim-threaded spec op — same shape as `_CastSpecExtension`
+    (one extra scalar arg alongside the tensor), except the extra arg is a
+    dim rather than a dtype, so it plays no part in `make_defines`/
+    `make_canonical_defines`: two different dims of the same input/output
+    dtype compile to the exact same Mojo variant (dim is a plain runtime
+    int read via `_raw_int` at the boundary, not a compile-time define)."""
+
+    MOJO_FILE: ClassVar[Path] = _NNExtension.MOJO_FILE
+
+    @classmethod
+    def make_defines(
+        cls, tensor: MojoTensorLike, dim: int
+    ) -> dict[str, bool | int | str]:
+        return {"OP": "CumsumSpec", "DTYPE_ARG_0": tensor._dtype.name}
+
+    @classmethod
+    def make_canonical_defines(
+        cls, tensor: MojoTensorLike, dim: int
+    ) -> "eager_kernels.CanonicalDefines":
+        return eager_kernels._canonical_call_defines(
+            "CumsumSpec", (tensor._dtype,), (tensor._dtype,), ()
+        )
+
+    @classmethod
+    def expected_output_specs(
+        cls, tensor: MojoTensorLike, dim: int
+    ) -> _TensorOutputSpec:
+        return _TensorOutputSpec(tuple(tensor._shape), tensor._dtype, tensor._device)
+
+    @classmethod
+    def extension_args(
+        cls, out: TorchMojoTensor, tensor: MojoTensorLike, dim: int
+    ) -> tuple[object, ...]:
+        return (_spec_of(tensor), dim, _spec_of(out))
+
+
 class _BinarySpecExtension(
     eager_kernels.MojoExtension[_TensorOutputSpec, TorchMojoTensor]
 ):
@@ -1860,6 +1899,24 @@ def _try_spec_min_dim(
     return outputs
 
 
+def _try_spec_cumsum(a: TorchMojoTensor, dim: int) -> TorchMojoTensor | None:
+    """cumsum through CumsumSpec (dim-threaded), or None.
+
+    Not queue-eligible yet (mirrors `_try_spec_unary`'s old CumsumSpec
+    branch: "constraints not mirrored" — CumsumSpec is not registered in
+    the call-queue's static rule tables), so every call drains and runs
+    synchronously. `a` must already be contiguous; the caller materializes
+    non-contiguous inputs first.
+    """
+    try:
+        return _submit_prepared_into(
+            _CumsumSpecExtension.prepare(a, dim), force_sync=True
+        )
+    except Exception as exc:
+        _raise_if_device_oom(exc)
+        return None
+
+
 def _try_spec_unary(spec_fn_name, x, out_dtype=None, module_name="elementwise_ops"):
     """Contiguous unary through a spec op, or None.
 
@@ -1887,7 +1944,7 @@ def _try_spec_unary(spec_fn_name, x, out_dtype=None, module_name="elementwise_op
     elif spec_fn_name in ("LogSoftmaxSpec", "SoftmaxSpec"):
         ok = a._dtype in _SPEC_FLOAT_DTYPES and len(a._shape) >= 1 and a._numel > 0
     else:
-        ok = False  # e.g. CumsumSpec: constraints not mirrored, stay sync
+        ok = False  # any other spec_fn_name: constraints not mirrored, stay sync
     try:
         return _submit_prepared_into(
             _UNARY_SPEC_EXTENSIONS[module_name].prepare(
@@ -5783,18 +5840,76 @@ def fast_aten_nll_loss_backward_grad_input(
     return grad_input
 
 
+# What CumsumSpec's kernels are compiled for (nn_ops/cumsum_kernels.mojo's
+# CUMSUM_DTYPES) -- narrower than _CAST_DTYPES (no uint8/bool: torch never
+# needs cumsum's *own* dtype to be one of those, only promoted FROM one).
+_CUMSUM_DTYPES = (
+    DType.float32,
+    DType.bfloat16,
+    DType.float16,
+    DType.int32,
+    DType.int64,
+)
+# What `main` supported before this file's CUDA-only fast kernels: bf16/f16
+# need the new block.prefix_sum-based kernels, which are unmeasured on
+# non-CUDA GPUs (see the `is_cuda` gate in fast_aten_cumsum below).
+_CUMSUM_DTYPES_LEGACY = (DType.float32, DType.int32, DType.int64)
+
+
 def fast_aten_cumsum(input, dim, *, dtype=None):
-    a = _t(input) if dtype is None else None
-    if (
-        a is None
-        or a._numel == 0
-        or a._dtype not in (DType.int64, DType.int32, DType.float32)
-    ):
+    a = _t(input)
+    if a is None or a._numel == 0:
+        return NOT_HANDLED
+    # The fast nn_ops/cumsum_kernels.mojo family (block.prefix_sum INNER,
+    # workspace long-line route, OUTER dim=0) was only ever MEASURED on
+    # NVIDIA (H100) -- it cross-compiles for AMD (block.prefix_sum/block.sum
+    # are portable MAX primitives, verified with
+    # scripts/compare_kernel_asm.py --accelerator gfx942) but per AGENTS.md's
+    # "To check a kernel change against a GPU you do not have", an unmeasured
+    # architecture does not get shipped on faith. Anything that is not a CUDA
+    # device gets EXACTLY today's `main` behavior: int64/int32/float32,
+    # trailing dim only -- the nn_ops.mojo Mojo-side dispatch mirrors this
+    # (`ctx.api() == "cuda"` gates the same fast kernels off there too).
+    is_cuda = a._device.api == "cuda"
+    allowed_dtypes = _CUMSUM_DTYPES if is_cuda else _CUMSUM_DTYPES_LEGACY
+    if dtype is not None:
+        # torch casts the input to `dtype` first, then accumulates in it
+        # (verified: dtype=int32 on a float input truncates before summing,
+        # not the other way around) -- same cast-then-op convention as
+        # fast_aten_sum/fast_aten_mean above.
+        target = _torch_dtype_to_max(dtype)
+        if target is None or target not in allowed_dtypes:
+            return NOT_HANDLED
+        if a._dtype != target:
+            if a._dtype not in _CAST_DTYPES or target not in _CAST_DTYPES:
+                return NOT_HANDLED
+            a = _cast_tensor(a, target)
+    elif not a._dtype.is_float():
+        # No dtype= kwarg: torch promotes bool/sub-int64 integer cumsum to
+        # int64 (verified: int8/int16/int32/uint8/bool all cumsum to int64;
+        # same rule fast_aten_sum applies above).
+        if a._dtype != DType.int64:
+            if a._dtype not in _CAST_DTYPES:
+                return NOT_HANDLED
+            a = _cast_tensor(a, DType.int64)
+    if a._dtype not in allowed_dtypes:
         return NOT_HANDLED
     rank = len(a._shape)
-    if not isinstance(dim, int) or rank == 0 or dim % rank != rank - 1:
+    if not isinstance(dim, int) or rank == 0:
         return NOT_HANDLED
-    result = _try_spec_unary("CumsumSpec", a, module_name="nn_ops")
+    dim = dim % rank
+    # INNER (trailing dim, any rank) or OUTER (dim=0, rank 2 only, CUDA
+    # only) -- see cumsum_kernels.mojo. Everything else (rank>=3
+    # non-trailing dims, dim=0 on a non-CUDA device, non-contiguous strides
+    # not fixed by `_contig()` below) is out of this kernel family's scope
+    # and declines, same as every unsupported input: NOT_HANDLED here
+    # becomes an actionable NotImplementedError (eager has no graph
+    # fallback to fall back to).
+    if dim != rank - 1 and not (is_cuda and rank == 2 and dim == 0):
+        return NOT_HANDLED
+    if not a._is_contiguous:
+        a = a._contig()
+    result = _try_spec_cumsum(a, dim)
     return result if result is not None else NOT_HANDLED
 
 

--- a/torch_mojo_backend/eager_kernels/nn_ops/cumsum_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/nn_ops/cumsum_kernels.mojo
@@ -1,0 +1,555 @@
+# ===----------------------------------------------------------------------=== #
+# GPU kernels + host-side enqueue wrappers for aten::cumsum's fast eager path.
+#
+# Ported from a standalone kernel-optimization engagement (see the PR that
+# added this file for the harness measurements and the negative-result
+# writeup on the long-line regime). Two orthogonal regimes, chosen by the
+# STRIDE of the scan dim:
+#
+#  * INNER  (stride 1, e.g. dim=-1 on a contiguous tensor): the scan is
+#    along the fastest-varying axis, so parallelizing it needs cooperation
+#    across threads. One block owns one independent "line" (or, via
+#    grid-stride, several); within a line, `threads`-sized tiles are scanned
+#    with `block.prefix_sum` + `block.broadcast` (both from the mojo
+#    stdlib -- no hand-rolled shared memory), threaded together by a
+#    register-resident serial `carry`.
+#
+#  * OUTER  (stride == line_len, e.g. dim=0 on a contiguous 2D tensor): the
+#    scan is along the SLOW axis and the fast axis is the independent-lines
+#    axis, so coalescing falls out for free from adjacent threads owning
+#    adjacent lines. No cooperation needed at all: each thread walks its own
+#    line with a plain serial accumulate-and-store loop.
+#
+# A single very long INNER line (few lines, e.g. one row of 10M elements)
+# cannot be parallelized by "one block per line" -- one block would own the
+# whole GPU's worth of work alone. That regime uses a 3-pass workspace scan
+# (reduce chunk totals -> exclusive-scan the small workspace -> re-scan each
+# chunk seeded with its workspace prefix) instead of decoupled lookback:
+# per AGENTS.md, atomics with sequential ordering are out, and decoupled
+# lookback needs acquire/release visibility across SMs that is not something
+# this kernel leans on -- the workspace passes are correct by construction
+# (kernel-launch ordering on one stream already gives the needed
+# happens-before, no fences to get right). This 3-pass design measures
+# ~1.6x stock on the extreme "one 10M-element line" shape (vs. today's
+# ~18700x SLOWER one-thread-per-row kernel) -- a real regression on an
+# absolute roofline, but still a large win, and a decoupled-lookback
+# single-pass scan to close the remaining gap is a separate, queued
+# follow-up (see the PR description).
+#
+# This file only contains the device kernels and pointer-taking host
+# wrappers (no TensorSpec/CPU-fallback plumbing, no dtype gating loops --
+# see `_cumsum_spec_into_go` in nn_ops.mojo for that), mirroring how
+# `tn_f32_gemm_core.mojo`/`gemm_splitk_common.mojo` sit next to
+# `matmul_ops.mojo` in the sibling family.
+# ===----------------------------------------------------------------------=== #
+
+from max.gpu.host import DeviceContext
+from max.gpu.primitives import block
+from std.gpu import (
+    MAX_THREADS_PER_BLOCK_METADATA,
+    WARP_SIZE,
+    block_dim,
+    block_idx,
+    grid_dim,
+    thread_idx,
+)
+from std.math import ceildiv
+from std.sys import size_of
+from std.utils.static_tuple import StaticTuple
+
+from op_utils import _device_sm_count, _enqueue_cached
+
+# Annotated List[DType]: rc1 infers bare `[...]` literals as Array, which no
+# longer binds to variant_gates._dtype_supported's `List[DType]` parameter
+# (see reduction_ops.mojo's SPEC_ROWRED_DTYPES for the same wrap).
+comptime CUMSUM_DTYPES: List[DType] = [
+    DType.float32,
+    DType.bfloat16,
+    DType.float16,
+    DType.int32,
+    DType.int64,
+]
+
+# Threads-per-block choices for the INNER family. 1024 covers the primary
+# 4096-column benchmark shape in a single tile (zero carry-loop rounds); 256
+# is kept for short rows where a 1024-thread block would leave most lanes
+# idle on every tile and cost occupancy for no benefit.
+comptime INNER_THREADS_BIG = 1024
+comptime INNER_THREADS_SMALL = 256
+# Row byte threshold between them -- mirrors reduction_ops.mojo's
+# LSM_BIG_ROW_BYTES (same reasoning: below this, more, smaller blocks beat
+# fewer, bigger ones because there is nothing to hide behind fewer tiles).
+comptime INNER_BIG_ROW_BYTES = 8192
+
+comptime OUTER_THREADS = WARP_SIZE
+
+# Threads-per-block and elements-per-thread ("tiles") for the long-line
+# workspace path's phase 1/3 kernels -- deliberately a SEPARATE knob from
+# INNER_THREADS_{BIG,SMALL} above: that pair was fitted to the "many lines,
+# one block owns a whole line" regime, and the workspace regime's optimum
+# turned out to sit at a different point entirely (fewer threads/block, not
+# more). Fitted on H100 PCIe (114 SMs) -- see the PR description for the
+# full swept table (threads x tiles vs. phase1/phase3 device time):
+#   * threads=1024, tiles=1 (one block = one 4KB tile, the naive starting
+#     point) is LATENCY-bound by the block-wide combine's own round-trip
+#     latency, not bandwidth -- far too many small blocks per wave.
+#   * Growing `tiles` while reusing `_inner_tile` per round does not help
+#     past tiles~8-16: total ROUNDS over the whole line is invariant to
+#     tiles under that scheme.
+#   * Fix: `_cumsum_chunk_finish_kernel` below does ONE block.prefix_sum per
+#     chunk regardless of `tiles` (each thread serially scans its own
+#     CONTIGUOUS `tiles`-run in registers first). A big `tiles` on a
+#     1024-thread block then blows the register budget and collapses
+#     occupancy -- measured: threads=1024 CRASHES outright at tiles=32 with
+#     CUDA LAUNCH_OUT_OF_RESOURCES, the exact trap AGENTS.md's "Fully
+#     comptime-unrolled inner loops" note warns about. The
+#     MAX_THREADS_PER_BLOCK_METADATA launch-bounds hint below is what turns
+#     that class of failure into a compile-time-checked launch instead of a
+#     silent runtime crash on a future retune.
+#   * The real optimum sits at SMALLER blocks: threads=256, tiles=4 (chunk
+#     = 1024 elements/block) was the fastest of the swept configurations,
+#     with 128/192 threads at tiles=4 statistically indistinguishable; 256
+#     is kept for being a round, warp-aligned, already-used-elsewhere
+#     (INNER_THREADS_SMALL) number.
+comptime WS_THREADS = 256
+comptime WS_CHUNK_TILES = 4
+
+# Below this many independent lines (relative to the device's own SM count),
+# a regime cannot fill the GPU by line parallelism alone. FILL_WAVES=2 is a
+# launch-geometry choice (not device code -- would not show up in a
+# PTX/asm diff, see AGENTS.md's cross-compile note), fitted once and
+# expected to transfer across NVIDIA parts of different SM counts because
+# the actual SM count is read at runtime via `_device_sm_count` below
+# (an H100 PCIe has 114 SMs, an H100 SXM 132 -- the compile-time
+# `default_device_info` table reports 132 for both, which is why this uses
+# the runtime count, not the table).
+comptime FILL_WAVES = 2
+
+
+@always_inline
+def _acc_dtype[dtype: DType]() -> DType:
+    """Accumulation dtype: f32 for the 16-bit floats (stock torch's cumsum
+    accumulates half/bf16 in f32 and casts back down), native dtype
+    otherwise -- matches stock behavior and avoids a lossy running sum."""
+    comptime if dtype in (DType.float16, DType.bfloat16):
+        return DType.float32
+    else:
+        return dtype
+
+
+# ===========================================================================
+# INNER family
+# ===========================================================================
+
+
+@always_inline
+def _inner_tile[
+    dtype: DType, acc: DType, threads: Int, exclusive: Bool = False
+](
+    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    base: Int,
+    n_valid: Int,
+    carry: Scalar[acc],
+) -> Scalar[acc]:
+    """Scan one tile of up to `threads` contiguous elements starting at
+    `base` (element index in `in_ptr`/`out_ptr`), add `carry`, store to
+    `out_ptr`. Returns the new carry (running total through this tile,
+    always the INCLUSIVE tile sum regardless of `exclusive`, so the caller
+    can chain tiles regardless of which flavor it asked for).
+
+    `n_valid <= threads` on a ragged last tile: lanes >= n_valid contribute
+    the identity (0) to the scan and do not store (there is nothing at
+    `base + tid` for them to write).
+    """
+    var tid = Int(thread_idx.x)
+    var val = Scalar[acc](0)
+    if tid < n_valid:
+        val = in_ptr[base + tid].cast[acc]()
+    # Always scan exclusive internally: the inclusive value (needed for the
+    # tile-total broadcast either way) is one add away, and the caller's
+    # requested flavor is a comptime select, not a second scan.
+    var excl = block.prefix_sum[block_size=threads, exclusive=True](val)
+    var incl = excl + val
+
+    comptime if exclusive:
+        if tid < n_valid:
+            out_ptr[base + tid] = (carry + excl).cast[dtype]()
+    else:
+        if tid < n_valid:
+            out_ptr[base + tid] = (carry + incl).cast[dtype]()
+
+    var last = n_valid - 1
+    var tile_total = block.broadcast[block_size=threads](incl, src_thread=last)
+    return carry + tile_total
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(threads))
+)
+@__name(t"cumsum_inner_lines_{dtype}_{threads}_{exclusive}")
+def _cumsum_inner_lines_kernel[
+    dtype: DType, threads: Int, exclusive: Bool = False
+](
+    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    line_len_arg: Int64,
+    num_lines_arg: Int64,
+):
+    """One block owns a whole line (grid-stride over lines); within a line,
+    `threads`-sized tiles are chained by a register `carry`. Used both as
+    the main "many lines" INNER kernel and, with dtype=acc/exclusive=True,
+    as phase 2 (the small in-place exclusive scan of a workspace) of the
+    long-line path below.
+    """
+    comptime acc = _acc_dtype[dtype]()
+    var line_len = Int(line_len_arg)
+    var num_lines = Int(num_lines_arg)
+    var line = Int(block_idx.x)
+    while line < num_lines:
+        var row_base = line * line_len
+        var carry = Scalar[acc](0)
+        var chunk_start = 0
+        while chunk_start < line_len:
+            var n_valid = min(threads, line_len - chunk_start)
+            carry = _inner_tile[dtype, acc, threads, exclusive](
+                in_ptr, out_ptr, row_base + chunk_start, n_valid, carry
+            )
+            chunk_start += threads
+        line += Int(grid_dim.x)
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(threads))
+)
+@__name(t"cumsum_chunk_reduce_{dtype}_{threads}_{tiles}")
+def _cumsum_chunk_reduce_kernel[
+    dtype: DType, threads: Int, tiles: Int
+](
+    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    workspace_ptr: UnsafePointer[Scalar[_acc_dtype[dtype]()], MutAnyOrigin],
+    line_len_arg: Int64,
+    chunks_per_line_arg: Int64,
+):
+    """Phase 1 of the long-line path: one block per (line, chunk) of up to
+    `tiles * threads` elements, each thread summing its up-to-`tiles`
+    strided elements serially before a single `block.sum` combine, into
+    `workspace[line*chunks_per_line+chunk]`.
+
+    `tiles` amortizes fixed per-block cost (CTA launch/teardown, the
+    block-wide combine's own latency) over more bytes moved per block --
+    at tiles=1 (one element/thread/block) this kernel is latency-bound by
+    the SHEER NUMBER of blocks/waves, not bandwidth, on a line long enough
+    to need the workspace path at all.
+    """
+    comptime acc = _acc_dtype[dtype]()
+    var line_len = Int(line_len_arg)
+    var chunks_per_line = Int(chunks_per_line_arg)
+    var flat = Int(block_idx.x)
+    var line = flat // chunks_per_line
+    var chunk = flat % chunks_per_line
+    var chunk_start = chunk * threads * tiles
+    var row_base = line * line_len
+    var tid = Int(thread_idx.x)
+    var partial = Scalar[acc](0)
+
+    @parameter
+    for t in range(tiles):
+        var local = t * threads + tid
+        var global_idx = chunk_start + local
+        if global_idx < line_len:
+            partial += in_ptr[row_base + global_idx].cast[acc]()
+    var total = block.sum[block_size=threads](partial)
+    if tid == 0:
+        workspace_ptr[flat] = total
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(threads))
+)
+@__name(t"cumsum_chunk_finish_{dtype}_{threads}_{tiles}")
+def _cumsum_chunk_finish_kernel[
+    dtype: DType, threads: Int, tiles: Int
+](
+    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    workspace_ptr: UnsafePointer[Scalar[_acc_dtype[dtype]()], ImmutAnyOrigin],
+    line_len_arg: Int64,
+    chunks_per_line_arg: Int64,
+):
+    """Phase 3: one block per (line, chunk) again, re-scans its own up to
+    `tiles * threads` elements (cheap ALU vs. the alternative of storing and
+    re-reading the phase-1 local scan -- this is what keeps total traffic at
+    2 reads + 1 write instead of 2 reads + 2 writes) seeded with the
+    workspace's exclusive prefix. No cross-block carry: every chunk already
+    knows its true global starting offset from the workspace.
+
+    Coarsened (blocked, not striped) assignment: thread `tid` owns the
+    CONTIGUOUS run `[tid*tiles, tid*tiles+tiles)` of the chunk, scans it
+    serially in registers (no synchronization), and only ONE
+    `block.prefix_sum` (over the `threads` per-thread local totals) is
+    needed to place every thread's run, regardless of `tiles`. Without the
+    launch-bounds metadata below, a large `tiles` on a large `threads` block
+    (`InlineArray[Scalar[acc], tiles]` fully live across the
+    `block.prefix_sum` call) can ask the register allocator for more than
+    the hardware has and crash at launch (CUDA LAUNCH_OUT_OF_RESOURCES,
+    measured at threads=1024/tiles=32) instead of just running slower --
+    the metadata turns that into a compile-time-checked bound.
+    """
+    comptime acc = _acc_dtype[dtype]()
+    var line_len = Int(line_len_arg)
+    var chunks_per_line = Int(chunks_per_line_arg)
+    var flat = Int(block_idx.x)
+    var line = flat // chunks_per_line
+    var chunk = flat % chunks_per_line
+    var chunk_start = chunk * threads * tiles
+    var row_base = line * line_len
+    var seed = workspace_ptr[flat]
+    var tid = Int(thread_idx.x)
+    var local_base = chunk_start + tid * tiles
+
+    var local_scan = InlineArray[Scalar[acc], tiles](uninitialized=True)
+    var running = Scalar[acc](0)
+
+    @parameter
+    for k in range(tiles):
+        var idx = local_base + k
+        if idx < line_len:
+            running += in_ptr[row_base + idx].cast[acc]()
+        local_scan[k] = running
+
+    var excl = block.prefix_sum[block_size=threads, exclusive=True](running)
+    var base = seed + excl
+
+    @parameter
+    for k in range(tiles):
+        var idx = local_base + k
+        if idx < line_len:
+            out_ptr[row_base + idx] = (base + local_scan[k]).cast[dtype]()
+
+
+# ===========================================================================
+# OUTER family: scan dim stride == line_len (e.g. dim=0 on a contiguous 2D
+# tensor). `outer`/`inner` generalize past rank 2: elements before the scan
+# dim fold into `outer`, elements after it (the contiguous, independent-line
+# axis) fold into `inner`. dim=0 on a plain (R, C) tensor is outer=1,
+# inner=C, scan_len=R. Only the rank-2 case is wired up on the Python side
+# today (see nn_ops.mojo); the kernel itself is already generic.
+# ===========================================================================
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(threads))
+)
+@__name(t"cumsum_outer_lines_{dtype}_{threads}")
+def _cumsum_outer_kernel[
+    dtype: DType, threads: Int
+](
+    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    scan_len_arg: Int64,
+    inner_arg: Int64,
+    num_lines_arg: Int64,
+):
+    comptime acc = _acc_dtype[dtype]()
+    var scan_len = Int(scan_len_arg)
+    var inner = Int(inner_arg)
+    var num_lines = Int(num_lines_arg)
+    var gtid = Int(block_idx.x) * Int(block_dim.x) + Int(thread_idx.x)
+    var gstride = Int(grid_dim.x) * Int(block_dim.x)
+    var line = gtid
+    while line < num_lines:
+        var outer_idx = line // inner
+        var inner_idx = line % inner
+        var base = outer_idx * scan_len * inner + inner_idx
+        var acc_v = Scalar[acc](0)
+        var r = 0
+        while r < scan_len:
+            var addr = base + r * inner
+            acc_v += in_ptr[addr].cast[acc]()
+            out_ptr[addr] = acc_v.cast[dtype]()
+            r += 1
+        line += gstride
+
+
+# ===========================================================================
+# Host-side enqueue wrappers. Pointers are already typed/origin-cast by the
+# caller (see nn_ops.mojo's `_cumsum_inner_into`/`_cumsum_outer_into`, which
+# also own the CPU-fallback branch and the TensorSpec address plumbing).
+# ===========================================================================
+
+
+@always_inline
+def _inner_threads(cols: Int, itemsize: Int) -> Int:
+    if cols * itemsize > INNER_BIG_ROW_BYTES:
+        return INNER_THREADS_BIG
+    return INNER_THREADS_SMALL
+
+
+@always_inline
+def enqueue_cumsum_rows[
+    dtype: DType
+](
+    ctx: DeviceContext,
+    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    rows: Int,
+    cols: Int,
+) raises:
+    """INNER family, 'many lines' regime: no workspace, one block per line
+    (grid-stride)."""
+    comptime esize = size_of[dtype]()
+    var threads = _inner_threads(cols, esize)
+    var blocks = min(rows, _device_sm_count(ctx) * 8)
+    if threads == INNER_THREADS_BIG:
+        _enqueue_cached[_cumsum_inner_lines_kernel[dtype, INNER_THREADS_BIG]](
+            ctx,
+            String(t"cumsum_rows_{dtype}_{INNER_THREADS_BIG}"),
+            blocks,
+            1,
+            1,
+            INNER_THREADS_BIG,
+            out_ptr,
+            in_ptr,
+            Int64(cols),
+            Int64(rows),
+        )
+    else:
+        _enqueue_cached[_cumsum_inner_lines_kernel[dtype, INNER_THREADS_SMALL]](
+            ctx,
+            String(t"cumsum_rows_{dtype}_{INNER_THREADS_SMALL}"),
+            blocks,
+            1,
+            1,
+            INNER_THREADS_SMALL,
+            out_ptr,
+            in_ptr,
+            Int64(cols),
+            Int64(rows),
+        )
+
+
+@always_inline
+def cumsum_workspace_lines[dtype: DType](rows: Int, cols: Int) -> Int:
+    """Element count (in acc dtype) the caller must allocate for
+    `enqueue_cumsum_rows_workspace`'s workspace buffer."""
+    return rows * ceildiv(cols, WS_THREADS * WS_CHUNK_TILES)
+
+
+@always_inline
+def enqueue_cumsum_rows_workspace[
+    dtype: DType
+](
+    ctx: DeviceContext,
+    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    rows: Int,
+    cols: Int,
+    workspace_ptr: UnsafePointer[Scalar[_acc_dtype[dtype]()], MutAnyOrigin],
+) raises:
+    """INNER family, 'few very long lines' regime: 3-pass workspace scan.
+    `workspace_ptr` must hold >= cumsum_workspace_lines[dtype](rows, cols)
+    elements of the accumulation dtype. Phase 1/3 threads/tiles are the
+    WS_THREADS/WS_CHUNK_TILES fitted separately from the 'many lines'
+    regime -- see their definition for the measurements.
+    """
+    comptime acc = _acc_dtype[dtype]()
+    comptime esize = size_of[dtype]()
+    var chunks_per_line = ceildiv(cols, WS_THREADS * WS_CHUNK_TILES)
+    var total_chunks = rows * chunks_per_line
+    var ws_immut = workspace_ptr.as_immutable()
+    var sm_blocks = min(rows, _device_sm_count(ctx) * 8)
+
+    _enqueue_cached[
+        _cumsum_chunk_reduce_kernel[dtype, WS_THREADS, WS_CHUNK_TILES]
+    ](
+        ctx,
+        String(t"cumsum_reduce_{dtype}_{WS_THREADS}_{WS_CHUNK_TILES}"),
+        total_chunks,
+        1,
+        1,
+        WS_THREADS,
+        in_ptr,
+        workspace_ptr,
+        Int64(cols),
+        Int64(chunks_per_line),
+    )
+
+    # Phase 2: exclusive-scan the (rows, chunks_per_line) workspace in place.
+    # Reuses the INNER 'many lines' kernel with dtype=acc: each of the `rows`
+    # lines resets its own carry, so per-line independence is automatic.
+    var ws_threads = _inner_threads(chunks_per_line, esize)
+    if ws_threads == INNER_THREADS_BIG:
+        _enqueue_cached[
+            _cumsum_inner_lines_kernel[acc, INNER_THREADS_BIG, True]
+        ](
+            ctx,
+            String(t"cumsum_ws_scan_{acc}_{INNER_THREADS_BIG}"),
+            sm_blocks,
+            1,
+            1,
+            INNER_THREADS_BIG,
+            workspace_ptr,
+            ws_immut,
+            Int64(chunks_per_line),
+            Int64(rows),
+        )
+    else:
+        _enqueue_cached[
+            _cumsum_inner_lines_kernel[acc, INNER_THREADS_SMALL, True]
+        ](
+            ctx,
+            String(t"cumsum_ws_scan_{acc}_{INNER_THREADS_SMALL}"),
+            sm_blocks,
+            1,
+            1,
+            INNER_THREADS_SMALL,
+            workspace_ptr,
+            ws_immut,
+            Int64(chunks_per_line),
+            Int64(rows),
+        )
+
+    _enqueue_cached[
+        _cumsum_chunk_finish_kernel[dtype, WS_THREADS, WS_CHUNK_TILES]
+    ](
+        ctx,
+        String(t"cumsum_finish_{dtype}_{WS_THREADS}_{WS_CHUNK_TILES}"),
+        total_chunks,
+        1,
+        1,
+        WS_THREADS,
+        out_ptr,
+        in_ptr,
+        ws_immut,
+        Int64(cols),
+        Int64(chunks_per_line),
+    )
+
+
+@always_inline
+def enqueue_cumsum_cols[
+    dtype: DType
+](
+    ctx: DeviceContext,
+    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    rows: Int,
+    cols: Int,
+) raises:
+    """OUTER family (dim=0 on a plain contiguous 2D tensor): outer=1,
+    inner=cols, scan_len=rows."""
+    var blocks = ceildiv(cols, OUTER_THREADS)
+    _enqueue_cached[_cumsum_outer_kernel[dtype, OUTER_THREADS]](
+        ctx,
+        String(t"cumsum_cols_{dtype}_{OUTER_THREADS}"),
+        blocks,
+        1,
+        1,
+        OUTER_THREADS,
+        out_ptr,
+        in_ptr,
+        Int64(rows),
+        Int64(cols),
+        Int64(cols),
+    )

--- a/torch_mojo_backend/eager_kernels/nn_ops/nn_ops.mojo
+++ b/torch_mojo_backend/eager_kernels/nn_ops/nn_ops.mojo
@@ -51,6 +51,15 @@ from std.utils.static_tuple import StaticTuple
 from max.algorithm import elementwise
 
 from argreduce_kernels import _argreduce_spec_into
+from cumsum_kernels import (
+    CUMSUM_DTYPES,
+    FILL_WAVES,
+    _acc_dtype,
+    cumsum_workspace_lines,
+    enqueue_cumsum_cols,
+    enqueue_cumsum_rows,
+    enqueue_cumsum_rows_workspace,
+)
 from reduce_skeleton import (
     AllOp,
     AnyOp,
@@ -70,6 +79,7 @@ from op_utils import (
     MAX_RANK,
     _check_into,
     _check_into_sized,
+    _device_sm_count,
     _enqueue_cached,
     _make_ptr,
     _parallel_for,
@@ -82,6 +92,7 @@ from op_utils import (
     _raw_tuple_int,
     _reduce_spec_geom,
     _spec_dispatcher2,
+    _spec_dispatcher3,
     _spec_dispatcher4,
     _spec_dispatcher5,
     _spec_dispatcher7,
@@ -1934,16 +1945,40 @@ def _any_bool_go(
 
 
 # ---------------------------------------------------------------------------
-# Row-wise cumulative sum along the last dim: input viewed as (rows, cols).
-# One sequential task per row — used on the small int tensors of the
-# generation loop (position ids from attention-mask cumsum).
+# Cumulative sum, INNER (trailing dim, any rank) or OUTER (dim=0, rank 2)
+# family — see cumsum_kernels.mojo for the fast, NVIDIA-measured kernels
+# (one block cooperating over a "line" via block.prefix_sum for INNER, one
+# thread per independent column for OUTER, plus a 3-pass workspace scan for
+# the few-very-long-lines regime).
+#
+# `_cumsum_rows_portable`/`_cumsum_cols_portable` below are a DIFFERENT,
+# simpler thing: a plain one-task-per-line serial accumulate through
+# `_parallel_for`, which is what's used for
+#   (a) true CPU (`ctx.api() == "cpu"`, e.g. the `mojo:cpu` test device —
+#       there is no warp coalescing to lose in the first place, and this is
+#       what the small int tensors of the generation loop, position ids
+#       from attention-mask cumsum, hit today), and
+#   (b) any GPU `ctx.api()` is not `"cuda"` for (AMD, Apple): `block.
+#       prefix_sum`/`block.sum` are portable MAX primitives and this whole
+#       kernel family DOES cross-compile for gfx942 (verified with
+#       scripts/compare_kernel_asm.py), but it was only ever MEASURED on
+#       NVIDIA (H100) — see the PR that added this file. Per AGENTS.md's
+#       "To check a kernel change against a GPU you do not have", an
+#       unmeasured architecture gets the change gated off, not shipped on
+#       faith, so non-CUDA GPUs keep running the exact naive kernel `main`
+#       ran for cumsum before this file existed (dispatch matches at the
+#       Python layer too — see `fast_aten_cumsum`'s `is_cuda` gate).
+#       `_parallel_for` itself already knows how to target a non-CPU
+#       device (`elementwise[..., target="gpu"]`), so this same function
+#       serves both (a) and (b) — "portable", not "CPU-only".
 # ---------------------------------------------------------------------------
 
 
 @always_inline
-def _cumsum_rows[
+def _cumsum_rows_portable[
     dtype: DType
 ](out_addr: Int, in_addr: Int, rows: Int, cols: Int, ctx: DeviceContext) raises:
+    comptime acc = _acc_dtype[dtype]()
     var out_ptr = _make_ptr[dtype](out_addr)
     var in_ptr = _make_ptr[dtype](in_addr)
 
@@ -1953,12 +1988,113 @@ def _cumsum_rows[
     def func[width: Int, alignment: Int = 1](idx: Coord):
         var r = Int(idx[0].value())
         var base = r * cols
-        var total = Scalar[dtype](0)
+        var total = Scalar[acc](0)
         for j in range(cols):
-            total += in_ptr[base + j]
-            out_ptr[base + j] = total
+            total += in_ptr[base + j].cast[acc]()
+            out_ptr[base + j] = total.cast[dtype]()
 
     _parallel_for[func](rows, ctx)
+
+
+@always_inline
+def _cumsum_cols_portable[
+    dtype: DType
+](out_addr: Int, in_addr: Int, rows: Int, cols: Int, ctx: DeviceContext) raises:
+    """Portable (CPU or non-CUDA GPU) fallback for dim=0: one parallel task
+    per column. Unlike `_cumsum_rows_portable`, this has no naive-kernel
+    precedent on `main` (dim=0 simply raised NotImplementedError there).
+    `fast_aten_cumsum` currently only ever reaches dim=0 on a CUDA device
+    (its own `is_cuda` gate declines dim=0 elsewhere, matching "keep AMD on
+    its current path"), so on today's dispatch this body only runs for the
+    `mojo:cpu` test device; it stays a real, tested implementation (not a
+    stub) so that gate can be loosened later without a new kernel."""
+    comptime acc = _acc_dtype[dtype]()
+    var out_ptr = _make_ptr[dtype](out_addr)
+    var in_ptr = _make_ptr[dtype](in_addr)
+
+    @always_inline
+    @parameter
+    @__copy_capture(out_ptr, in_ptr)
+    def func[width: Int, alignment: Int = 1](idx: Coord):
+        var c = Int(idx[0].value())
+        var total = Scalar[acc](0)
+        var i = 0
+        while i < rows:
+            var addr = i * cols + c
+            total += in_ptr[addr].cast[acc]()
+            out_ptr[addr] = total.cast[dtype]()
+            i += 1
+
+    _parallel_for[func](cols, ctx)
+
+
+@always_inline
+def _cumsum_inner_into[
+    dtype: DType
+](out_addr: Int, in_addr: Int, rows: Int, cols: Int, ctx: DeviceContext) raises:
+    """INNER family entry: dim is the trailing (stride-1) axis.
+
+    The fast `block.prefix_sum`-based kernels below are NVIDIA-only by
+    measurement, not by portability (`block.prefix_sum`/`block.sum` cross-
+    compile fine for AMD -- verified with scripts/compare_kernel_asm.py,
+    --accelerator gfx942). `ctx.api() == "cuda"` gates them off on anything
+    else, same as `_device.api == "cuda"` gates `fast_aten_cumsum`'s own
+    dim/dtype widening in aten_fast.py -- see that gate's comment for why.
+    """
+    if ctx.api() == "cuda":
+        comptime if has_accelerator():
+            var gout = _make_ptr[dtype](out_addr).as_unsafe_any_origin()
+            var gin = (
+                _make_ptr[dtype](in_addr).as_unsafe_any_origin().as_immutable()
+            )
+            # sm_count_floor: below this many independent lines, one block
+            # per line cannot fill the device — see FILL_WAVES in
+            # cumsum_kernels.mojo. Read at runtime (not the compile-time
+            # `default_device_info` table) because two cards of the same
+            # architecture can differ here (H100 PCIe: 114 SMs, H100 SXM:
+            # 132 — the table reports 132 for both).
+            var sm_count_floor = _device_sm_count(ctx) * FILL_WAVES
+            if rows >= sm_count_floor:
+                enqueue_cumsum_rows[dtype](ctx, gout, gin, rows, cols)
+            else:
+                comptime acc = _acc_dtype[dtype]()
+                var ws_n = max(1, cumsum_workspace_lines[dtype](rows, cols))
+                var ws = ctx.enqueue_create_buffer[acc](ws_n)
+                enqueue_cumsum_rows_workspace[dtype](
+                    ctx,
+                    gout,
+                    gin,
+                    rows,
+                    cols,
+                    ws.unsafe_ptr().as_unsafe_any_origin(),
+                )
+                # Keep the workspace alive until its free is enqueued after
+                # the finish kernel (stream-ordered, matches the GEMM
+                # split-K workspace pattern in matmul_ops.mojo).
+                _ = ws^
+        else:
+            raise Error("no GPU accelerator available at compile time")
+    else:
+        _cumsum_rows_portable[dtype](out_addr, in_addr, rows, cols, ctx)
+
+
+@always_inline
+def _cumsum_outer_into[
+    dtype: DType
+](out_addr: Int, in_addr: Int, rows: Int, cols: Int, ctx: DeviceContext) raises:
+    """OUTER family entry: dim=0 on a contiguous rank-2 tensor. Same
+    CUDA-only fast-path gate as `_cumsum_inner_into` above."""
+    if ctx.api() == "cuda":
+        comptime if has_accelerator():
+            var gout = _make_ptr[dtype](out_addr).as_unsafe_any_origin()
+            var gin = (
+                _make_ptr[dtype](in_addr).as_unsafe_any_origin().as_immutable()
+            )
+            enqueue_cumsum_cols[dtype](ctx, gout, gin, rows, cols)
+        else:
+            raise Error("no GPU accelerator available at compile time")
+    else:
+        _cumsum_cols_portable[dtype](out_addr, in_addr, rows, cols, ctx)
 
 
 # ---------------------------------------------------------------------------
@@ -2656,12 +2792,6 @@ def _any_bool_dispatcher(
     return _raw_ret_none()
 
 
-comptime SPEC_CUMSUM_DTYPES: List[DType] = [
-    DType.int64,
-    DType.int32,
-    DType.float32,
-]
-
 comptime SPEC_MAXROWS_DTYPES: List[DType] = [
     DType.float32,
     DType.float16,
@@ -2686,31 +2816,50 @@ def _argmax_spec_into_go(
     _argreduce_spec_into[SPEC_MAXROWS_DTYPES, False](a, out, rdims_t, a.ctx())
 
 
-def _cumsum_spec_into_go(a_o: PyObjectPtr, out_o: PyObjectPtr) raises:
-    """Cumulative sum over the trailing dim; full-shape output."""
+def _cumsum_spec_into_go(
+    a_o: PyObjectPtr, dim_o: PyObjectPtr, out_o: PyObjectPtr
+) raises:
+    """Cumulative sum over the trailing dim (any rank) or dim=0 of a rank-2
+    tensor; full-shape output. Python (`fast_aten_cumsum`) normalizes the
+    dim and pre-materializes non-contiguous/other-dim inputs, but this
+    boundary re-validates rather than trusting the caller, matching every
+    other spec bridge in this file."""
     ref a = _spec_ptr(a_o)[]
     ref out = _spec_ptr(out_o)[]
-    if not _dtype_supported[SPEC_CUMSUM_DTYPES](a.dtype):
+    if not _dtype_supported[CUMSUM_DTYPES](a.dtype):
         raise Error("mojo spec cumsum: unsupported dtype ", a.dtype)
     if a.rank < 1 or a.numel == 0:
         raise Error("mojo spec cumsum: empty or rank-0 input")
-
-    var cols = a.shape[MAX_RANK - 1]
-    var rows = a.numel // cols
-    var ctx = a.ctx()
-    var nbytes = a.numel * a.itemsize
-    _ = nbytes
-    _check_into(a, out, a.dtype)
-    var addr = out.ptr
-    if a.contig:
-        comptime for dt in [DType.int64, DType.int32, DType.float32]:
-            comptime if _dtype_arg_on[0, dt]():
-                if a.dtype == dt:
-                    _cumsum_rows[dt](addr, a.ptr, rows, cols, ctx)
-    else:
+    var dim = _raw_int(dim_o)
+    if dim < 0 or dim >= a.rank:
+        raise Error("mojo spec cumsum: dim out of range")
+    if not a.contig:
         raise Error(
             "mojo spec cumsum: input must be contiguous"
             " (Python pre-materializes)"
+        )
+    _check_into(a, out, a.dtype)
+    var addr = out.ptr
+    var ctx = a.ctx()
+
+    if dim == a.rank - 1:
+        var cols = a.shape[MAX_RANK - 1]
+        var rows = a.numel // cols
+        comptime for dt in CUMSUM_DTYPES:
+            comptime if _dtype_arg_on[0, dt]():
+                if a.dtype == dt:
+                    _cumsum_inner_into[dt](addr, a.ptr, rows, cols, ctx)
+    elif dim == 0 and a.rank == 2:
+        var rows = a.dim(0)
+        var cols = a.dim(1)
+        comptime for dt in CUMSUM_DTYPES:
+            comptime if _dtype_arg_on[0, dt]():
+                if a.dtype == dt:
+                    _cumsum_outer_into[dt](addr, a.ptr, rows, cols, ctx)
+    else:
+        raise Error(
+            "mojo spec cumsum: dim must be the trailing dim, or dim=0 on a"
+            " rank-2 tensor"
         )
 
 
@@ -2942,8 +3091,11 @@ def PyInit_nn_ops() abi("C") -> PythonObject:
         comptime if _op_on["CumsumSpec"]():
             _register_call(
                 b,
-                _spec_dispatcher2[_cumsum_spec_into_go, "CumsumSpec"],
-                docstring="(a_spec, out_spec); trailing dim",
+                _spec_dispatcher3[_cumsum_spec_into_go, "CumsumSpec"],
+                docstring=(
+                    "(a_spec, dim, out_spec); trailing dim, or dim=0 on a"
+                    " rank-2 tensor"
+                ),
             )
         comptime if _op_on["BatchNormSpec"]():
             _register_call(


### PR DESCRIPTION
## Summary

`aten::cumsum`'s eager fast path was one thread per row, serially walking
each row of a `(rows, cols)`-viewed tensor. Adjacent threads (adjacent rows)
touch addresses `cols` elements apart at every step, so the warp never
coalesces — 7.08x slower than stock on the recorded `S_4096x4096_d1`/f32
baseline, and `dim=0`/bf16/f16 raised `NotImplementedError` outright.

This replaces it with a parametric kernel family in a new
`nn_ops/cumsum_kernels.mojo`, chosen by the STRIDE of the scan dim:

- **INNER** (trailing/stride-1 dim, any rank): one block owns a "line";
  `threads`-sized tiles are scanned with the mojo stdlib's
  `block.prefix_sum` + `block.broadcast`, chained by a register-resident
  carry. Below `sm_count * FILL_WAVES` independent lines (read at runtime,
  not the compile-time SM table — an H100 PCIe has 114 SMs, an SXM 132, and
  the table reports 132 for both), a 3-pass workspace scan takes over
  instead: reduce chunk totals, exclusive-scan the small workspace,
  re-scan each chunk seeded with its prefix. Not decoupled lookback — per
  AGENTS.md, sequential-ordering atomics are out and lookback needs
  cross-SM acquire/release this kernel doesn't lean on; kernel-launch
  ordering on one stream already gives the happens-before the workspace
  needs.
- **OUTER** (`dim=0` on a contiguous rank-2 tensor): adjacent threads own
  adjacent columns, so coalescing is free — a plain serial
  accumulate-and-store loop per thread, no cooperation at all.

## Results (H100 PCIe, kineto device time, `benchmarks/` methodology)

| Node | Before | After | Bar (≤1.10x) |
|---|---|---|---|
| `cumsum/f32/S_4096x4096_d1` | 7.081x | **0.466x** | PASS (2.1x faster than stock) |
| `cumsum/f32/S_4096x4096_d0` | *(NotImplementedError)* | **1.011x** | PASS — new |
| `cumsum/bf16/S_4096x4096_d1` | *(NotImplementedError)* | **0.375x** | PASS — new |
| `cumsum/bf16/S_4096x4096_d0` | *(NotImplementedError)* | **0.985x** | PASS — new |

All four recorded in `benchmarks/baselines.html`. Collateral: the rest of
`benchmarks/test_reduction.py` passes (one unrelated `test_sum[bf16,
C_16777216_all]` flake at +8.6% vs. an 8% threshold reproduced only inside
the full 6-minute suite, not in isolation — pre-existing thermal-ordering
noise per AGENTS.md's benchmark notes, not touched by this PR: `sum` shares
no code with `cumsum`).

**Long single-line regime** (not a recorded benchmark node): `(1,
10_000_000)`/f32 measured ~1.6x stock on the standalone harness this PR
integrates (vs. today's ~18700x-slower naive kernel) — a real win, but
short of the 1.10x bar. Root cause: the 3-pass workspace design's cheapest
possible phase 3 (a scan+write seeded by a precomputed prefix) is already
close to stock's entire single-pass time, so phases 1+2 on top can't help
but exceed it. Closing that gap needs a decoupled-lookback single-pass scan
(true ~2N traffic vs. this design's 3N) — deliberately not attempted here:
it needs case-by-case justification of the memory-ordering primitives and
`compute-sanitizer`-grade verification this environment doesn't have, per
AGENTS.md's framing of the workspace pattern as the default-safe choice.
Queued as a follow-up; the two affected shapes are a narrow "one or a
handful of independent lines, tens of millions of elements" regime, not
what this repo's target models hit (attention masks / position-id cumsum
are many short-to-medium rows — exactly the regime that already beats
stock 2-3x).

## New test coverage

40 new tests in `tests/test_eager_kernels.py` (mid-file, next to the
`var`/reduction tests): the shape sweep covers both regimes plus edge cases
(single element/line/column, exact tile multiples, the awkward 357x789
shape), a dtype sweep (bf16/f16/i32/i64) on both the many-lines and
workspace-triggering shapes (previously f32-only), negative dim, the
`dtype=` kwarg (verified against real stock semantics: casts the input
*first*, then accumulates — not sum-then-cast), default integer/bool
promotion to int64, non-contiguous materialization (correct, not a
decline — see below), a rank-3 middle-dim decline, and a dedicated
non-CUDA-device gate check. All seeded and re-run 3x for stability; one
shape (`(200_003, 4)`, dim=0 — a 200k-deep accumulation) needed a
float64-reference tolerance instead of a raw 1e-4 bound once I hit its
zero-crossing sensitivity under an unseeded run — documented in the test.

bf16/f16 tolerance: measured worst relative error 0.39-0.90% across the
tested regimes (against an fp64 reference); test bound is 3%, roughly a
3-4x margin.

## Dispatch conditions added

`fast_aten_cumsum` in `aten_fast.py`:
- dtype gate widened to `{f32, bf16, f16, i32, i64}` (was `{f32, i32,
  i64}`), plus correct dtype promotion: no `dtype=` kwarg promotes
  non-int64 integers/bool to int64 (matches stock, verified directly — the
  old code had NO promotion logic at all, silently keeping e.g. int32
  output where stock returns int64); `dtype=` kwarg casts input first,
  then accumulates.
- dim gate widened to accept `dim == 0` when `rank == 2` (OUTER), alongside
  the existing trailing-dim-any-rank case (INNER). Everything else (rank≥3
  non-trailing dims) still declines exactly as before.
- **New `is_cuda = a._device.api == "cuda"` gate**: the fast kernel family
  was only ever measured on NVIDIA. `block.prefix_sum`/`block.sum` are
  portable MAX primitives and this family DOES cross-compile for AMD
  (verified with `scripts/compare_kernel_asm.py --accelerator gfx942` — 9
  device kernels emitted per dtype, same as sm_90a), but per AGENTS.md's
  "To check a kernel change against a GPU you do not have", an unmeasured
  architecture doesn't ship on faith. Non-CUDA devices (AMD, Apple, and
  incidentally the `mojo:cpu` test device) get exactly `main`'s pre-PR
  surface — `{f32, i32, i64}`, trailing dim only — through a portable
  `_parallel_for`-based kernel that mirrors this same gate in
  `nn_ops.mojo` (`ctx.api() == "cuda"`).

## Blast radius

`scripts/compare_kernel_asm.py --before <b693611 worktree> --after . `
scoped to `--modules nn_ops --dtypes float32 bfloat16 float16`:

- **sm_90a**: of 57 op×dtype specializations, only `CumsumSpec` differs
  (+25 new kernels; every other op — LayerNorm, BatchNorm, Softmax,
  ArgmaxSpec, GroupNorm, pooling, etc. — byte-identical). A "2 changed"
  entry under a generic `nn_ops_elementwise_r1_w1_b256_gs_*` name is a
  known limitation of the script's hash-stripped kernel-name pairing (a
  plain `dict`, confirmed by reading `collect()`): this PR is the first
  case in this codebase where one op has *two* `_parallel_for`-based
  fallback closures (INNER's and OUTER's) sharing that generic template
  name within one op-scoped build, so the script's before(1)-vs-after(2)
  comparison mispairs across closures. Verified NOT a real symbol
  collision or bug by running both fallback closures directly on the
  `mojo:cpu` device and confirming each computes its own (different,
  correct) answer.
- **gfx942**: `CumsumSpec` builds and emits 9 device kernels per dtype
  (same count as NVIDIA) — portable, as expected, but gated off by the
  `is_cuda` check above.
- Only `nn_ops.mojo` and the new `nn_ops/cumsum_kernels.mojo` were
  touched; no other entry module imports from `nn_ops/`, so no other
  module can have changed.

## Test plan

- [x] `tests/test_eager_kernels.py -k cumsum` — 40/40 passed, 3x repeat run
- [x] `tests/test_high_level_ops.py -k cumsum` — unchanged pass/xfail set,
      plus `test_cumsum_with_dtype` now genuinely passes (previously
      xfailed on a no-op `dtype=` cast the old code declined unconditionally)
- [x] `benchmarks/test_reduction.py` full file — cumsum 4/4 pass the bar,
      collateral pass except one pre-existing flaky `sum` node (see above)
- [x] `benchmarks/test_coverage.py` — 2/2 pass
- [x] `scripts/compare_kernel_asm.py` sm_90a + gfx942 — see Blast radius
- [x] `uvx pre-commit run --all-files` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TFYWf7vJNAv5VadqSz3bRu