### PR TITLE
Make the GEMM vendor-library contract test scan code, not comments

### DIFF
--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -6101,7 +6101,14 @@ def test_bf16_v3_source_dependency_and_kernel_contract():
     ):
         assert scratch_only not in v3_source
 
+    def _code_only(source: str) -> str:
+        # The vendor-library ban is about imports and calls, not prose: a
+        # comment saying a kernel was benchmarked against cuBLAS must not
+        # trip it (it did once, via #392's tuning notes).
+        return "\n".join(line.split("#", 1)[0] for line in source.splitlines())
+
     for source in (bridge_source, v3_source, tn_v4_source, fallback_source):
+        code = _code_only(source).lower()
         for forbidden in (
             ".synchronize(",
             "devicecontext(",
@@ -6111,7 +6118,7 @@ def test_bf16_v3_source_dependency_and_kernel_contract():
             "rocblas",
             "triton",
         ):
-            assert forbidden not in source.lower()
+            assert forbidden not in code
 
 
 @pytest.mark.parametrize("operation", ["gemm", "bmm"])


### PR DESCRIPTION
The bf16-GEMM source-contract test bans vendor-library tokens (`cublas`, `cudnn`, `rocblas`, `triton`, ...) with a plain substring match over the whole file, so #392's tuning comment — a *benchmark comparison* against cuBLAS, not a dependency — fails `tests/test_eager_kernels.py::test_bf16_v3_source_dependency_and_kernel_contract` on main today (found while validating #401's full-suite run; proven pre-existing there).

Fix: strip `#`-comments before matching, so imports and calls still trip the ban while prose does not. The next kernel author who benchmarks against a vendor library and says so in a comment won't re-trip it.

Red on main → green with this change (test is GPU-free, 1.8s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Co2wBC1UYzM4y9PEC92Af