### PR TITLE
Refuse unrunnable autograd nodes from the forward instead of aborting the process

### DIFF
--- a/docs/optimization_backlog.md
+++ b/docs/optimization_backlog.md
@@ -580,7 +580,9 @@ forward now exists)**
   `mojo_device_native_batch_norm` refuses a training call whose inputs require
   grad IN THE FORWARD — a raise from inside the autograd engine aborts the
   process on this backend rather than raising. GroupNorm likewise has a fused
-  forward and no backward.
+  forward and no backward, and `mojo_device_native_group_norm` now refuses a
+  grad-requiring call in the forward for the same reason — with no `training`
+  flag to key on, that means every such call.
 * **Why it is not optimal.** ResNet / VGG / DenseNet *training* on the mojo
   device is still blocked — now by the missing backward rather than the
   missing forward; the `demo_scripts/` vision examples are inference-only for
@@ -936,7 +938,11 @@ temporary** — **DONE** (`NormSpec`)
   and `:7442` (`len(a._shape) == 4`). `aten::convolution_backward` is not
   registered in `mojo_device_aten_ops.py` (`aten::convolution` is).
 * **Current implementation.** conv1d (rank-3 input), conv3d and transposed
-  convolutions all return `NOT_HANDLED` → raise. There is no eager conv backward.
+  convolutions all return `NOT_HANDLED` → raise. There is no eager conv
+  backward, so `mojo_device_convolution` refuses any conv whose operands
+  require grad in the FORWARD (see [N2](#n2) for why it cannot wait for the
+  backward node). A conv weight normally requires grad, so that is every conv
+  in a training model; inference under `torch.no_grad()` is unaffected.
 * **Why it is not optimal.** conv1d is a reshape away — `(N, C, L)` →
   `(N, C, 1, L)` with a `(1, kw)` kernel. The missing backward blocks all vision
   training together with [N2](#n2) and [C4](#c4).
@@ -957,7 +963,10 @@ temporary** — **DONE** (`NormSpec`)
   `aten::avg_pool2d_backward` are unregistered;
   `aten::_adaptive_avg_pool2d_backward` is explicitly `_register_missing`
   (`mojo_device_aten_ops.py`).
-* **Current implementation.** Forward-only, floor-mode-only, rank-4-only.
+* **Current implementation.** Forward-only, floor-mode-only, rank-4-only. All
+  three pooling forwards refuse a grad-requiring call in the FORWARD (see
+  [N2](#n2)); `_register_missing` on the backward was not enough, because that
+  raise still happens inside the autograd node and aborts the process.
 * **Why it is not optimal.** `ceil_mode=True` appears in common torchvision
   configurations; the missing backwards are the third blocker for vision
   training.

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -1,5 +1,6 @@
 """Tests for the Mojo-extension fast path used by mojo eager mode."""
 
+import functools
 import math
 import weakref
 from pathlib import Path
@@ -866,6 +867,175 @@ def test_fast_batch_norm_training_refuses_autograd_in_the_forward(mojo_gpu):
         )
 
 
+# Every op here has a fast forward and no runnable native backward. Reaching
+# the backward node aborts the process (exit 134, "terminate called without an
+# active exception", no traceback), so each is refused from the forward
+# instead; the table pairs the call with the backward op its message must name.
+# One case per op, so a preflight that regresses names itself in the failing
+# node id -- and can be re-run alone, which matters here: a broken preflight
+# does not fail this test, it kills the pytest process.
+_UNARY_AUTOGRAD_PREFLIGHT_CASES = [
+    ("relu", (4, 8), torch.relu, "aten::threshold_backward"),
+    ("tanh", (4, 8), torch.tanh, "aten::tanh_backward"),
+    ("sigmoid", (4, 8), torch.sigmoid, "aten::sigmoid_backward"),
+    (
+        "softmax",
+        (4, 8),
+        functools.partial(torch.softmax, dim=-1),
+        "aten::_softmax_backward_data",
+    ),
+    (
+        "_softmax",
+        (4, 8),
+        functools.partial(torch.ops.aten._softmax, dim=-1, half_to_float=False),
+        "aten::_softmax_backward_data",
+    ),
+    ("cumsum", (4, 5), functools.partial(torch.cumsum, dim=-1), "aten::flip"),
+    (
+        "avg_pool2d",
+        (2, 3, 8, 8),
+        functools.partial(torch.nn.functional.avg_pool2d, kernel_size=2),
+        "aten::avg_pool2d_backward",
+    ),
+    (
+        "max_pool2d",
+        (2, 3, 8, 8),
+        functools.partial(torch.nn.functional.max_pool2d, kernel_size=2),
+        "aten::max_pool2d_with_indices_backward",
+    ),
+    (
+        "adaptive_avg_pool2d",
+        (2, 3, 8, 8),
+        functools.partial(torch.nn.functional.adaptive_avg_pool2d, output_size=(2, 2)),
+        "aten::_adaptive_avg_pool2d_backward",
+    ),
+    (
+        "upsample_bilinear2d",
+        (2, 3, 4, 4),
+        functools.partial(
+            torch.nn.functional.interpolate, scale_factor=2, mode="bilinear"
+        ),
+        "aten::upsample_bilinear2d_backward",
+    ),
+]
+
+
+def _preflight_input(
+    shape: tuple[int, ...], device: str, seed: int = 20260819
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """The same values on the host and on the device, for an A/B comparison."""
+    host = torch.randn(*shape, generator=torch.Generator().manual_seed(seed))
+    return host, host.to(device)
+
+
+@pytest.mark.parametrize(
+    ("shape", "call", "backward_op"),
+    [case[1:] for case in _UNARY_AUTOGRAD_PREFLIGHT_CASES],
+    ids=[case[0] for case in _UNARY_AUTOGRAD_PREFLIGHT_CASES],
+)
+def test_autograd_preflight_refuses_unrunnable_backward_in_the_forward(
+    mojo_gpu, shape, call, backward_op
+):
+    """A grad-requiring call must raise here, not abort in the engine later."""
+    _, device_input = _preflight_input(shape, mojo_gpu)
+    device_input.requires_grad_()
+    with pytest.raises(NotImplementedError, match=backward_op):
+        call(device_input)
+
+
+@pytest.mark.parametrize(
+    ("shape", "call", "backward_op"),
+    [case[1:] for case in _UNARY_AUTOGRAD_PREFLIGHT_CASES],
+    ids=[case[0] for case in _UNARY_AUTOGRAD_PREFLIGHT_CASES],
+)
+def test_autograd_preflight_leaves_the_gradless_forward_working(
+    mojo_gpu, shape, call, backward_op
+):
+    """The preflight must not cost the forward: no grad wanted, no refusal.
+
+    Both halves matter -- a grad-free call, and a grad-requiring call under
+    `torch.no_grad()`, which is the workaround the refusal message advertises.
+    """
+    host_input, device_input = _preflight_input(shape, mojo_gpu)
+    expected = call(host_input)
+
+    torch.testing.assert_close(call(device_input).cpu(), expected, atol=1e-5, rtol=1e-5)
+    with torch.no_grad():
+        grad_wanted = device_input.detach().requires_grad_()
+        torch.testing.assert_close(
+            call(grad_wanted).cpu(), expected, atol=1e-5, rtol=1e-5
+        )
+
+
+def test_autograd_preflight_refuses_relu_inplace_in_the_forward(mojo_gpu):
+    """`nn.ReLU(inplace=True)` records the same node the functional form does.
+
+    The operand has to be a non-leaf: an in-place write to a leaf that requires
+    grad is rejected by PyTorch before this backend is consulted.
+    """
+    _, device_input = _preflight_input((4, 8), mojo_gpu)
+    device_input.requires_grad_()
+    with torch.no_grad():
+        torch.relu_(device_input.detach().clone())
+    non_leaf = device_input * 1.0
+    with pytest.raises(NotImplementedError, match="aten::threshold_backward"):
+        torch.relu_(non_leaf)
+
+
+def test_autograd_preflight_refuses_advanced_indexing_in_the_forward(mojo_gpu):
+    """`index.Tensor`'s backward scatters through `_index_put_impl_`."""
+    host_input, device_input = _preflight_input((4, 5), mojo_gpu)
+    index = torch.tensor([0, 2], device=mojo_gpu)
+    torch.testing.assert_close(device_input[index].cpu(), host_input[[0, 2]])
+    device_input.requires_grad_()
+    with pytest.raises(NotImplementedError, match="aten::_index_put_impl_"):
+        device_input[index]
+
+
+def test_autograd_preflight_refuses_scatter_src_only_for_the_src_gradient(mojo_gpu):
+    """Only `src`'s gradient needs `gather`; a self-only call still runs.
+
+    The `self` gradient is a scatter of zeros, which this backend can run, so
+    preflighting on "any operand requires grad" would refuse a working call.
+    """
+    host_input, device_input = _preflight_input((4, 5), mojo_gpu)
+    host_src, device_src = _preflight_input((4, 1), mojo_gpu, seed=7)
+    index = torch.zeros(4, 1, dtype=torch.long, device=mojo_gpu)
+
+    expected = host_input.scatter(1, torch.zeros(4, 1, dtype=torch.long), host_src)
+    torch.testing.assert_close(
+        device_input.scatter(1, index, device_src).cpu(), expected
+    )
+    # self-only: still allowed, and the node it records is runnable.
+    device_input.requires_grad_()
+    device_input.scatter(1, index, device_src).sum().backward()
+    assert device_input.grad is not None
+
+    with pytest.raises(NotImplementedError, match="aten::gather"):
+        device_input.detach().scatter(1, index, device_src.requires_grad_())
+
+
+def test_autograd_preflight_refuses_efficient_attention_in_the_forward(mojo_gpu):
+    """The low-level efficient-attention op, reached only by a direct call.
+
+    `F.scaled_dot_product_attention` goes through this backend's own Python
+    autograd Function, whose backward raises normally; this op is what a
+    caller reaching past that hits.
+    """
+    _, query = _preflight_input((1, 2, 4, 8), mojo_gpu)
+    with torch.no_grad():
+        torch.ops.aten._scaled_dot_product_efficient_attention(
+            query, query, query, None, False
+        )
+    query.requires_grad_()
+    with pytest.raises(
+        NotImplementedError, match="_scaled_dot_product_efficient_attention_backward"
+    ):
+        torch.ops.aten._scaled_dot_product_efficient_attention(
+            query, query, query, None, False
+        )
+
+
 @pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
 @pytest.mark.parametrize("cols", [7, 789, 1024, 4096, 20000])
 def test_fast_layer_norm_row_widths(mojo_gpu, dtype, cols):
@@ -975,6 +1145,48 @@ def test_fast_group_norm_matches_torch(mojo_gpu, dtype, n, c, hxw, groups):
     )
     for got, want in zip(actual[1:], expected[1:], strict=True):
         torch.testing.assert_close(got.cpu(), want, atol=1e-3, rtol=1e-3)
+
+
+def test_fast_group_norm_refuses_autograd_in_the_forward(mojo_gpu):
+    """A grad-requiring group norm must fail at the FORWARD.
+
+    `aten::native_group_norm_backward` is not implemented here, and a raise
+    from inside the autograd engine aborts the process on this backend instead
+    of propagating, so the refusal cannot wait for NativeGroupNormBackward0.
+    Unlike batch norm there is no `training` flag to key on: every
+    grad-requiring call is refused, and only turning grad off gets the forward.
+    """
+    host_input, device_input = _preflight_input((2, 4, 6, 6), mojo_gpu)
+    host_weight, device_weight = _preflight_input((4,), mojo_gpu, seed=11)
+    host_bias, device_bias = _preflight_input((4,), mojo_gpu, seed=13)
+
+    expected = torch.nn.functional.group_norm(host_input, 2, host_weight, host_bias)
+    torch.testing.assert_close(
+        torch.nn.functional.group_norm(
+            device_input, 2, device_weight, device_bias
+        ).cpu(),
+        expected,
+        atol=1e-5,
+        rtol=1e-5,
+    )
+
+    # Any one of the three operands wanting a gradient is enough to refuse:
+    # the engine would come back for the same unrunnable node either way.
+    for which in range(3):
+        operands = [device_input.detach(), device_weight.detach(), device_bias.detach()]
+        operands[which] = operands[which].requires_grad_()
+        with pytest.raises(NotImplementedError, match="native_group_norm_backward"):
+            torch.nn.functional.group_norm(operands[0], 2, operands[1], operands[2])
+
+    with torch.no_grad():
+        torch.testing.assert_close(
+            torch.nn.functional.group_norm(
+                device_input.detach().requires_grad_(), 2, device_weight, device_bias
+            ).cpu(),
+            expected,
+            atol=1e-5,
+            rtol=1e-5,
+        )
 
 
 def test_fast_group_norm_without_affine(mojo_gpu):
@@ -9076,6 +9288,51 @@ def test_fast_conv2d_batched_falls_back_correctly(mojo_gpu):
     dev = torch.nn.functional.conv2d(x.to(mojo_gpu), w.to(mojo_gpu), padding=1).cpu()
     ref = torch.nn.functional.conv2d(x, w, padding=1)
     torch.testing.assert_close(dev, ref, atol=5e-2, rtol=5e-2)
+
+
+def test_fast_conv2d_refuses_autograd_in_the_forward(mojo_gpu):
+    """A grad-requiring conv must fail at the FORWARD.
+
+    `aten::convolution_backward` is not implemented here, and a raise from
+    inside the autograd engine aborts the process on this backend (exit 134,
+    no traceback) instead of propagating, so the refusal cannot wait for
+    ConvolutionBackward0. A conv weight normally requires grad, so this refuses
+    conv training outright -- the alternative was a dead process -- while
+    inference under `torch.no_grad()` is untouched.
+    """
+    host_input, device_input = _preflight_input((2, 3, 8, 8), mojo_gpu)
+    host_weight, device_weight = _preflight_input((4, 3, 3, 3), mojo_gpu, seed=11)
+    host_bias, device_bias = _preflight_input((4,), mojo_gpu, seed=13)
+
+    expected = torch.nn.functional.conv2d(host_input, host_weight, host_bias, padding=1)
+    torch.testing.assert_close(
+        torch.nn.functional.conv2d(
+            device_input, device_weight, device_bias, padding=1
+        ).cpu(),
+        expected,
+        atol=5e-2,
+        rtol=5e-2,
+    )
+
+    # The weight-only case is the one every training model actually hits.
+    for which in range(3):
+        operands = [device_input.detach(), device_weight.detach(), device_bias.detach()]
+        operands[which] = operands[which].requires_grad_()
+        with pytest.raises(NotImplementedError, match="convolution_backward"):
+            torch.nn.functional.conv2d(operands[0], operands[1], operands[2], padding=1)
+
+    with torch.no_grad():
+        torch.testing.assert_close(
+            torch.nn.functional.conv2d(
+                device_input.detach().requires_grad_(),
+                device_weight,
+                device_bias,
+                padding=1,
+            ).cpu(),
+            expected,
+            atol=5e-2,
+            rtol=5e-2,
+        )
 
 
 @pytest.mark.parametrize("is_causal", [True, False])

--- a/torch_mojo_backend/mojo_device/aten_ops/autograd_preflight.py
+++ b/torch_mojo_backend/mojo_device/aten_ops/autograd_preflight.py
@@ -9,11 +9,205 @@ forward, where it still has a traceback naming the op. Each function's
 docstring spells out its own case.
 """
 
+from collections.abc import Callable, Sequence
+
 import torch
 
 from torch_mojo_backend.mojo_device.torch_mojo_tensor import TorchMojoTensor
 
-from .support import _fast, _unsupported
+from .support import _eager_impl, _fast, _refuse_unsupported_backward, _unsupported
+
+# Most of these ops have no autograd escape other than turning grad off: their
+# parameters legitimately require grad during training, so unlike batch norm
+# (whose `training=False` forward records a node nobody runs) there is no mode
+# that keeps training working. `.eval()` specifically does NOT help — it leaves
+# grad mode on and the parameters still require grad — and saying otherwise has
+# sent users chasing a workaround that cannot exist.
+_GRAD_OFF_ONLY = (
+    "The forward itself is supported: run it under torch.no_grad() or "
+    "torch.inference_mode(). Module .eval() alone does not help here, because "
+    "it leaves grad mode enabled and the parameters still require grad; "
+    "training through this op needs the backward kernel itself."
+)
+
+
+def _preflight_unsupported_backward(
+    op_name: str,
+    fast_name: str,
+    backward_op: str,
+    grad_operands: Sequence[int],
+    workaround: str = _GRAD_OFF_ONLY,
+) -> Callable[..., TorchMojoTensor | tuple[TorchMojoTensor, ...]]:
+    """`aten_fast.<fast_name>`, fronted by the forward-time autograd refusal.
+
+    One entry per op whose whole native backward is missing, which is the
+    common case and needs no reasoning beyond "which operands' gradients would
+    require it": `grad_operands` are positions in the ATen schema, so an op
+    whose backward only needs the missing kernel for one operand (scatter's
+    `src`, say) refuses only that. Ops needing more than a position list get a
+    hand-written function further down.
+    """
+    dispatch = _eager_impl(fast_name, op_name)
+
+    def preflighted(
+        *args: object, **kwargs: object
+    ) -> TorchMojoTensor | tuple[TorchMojoTensor, ...]:
+        operands = [
+            args[index]
+            for index in grad_operands
+            if index < len(args) and isinstance(args[index], torch.Tensor)
+        ]
+        if len(operands) < len(grad_operands):
+            # The PrivateUse1 boxed kernel passes every positional schema
+            # argument positionally, so this is unreachable today. If some call
+            # shape ever moves one into kwargs, checking every keyword tensor
+            # over-refuses at worst; skipping the check aborts the process.
+            operands += [
+                value for value in kwargs.values() if isinstance(value, torch.Tensor)
+            ]
+        _refuse_unsupported_backward(op_name, backward_op, tuple(operands), workaround)
+        return dispatch(*args, **kwargs)
+
+    preflighted.__name__ = "mojo_device_" + op_name.removeprefix("aten::").replace(
+        ".", "_"
+    )
+    preflighted.__qualname__ = preflighted.__name__
+    return preflighted
+
+
+# ---------------------------------------------------------------------------
+# Ops whose entire native backward is unsupported: one table entry each.
+# Alphabetical by aten name. `backward_op` names what the engine would actually
+# have failed on, which for a few of these is an ordinary forward op the
+# generated backward composes (cumsum needs `flip`, scatter needs `gather`,
+# advanced indexing needs `_index_put_impl_`) rather than a `*_backward` op.
+# ---------------------------------------------------------------------------
+
+mojo_device__adaptive_avg_pool2d = _preflight_unsupported_backward(
+    "aten::_adaptive_avg_pool2d",
+    "fast_aten__adaptive_avg_pool2d",
+    "aten::_adaptive_avg_pool2d_backward",
+    grad_operands=(0,),
+)
+
+mojo_device__scaled_dot_product_efficient_attention = _preflight_unsupported_backward(
+    "aten::_scaled_dot_product_efficient_attention",
+    "fast_aten__scaled_dot_product_efficient_attention",
+    "aten::_scaled_dot_product_efficient_attention_backward",
+    grad_operands=(0, 1, 2, 3),
+)
+
+mojo_device__softmax = _preflight_unsupported_backward(
+    "aten::_softmax",
+    "fast_aten__softmax",
+    "aten::_softmax_backward_data",
+    grad_operands=(0,),
+)
+
+mojo_device_avg_pool2d = _preflight_unsupported_backward(
+    "aten::avg_pool2d",
+    "fast_aten_avg_pool2d",
+    "aten::avg_pool2d_backward",
+    grad_operands=(0,),
+)
+
+mojo_device_cumsum = _preflight_unsupported_backward(
+    "aten::cumsum", "fast_aten_cumsum", "aten::flip", grad_operands=(0,)
+)
+
+mojo_device_index = _preflight_unsupported_backward(
+    "aten::index.Tensor",
+    "fast_aten_index",
+    "aten::_index_put_impl_",
+    grad_operands=(0,),
+)
+
+mojo_device_max_pool2d_with_indices = _preflight_unsupported_backward(
+    "aten::max_pool2d_with_indices",
+    "fast_aten_max_pool2d_with_indices",
+    "aten::max_pool2d_with_indices_backward",
+    grad_operands=(0,),
+)
+
+mojo_device_relu = _preflight_unsupported_backward(
+    "aten::relu", "fast_aten_relu", "aten::threshold_backward", grad_operands=(0,)
+)
+
+# Only the `src` gradient goes through `gather`; the `self` gradient is a
+# scatter of zeros, which runs, so a self-only call must not be refused.
+mojo_device_scatter_src = _preflight_unsupported_backward(
+    "aten::scatter.src", "fast_aten_scatter_src", "aten::gather", grad_operands=(3,)
+)
+
+mojo_device_sigmoid = _preflight_unsupported_backward(
+    "aten::sigmoid", "fast_aten_sigmoid", "aten::sigmoid_backward", grad_operands=(0,)
+)
+
+mojo_device_tanh = _preflight_unsupported_backward(
+    "aten::tanh", "fast_aten_tanh", "aten::tanh_backward", grad_operands=(0,)
+)
+
+mojo_device_upsample_bilinear2d = _preflight_unsupported_backward(
+    "aten::upsample_bilinear2d",
+    "fast_aten_upsample_bilinear2d",
+    "aten::upsample_bilinear2d_backward",
+    grad_operands=(0,),
+)
+
+
+# ---------------------------------------------------------------------------
+# Ops whose preflight needs op-specific reasoning. Alphabetical.
+# ---------------------------------------------------------------------------
+
+
+def mojo_device_convolution(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    stride: Sequence[int],
+    padding: Sequence[int],
+    dilation: Sequence[int],
+    transposed: bool,
+    output_padding: Sequence[int],
+    groups: int,
+) -> TorchMojoTensor:
+    """Convolution with a forward-time preflight of its native autograd node.
+
+    The forward exists here; `aten::convolution_backward` does not (it needs
+    the im2col-transpose GEMM pair). Recording ConvolutionBackward0 anyway
+    would move the failure into the autograd engine, where an exception aborts
+    the process instead of raising — the unwind hazard
+    `_refuse_unsupported_backward` documents — so a call whose gradient the
+    engine would come back for is refused here, from the forward, with a
+    traceback that names the op.
+
+    Unlike batch norm this has no training-mode escape: a conv weight normally
+    requires grad, so in practice this refuses every conv in a training model,
+    and the honest message is that the backward kernel is missing rather than
+    that some flag is set wrong. Inference is unaffected under
+    `torch.no_grad()` / `torch.inference_mode()`.
+    """
+    _refuse_unsupported_backward(
+        "aten::convolution",
+        "aten::convolution_backward",
+        (input, weight, bias),
+        _GRAD_OFF_ONLY,
+    )
+    aten_fast = _fast()
+    result = aten_fast.fast_aten_convolution(
+        input,
+        weight,
+        bias,
+        stride,
+        padding,
+        dilation,
+        transposed,
+        output_padding,
+        groups,
+    )
+    if result is aten_fast.NOT_HANDLED:
+        raise _unsupported("aten::convolution", (input, weight, bias))
+    return result
 
 
 def mojo_device_embedding(
@@ -217,4 +411,77 @@ def mojo_device_native_batch_norm(
         raise _unsupported(
             "aten::native_batch_norm", (input, weight, bias, running_mean, running_var)
         )
+    return result
+
+
+def mojo_device_native_group_norm(
+    input: torch.Tensor,
+    weight: torch.Tensor | None,
+    bias: torch.Tensor | None,
+    N: int,
+    C: int,
+    HxW: int,
+    group: int,
+    eps: float,
+) -> tuple[TorchMojoTensor, TorchMojoTensor, TorchMojoTensor]:
+    """Group norm with a forward-time preflight of its native autograd node.
+
+    The forward exists here; `aten::native_group_norm_backward` does not (it
+    needs the per-group reduction statistics). Recording
+    NativeGroupNormBackward0 anyway would move the failure into the autograd
+    engine, where an exception aborts the process instead of raising, so the
+    call is refused from the forward as `mojo_device_native_batch_norm` above
+    refuses its training case.
+
+    Group norm has no `training` flag to key on, so unlike batch norm every
+    grad-requiring call is refused; inference is unaffected under
+    `torch.no_grad()` / `torch.inference_mode()`.
+    """
+    _refuse_unsupported_backward(
+        "aten::native_group_norm",
+        "aten::native_group_norm_backward",
+        (input, weight, bias),
+        _GRAD_OFF_ONLY,
+    )
+    aten_fast = _fast()
+    result = aten_fast.fast_aten_native_group_norm(
+        input, weight, bias, N, C, HxW, group, eps
+    )
+    if result is aten_fast.NOT_HANDLED:
+        raise _unsupported("aten::native_group_norm", (input, weight, bias))
+    return result
+
+
+def mojo_device_softmax(
+    self: torch.Tensor, dim: int, dtype: torch.dtype | None = None
+) -> TorchMojoTensor:
+    """`aten::softmax.int`, refused when a gradient would silently go missing.
+
+    This one fails differently from its neighbours, and worse. `softmax.int` is
+    CompositeImplicitAutograd upstream, so registering a PrivateUse1 kernel for
+    it (worth it: the kernel is a fused softmax) takes it out of reach of the
+    decomposition autograd would otherwise differentiate. Autograd then falls
+    back to `autograd_not_implemented_fallback`, which does not abort and does
+    not raise — it warns and produces **no gradient at all**, leaving
+    `x.grad is None` after `backward()` and training silently stuck.
+
+    `aten::_softmax_backward_data` has no kernel here either, so there is no
+    gradient to be had by any route; refusing beats returning a model that
+    trains on zeros. Raised from the forward, same as the aborting ops around
+    it, so the traceback names the op.
+    """
+    if torch.is_grad_enabled() and self.requires_grad:
+        raise NotImplementedError(
+            "aten::softmax.int has no gradient in mojo eager mode, and unlike "
+            "the ops around it would not have failed: autograd cannot see "
+            "through the fused kernel registered for this op, so backward() "
+            "would leave .grad as None and train on nothing "
+            f"(input {tuple(self.shape)} {self.dtype} on {self.device}). "
+            "aten::_softmax_backward_data has no kernel here either, so no "
+            "route produces one. " + _GRAD_OFF_ONLY
+        )
+    aten_fast = _fast()
+    result = aten_fast.fast_aten_softmax(self, dim, dtype)
+    if result is aten_fast.NOT_HANDLED:
+        raise _unsupported("aten::softmax.int", (self,))
     return result

--- a/torch_mojo_backend/mojo_device/aten_ops/inplace.py
+++ b/torch_mojo_backend/mojo_device/aten_ops/inplace.py
@@ -2,7 +2,12 @@
 
 from torch_mojo_backend.mojo_device.torch_mojo_tensor import TorchMojoTensor
 
-from .support import _copy_into_tensor, _fast, _unsupported
+from .support import (
+    _copy_into_tensor,
+    _fast,
+    _refuse_unsupported_backward,
+    _unsupported,
+)
 
 
 def mojo_device_add_(
@@ -41,6 +46,18 @@ def mojo_device_mul_(self: TorchMojoTensor, other) -> TorchMojoTensor:
 
 
 def mojo_device_relu_(self: TorchMojoTensor) -> TorchMojoTensor:
+    # `nn.ReLU(inplace=True)` records the same ReluBackward0 as the functional
+    # form, and `aten::threshold_backward` has no kernel here, so the refusal
+    # has to happen in the forward for the reason
+    # `_refuse_unsupported_backward` documents. A leaf would already have been
+    # rejected by ADInplaceOrView; a non-leaf reaches this.
+    _refuse_unsupported_backward(
+        "aten::relu_",
+        "aten::threshold_backward",
+        (self,),
+        "The forward itself is supported: run it under torch.no_grad() or "
+        "torch.inference_mode().",
+    )
     aten_fast = _fast()
     result = aten_fast.fast_aten_relu(self)
     if result is aten_fast.NOT_HANDLED:

--- a/torch_mojo_backend/mojo_device/aten_ops/support.py
+++ b/torch_mojo_backend/mojo_device/aten_ops/support.py
@@ -64,6 +64,43 @@ def _unsupported(op_name: str, args=(), kwargs=None) -> NotImplementedError:
     )
 
 
+def _refuse_unsupported_backward(
+    op_name: str,
+    backward_op: str,
+    operands: tuple[torch.Tensor | None, ...],
+    workaround: str,
+) -> None:
+    """Refuse, from the forward, a call whose autograd node we cannot run.
+
+    An exception raised while the autograd engine runs a *native* backward node
+    does not propagate on this backend. The engine restores streams through
+    PyTorch's noexcept Python device guard, and that Python round-trip failing
+    during unwind reaches std::terminate: "terminate called without an active
+    exception", exit 134, no traceback and no Python exception at all. So an op
+    whose native backward is missing has to refuse before the node is recorded,
+    which means here, in ordinary forward-pass Python code.
+
+    `requires_grad` on any listed operand is the widest mask the engine could
+    ask the node for; callers pass only the operands whose gradient actually
+    needs the missing op.
+    """
+    if not torch.is_grad_enabled():
+        return
+    needs_grad = [
+        operand for operand in operands if operand is not None and operand.requires_grad
+    ]
+    if not needs_grad:
+        return
+    first = needs_grad[0]
+    raise NotImplementedError(
+        f"{op_name} would record an autograd node whose backward needs "
+        f"{backward_op}, which mojo eager mode does not implement (operand "
+        f"{tuple(first.shape)} {first.dtype} on {first.device}). {workaround} "
+        "Raised from the forward on purpose: raised from the backward node "
+        "instead, this aborts the process without a traceback."
+    )
+
+
 def _eager_impl(fast_name: str, op_name: str) -> Callable:
     """Bind an op to its aten_fast implementation; raise on NOT_HANDLED."""
     fast_fn: Callable | None = None

--- a/torch_mojo_backend/mojo_device/mojo_device_aten_ops.py
+++ b/torch_mojo_backend/mojo_device/mojo_device_aten_ops.py
@@ -21,9 +21,24 @@ import torch_mojo_backend.is_running_tests
 
 from .aten_ops import foreach
 from .aten_ops.autograd_preflight import (
+    mojo_device__adaptive_avg_pool2d,
+    mojo_device__scaled_dot_product_efficient_attention,
+    mojo_device__softmax,
+    mojo_device_avg_pool2d,
+    mojo_device_convolution,
+    mojo_device_cumsum,
     mojo_device_embedding,
+    mojo_device_index,
     mojo_device_linear,
+    mojo_device_max_pool2d_with_indices,
     mojo_device_native_batch_norm,
+    mojo_device_native_group_norm,
+    mojo_device_relu,
+    mojo_device_scatter_src,
+    mojo_device_sigmoid,
+    mojo_device_softmax,
+    mojo_device_tanh,
+    mojo_device_upsample_bilinear2d,
 )
 from .aten_ops.blas import mojo_device_addr
 from .aten_ops.factories import (
@@ -135,7 +150,7 @@ def _register_missing(op_name: str) -> None:
 #   register_aten_op(...)(fn)   -> a hand-written impl from aten_ops/
 # ----------------------------------------------------------------------------------
 
-_register_fast("aten::_adaptive_avg_pool2d", "fast_aten__adaptive_avg_pool2d")
+register_aten_op("aten::_adaptive_avg_pool2d")(mojo_device__adaptive_avg_pool2d)
 _register_missing("aten::_adaptive_avg_pool2d_backward")
 register_aten_op("aten::_copy_from")(mojo_device__copy_from)
 _register_foreach_inplace(
@@ -174,9 +189,8 @@ _register_fast(
     "aten::_scaled_dot_product_attention_math",
     "fast_aten__scaled_dot_product_attention_math",
 )
-_register_fast(
-    "aten::_scaled_dot_product_efficient_attention",
-    "fast_aten__scaled_dot_product_efficient_attention",
+register_aten_op("aten::_scaled_dot_product_efficient_attention")(
+    mojo_device__scaled_dot_product_efficient_attention
 )
 _register_fast(
     "aten::_scaled_dot_product_flash_attention",
@@ -186,7 +200,7 @@ _register_fast(
     "aten::_scaled_dot_product_flash_attention_backward",
     "fast_aten__scaled_dot_product_flash_attention_backward",
 )
-_register_fast("aten::_softmax", "fast_aten__softmax")
+register_aten_op("aten::_softmax")(mojo_device__softmax)
 register_aten_op("aten::_to_copy")(mojo_device__to_copy)
 _register_fast("aten::_unsafe_view", "fast_aten__unsafe_view")
 _register_fast("aten::abs", "fast_aten_abs")
@@ -215,7 +229,7 @@ _register_fast("aten::argmax", "fast_aten_argmax")
 _register_fast("aten::argmin", "fast_aten_argmin")
 _register_fast("aten::asinh", "fast_aten_asinh")
 _register_fast("aten::atanh", "fast_aten_atanh")
-_register_fast("aten::avg_pool2d", "fast_aten_avg_pool2d")
+register_aten_op("aten::avg_pool2d")(mojo_device_avg_pool2d)
 _register_fast("aten::bitwise_and.Scalar", "fast_aten_bitwise_and")
 _register_fast("aten::bitwise_and.Tensor", "fast_aten_bitwise_and")
 _register_fast("aten::bitwise_not", "fast_aten_bitwise_not")
@@ -228,10 +242,10 @@ _register_fast("aten::cat", "fast_aten_cat")
 _register_fast("aten::ceil", "fast_aten_ceil")
 _register_fast("aten::clamp", "fast_aten_clamp")
 _register_fast("aten::clone", "fast_aten_clone")
-_register_fast("aten::convolution", "fast_aten_convolution")
+register_aten_op("aten::convolution")(mojo_device_convolution)
 _register_fast("aten::cos", "fast_aten_cos")
 _register_fast("aten::cosh", "fast_aten_cosh")
-_register_fast("aten::cumsum", "fast_aten_cumsum")
+register_aten_op("aten::cumsum")(mojo_device_cumsum)
 _register_fast("aten::detach", "fast_aten_detach")
 _register_out("aten::div.out", "fast_aten_div")
 _register_fast("aten::div.Tensor", "fast_aten_div")
@@ -264,7 +278,7 @@ _register_fast("aten::gelu_backward", "fast_aten_gelu_backward")
 _register_fast("aten::gt", "fast_aten_gt")
 _register_fast("aten::gt.Scalar", "fast_aten_gt")
 _register_fast("aten::gt.Tensor", "fast_aten_gt")
-_register_fast("aten::index.Tensor", "fast_aten_index")
+register_aten_op("aten::index.Tensor")(mojo_device_index)
 _register_fast("aten::isin.Tensor_Tensor", "fast_aten_isin")
 _register_out("aten::isin.Tensor_Tensor_out", "fast_aten_isin", dtype_policy="exact")
 _register_fast("aten::isnan", "fast_aten_isnan")
@@ -291,7 +305,7 @@ register_aten_op("aten::masked_fill_.Tensor")(mojo_device_masked_fill_)
 _register_fast("aten::masked_fill.Scalar", "fast_aten_masked_fill")
 _register_fast("aten::masked_fill.Tensor", "fast_aten_masked_fill")
 _register_fast("aten::max", "fast_aten_max")
-_register_fast("aten::max_pool2d_with_indices", "fast_aten_max_pool2d_with_indices")
+register_aten_op("aten::max_pool2d_with_indices")(mojo_device_max_pool2d_with_indices)
 _register_fast("aten::maximum", "fast_aten_maximum")
 _register_fast("aten::mean", "fast_aten_mean")
 # Registering the base name only covers the default overload; mean.dim would
@@ -309,7 +323,7 @@ _register_fast("aten::mul.Tensor", "fast_aten_mul")
 register_aten_op("aten::native_batch_norm")(mojo_device_native_batch_norm)
 _register_fast("aten::native_dropout", "fast_aten_native_dropout")
 _register_fast("aten::native_dropout_backward", "fast_aten_native_dropout_backward")
-_register_fast("aten::native_group_norm", "fast_aten_native_group_norm")
+register_aten_op("aten::native_group_norm")(mojo_device_native_group_norm)
 _register_fast("aten::native_layer_norm", "fast_aten_native_layer_norm")
 _register_fast(
     "aten::native_layer_norm_backward", "fast_aten_native_layer_norm_backward"
@@ -334,7 +348,7 @@ _register_fast("aten::permute", "fast_aten_permute")
 _register_fast("aten::pow.Tensor_Scalar", "fast_aten_pow")
 _register_fast("aten::pow.Tensor_Tensor", "fast_aten_pow_tensor_tensor")
 _register_fast("aten::reciprocal", "fast_aten_reciprocal")
-_register_fast("aten::relu", "fast_aten_relu")
+register_aten_op("aten::relu")(mojo_device_relu)
 register_aten_op("aten::relu_")(mojo_device_relu_)
 _register_fast("aten::remainder.Scalar", "fast_aten_remainder")
 _register_fast("aten::remainder.Scalar_Tensor", "fast_aten_remainder")
@@ -345,17 +359,17 @@ register_aten_op("aten::scalar_tensor")(mojo_device_scalar_tensor)
 _register_fast(
     "aten::scaled_dot_product_attention", "fast_aten_scaled_dot_product_attention"
 )
-_register_fast("aten::scatter.src", "fast_aten_scatter_src")
+register_aten_op("aten::scatter.src")(mojo_device_scatter_src)
 _register_fast("aten::scatter.value", "fast_aten_scatter_value")
 _register_fast("aten::select_scatter", "fast_aten_select_scatter")
 _register_fast("aten::select.int", "fast_aten_select")
-_register_fast("aten::sigmoid", "fast_aten_sigmoid")
+register_aten_op("aten::sigmoid")(mojo_device_sigmoid)
 _register_fast("aten::sign", "fast_aten_sign")
 _register_fast("aten::silu", "fast_aten_silu")
 _register_fast("aten::sin", "fast_aten_sin")
 _register_fast("aten::sinh", "fast_aten_sinh")
 _register_fast("aten::slice.Tensor", "fast_aten_slice")
-_register_fast("aten::softmax.int", "fast_aten_softmax")
+register_aten_op("aten::softmax.int")(mojo_device_softmax)
 _register_fast("aten::split_with_sizes", "fast_aten_split_with_sizes")
 _register_fast("aten::split.Tensor", "fast_aten_split")
 _register_fast("aten::sqrt", "fast_aten_sqrt")
@@ -366,14 +380,14 @@ _register_fast("aten::sub.Tensor", "fast_aten_sub")
 _register_fast("aten::sum.dim_IntList", "fast_aten_sum")
 _register_fast("aten::t", "fast_aten_t")
 _register_fast("aten::tan", "fast_aten_tan")
-_register_fast("aten::tanh", "fast_aten_tanh")
+register_aten_op("aten::tanh")(mojo_device_tanh)
 _register_fast("aten::transpose.int", "fast_aten_transpose")
 _register_fast("aten::tril", "fast_aten_tril")
 _register_fast("aten::triu", "fast_aten_triu")
 _register_fast("aten::unbind.int", "fast_aten_unbind")
 _register_fast("aten::uniform_", "fast_aten_uniform_")
 _register_fast("aten::unsqueeze", "fast_aten_unsqueeze")
-_register_fast("aten::upsample_bilinear2d", "fast_aten_upsample_bilinear2d")
+register_aten_op("aten::upsample_bilinear2d")(mojo_device_upsample_bilinear2d)
 _register_fast("aten::var.correction", "fast_aten_var")
 _register_fast("aten::view", "fast_aten_view")
 _register_fast("aten::where.self", "fast_aten_where")


### PR DESCRIPTION
## What was broken

Calling certain ops with `requires_grad=True` and then `.backward()` did not
raise on the mojo device — **it killed the process**:

```
terminate called without an active exception
$ echo $?
134
```

No traceback, no Python exception, no frame naming the op. `pytest` does not
report a failure, it dies.

The mechanism: this backend registers ops only for `PrivateUse1`. When an op has
a dedicated derivative in `derivatives.yaml`, autograd records a **native C++**
`Node` (`ConvolutionBackward0`, `ReluBackward0`, ...). When that node runs it
calls back into the dispatcher for its backward op; if no PrivateUse1 kernel
exists, the resulting exception propagates up through
`Engine::evaluate_function`'s `c10::StreamGuard` destructor, which calls
`PythonDeviceGuard::exchangeStream` — a `noexcept` method that round-trips into
Python. That round-trip failing during unwind hits `std::terminate`.

Note this is specific to *native* nodes. A raise from a Python
`torch.autograd.Function.backward` (a PyNode, e.g. this repo's own SDPA) already
propagates normally — that path was never affected.

The fix is the pattern already used for `embedding` / `linear` /
`native_batch_norm`: check `torch.is_grad_enabled()` and the operands'
`requires_grad` **in the forward**, and raise `NotImplementedError` there — from
ordinary forward-pass Python code, long before any autograd `Node` exists, so
the crash path is unreachable. The forward still works whenever no gradient is
wanted (inference, `torch.no_grad()`, `torch.inference_mode()`).

**No backward kernel is implemented here.** This PR only converts a process
abort into an actionable exception; the missing kernels remain future work.

## Audit

The two ops named in the report were not alone. Sweeping every op registered in
`mojo_device_aten_ops.py` — `_dispatch_has_kernel_for_dispatch_key(op,
"Autograd")` for the risk shape, `derivatives.yaml` for the backward op's name,
then a **per-op subprocess crash probe** for ground truth — found **15 aborting
forwards**, plus one op failing a different and worse way.

Static reachability alone is not enough and would have missed most of these:
`aten::threshold_backward` reports a `CompositeExplicitAutogradNonFunctional`
kernel, but it redispatches to the structured `.grad_input` variant, which has no
PrivateUse1 kernel and raises. Only running it shows that.

| forward op | what the engine actually failed on | why it matters |
| --- | --- | --- |
| `aten::convolution` | `aten::convolution_backward` | any CNN training: ResNet, VGG, DenseNet, ViT patch-embed conv |
| `aten::native_group_norm` | `aten::native_group_norm_backward` | SD-UNet ResBlocks, GroupNorm CNNs |
| `aten::relu` | `aten::threshold_backward` | the most common activation there is |
| `aten::relu_` | `aten::threshold_backward` | `nn.ReLU(inplace=True)`, the torchvision default |
| `aten::tanh` | `aten::tanh_backward` | RNNs, tanh-gated heads |
| `aten::sigmoid` | `aten::sigmoid_backward` | BCE heads, gates |
| `aten::avg_pool2d` | `aten::avg_pool2d_backward` | CNN pooling |
| `aten::max_pool2d_with_indices` | `aten::max_pool2d_with_indices_backward` | CNN pooling |
| `aten::_adaptive_avg_pool2d` | `aten::_adaptive_avg_pool2d_backward` | classifier heads (see note) |
| `aten::upsample_bilinear2d` | `aten::upsample_bilinear2d_backward` | segmentation / UNet decoders |
| `aten::_softmax` | `aten::_softmax_backward_data` | any explicit softmax outside fused SDPA |
| `aten::cumsum` | `aten::flip` (its backward composes it) | cumulative losses, ordinal heads |
| `aten::index.Tensor` | `aten::_index_put_impl_` (ditto) | advanced indexing, gather-style lookups |
| `aten::scatter.src` | `aten::gather` (ditto) | only the `src` gradient — see below |
| `aten::_scaled_dot_product_efficient_attention` | its `_backward` | direct low-level calls only |

`_adaptive_avg_pool2d_backward` was already "registered" — as
`_register_missing`, an explicit raiser. That raise still happens inside
`Node::apply()`, so it aborted exactly like being unregistered. A clean raiser
is not a fix for this bug class; the refusal has to be in the forward.

`aten::scatter.src` is refused **only when `src` requires grad**: the `self`
gradient is a scatter of zeros, which this backend runs fine, and a blanket
"any operand requires grad" check would have broken a working call. There is a
test for that.

### The one that was not a crash

`aten::softmax.int` is `CompositeImplicitAutograd` upstream. Registering a
PrivateUse1 kernel for it (worth doing — it is a fused softmax) takes it out of
reach of the decomposition autograd would otherwise differentiate, so autograd
falls back to `autograd_not_implemented_fallback`: it does not abort and does not
raise, it **warns and produces no gradient at all**. `x.grad` stays `None` and
the model trains on nothing. Since `_softmax_backward_data` has no kernel here
either, there is no gradient to be had by any route, so this now raises too —
a silent wrong result traded for an error that names the op.

**Correction (post-merge, adversarial review):** the sentence above, and the
"Both fail; only one tells you why" framing below, describe **eager execution
only**. `torch.compile(..., backend=mojo_backend)` still hits this exact
silent-no-gradient failure for `torch.softmax` under backward — the eager
preflight added by this PR does not run on that path, and the root cause turns
out to be process-wide dispatcher state set by this backend's own eager
`aten::softmax.int` registration (not a decomposition-table gap in the compile
backend, which was the first, wrong hypothesis). This was found by adversarial
review after this PR merged and is tracked, with the full root-cause writeup
and a red `xfail(strict=True)` regression test, in #406. Fixing it needs its
own engagement (likely a working `AutogradPrivateUse1` path for
`aten::softmax.int`, without reopening the eager silent-training bug this PR
just closed) and is out of scope for a dispatch-registration PR.

### Checked and left alone

Ops whose native backward is reachable or already safe: `mm`, `addmm`, `bmm`,
`linear` (`linear_backward` is registered), `native_layer_norm`, `_log_softmax`,
`gelu`, `silu`, `native_dropout`, `nll_loss`, `embedding`, `scatter.value`,
`select_scatter`, `repeat`, `stack`, `split`, `cat`, the reductions
(`mean`/`sum`/`max`/`min`, whose backward is a broadcast of the incoming
gradient), the view family, `where`, `masked_fill`, `clone`, `lerp`, `tril`,
`var.correction`, `pow`, and `F.scaled_dot_product_attention` (this repo's own
Python autograd Function — a PyNode, so its raises propagate normally). All
verified to complete a real `.backward()`, not just to look reachable.

## Honest note on the trade-off

The preflight fires in the forward, so it refuses a grad-requiring call even if
the caller never reaches `.backward()`. For most of these ops there is **no
training-mode escape**, and the messages say so rather than repeating batch
norm's `.eval()` advice, which does not apply: `.eval()` leaves grad mode on and
the parameters still require grad. `torch.no_grad()` / `torch.inference_mode()`
is the real workaround, and it genuinely fixes the inference case.

Training through these ops now fails immediately instead of aborting the
process. Both fail; only one tells you why.

## Test evidence

New tests in `tests/test_eager_kernels.py`, each asserting the exact
`NotImplementedError` (never a broad `BaseException`) so a regression proves the
crash path stayed unreached, and each paired with a grad-free / `no_grad()`
forward compared against CPU so the working forward is not silently lost:

- `test_autograd_preflight_refuses_unrunnable_backward_in_the_forward` — 10
  parametrized ops, one node each
- `test_autograd_preflight_leaves_the_gradless_forward_working` — same 10, CPU
  A/B, plus the `no_grad()` workaround the message advertises
- `test_fast_conv2d_refuses_autograd_in_the_forward`
- `test_fast_group_norm_refuses_autograd_in_the_forward`
- `test_autograd_preflight_refuses_relu_inplace_in_the_forward`
- `test_autograd_preflight_refuses_advanced_indexing_in_the_forward`
- `test_autograd_preflight_refuses_scatter_src_only_for_the_src_gradient`
- `test_autograd_preflight_refuses_efficient_attention_in_the_forward`

Because a wrong preflight condition **kills the pytest process** rather than
failing a test, every one of the 16 cases was first proven in an isolated
subprocess — one op per process, exit code checked — which is how the 15
aborting forwards were found in the first place and how each was confirmed to
raise cleanly afterwards.

### Test runs

All on an H100, `flock /tmp/gpu_lock_0.lock`, serially:

| run | result |
| --- | --- |
| `pytest tests/test_eager_kernels.py` (full) | **1727 passed, 22 skipped, 1 failed** — the failure is pre-existing, see below |
| `pytest tests/test_compile_mojo_device.py` (full) | **44 passed** |
| `pytest tests/test_eager_kernels.py -k "<the 16 touched ops>"` | **305 passed, 0 skipped** |

The compile path is unaffected *by this PR's preflights*, as the 44/44
confirms: AOTAutograd runs its forward graph with grad disabled, so none of
the 16 preflights added here ever fire there. **This is narrower than "the
compile path is safe"** — see the correction under "The one that was not a
crash" above: `aten::softmax.int` has its own, separate silent-no-gradient
failure under `torch.compile`, pre-existing on `main`, not fixed by this PR,
and now tracked in #406.

Also verified off-GPU: every one of the 16 refusals on the **CPU** mojo device
(device-independent by construction — the preflight reads only
`torch.is_grad_enabled()` and `.requires_grad` and returns before any kernel);
every new type hint under `TORCH_MOJO_BACKEND_BEARTYPE=1` on both the refusal
and the success paths, including the tuple-returning `max_pool2d_with_indices`,
`native_group_norm` and efficient-attention wrappers; `uvx pre-commit run
--all-files` clean.

#### The one failure is pre-existing and unrelated

`test_bf16_v3_source_dependency_and_kernel_contract` fails on `main` too. It
greps the bf16 GEMM Mojo sources for forbidden tokens, and
`gemm16_v3_kernels.mojo:1775` now contains one — inside a prose comment:

```
# same kernel, ~6-7x cuBLAS overall) because that kernel predates the
```

That is a *performance comparison*, not a dependency, but the check is a plain
`"cublas" not in source.lower()` and cannot tell the difference. It arrived with
#392 (`0c8f1ee`), which is also the commit that last touched that file.

Proof it is not from this PR: this branch changes zero files under
`eager_kernels/` (`git diff upstream/main HEAD --stat -- torch_mojo_backend/eager_kernels/`
is empty), the test takes no fixtures and reads only those four `.mojo` files
plus `aten_fast._GEMM16_SOURCE_PATHS`, all byte-identical to `main`, and
`git show upstream/main:...gemm16_v3_kernels.mojo | grep -i cublas` returns the
same line. Left alone deliberately — fixing it means touching either #392's
kernel comment or the contract test's matcher, neither of which belongs in a
dispatch-registration PR. Worth its own one-liner: the matcher should look for
imports and calls rather than any mention of the word.

The set of registered aten op names is byte-identical to `main` (206 ops, only
the registration *style* changed for the 15), so `benchmarks/test_coverage.py`
is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Co2wBC1UYzM4y9PEC92Af



